### PR TITLE
fix(EditProfile): wrap email input in full-width container for FOS users

### DIFF
--- a/src/components/ProfileModal/EditProfile/EditProfile.tsx
+++ b/src/components/ProfileModal/EditProfile/EditProfile.tsx
@@ -222,15 +222,16 @@ const EditProfile = ({
               error={errors}
             />
             {user?.type === "FOS" && (
-              <Input
-                label="Correo electrónico"
-                name="email"
-                type="email"
-                value={formState.email}
-                onChange={onChange}
-                error={errors}
-                className={styles.fullWidth}
-              />
+              <div className={styles.fullWidth}>
+                <Input
+                  label="Correo electrónico"
+                  name="email"
+                  type="email"
+                  value={formState.email}
+                  onChange={onChange}
+                  error={errors}
+                />
+              </div>
             )}
           </div>
           {type !== "homeOwner" && type !== "owner" && (


### PR DESCRIPTION
Wrap the email input field in a div with the fullWidth class to ensure proper styling when the user type is "FOS". This corrects a layout inconsistency.