### PR TITLE
feat(RenderView): increase min width of payment detail modal

### DIFF
--- a/src/modulos/PartialPayments/RenderView/RenderView.tsx
+++ b/src/modulos/PartialPayments/RenderView/RenderView.tsx
@@ -252,6 +252,7 @@ const RenderView = ({
     <>
       <DataModal
         title="Detalle de pago parcial"
+        minWidth={"980px"}
         open={open}
         onClose={() => {
           onClose();


### PR DESCRIPTION
Set minWidth to 980px to better accommodate payment detail content
https://github.com/orgs/Condaty/projects/5/views/1?pane=issue&itemId=144529477
