### PR TITLE
fix(Condominios): hide delete action for inactive items

### DIFF
--- a/src/modulos/Condominios/Condominios.tsx
+++ b/src/modulos/Condominios/Condominios.tsx
@@ -25,7 +25,7 @@ const mod: ModCrudType = {
   extraData: true,
   onHideActions: (item: any) => {
     return {
-      hideDel: item.privacy == "P",
+      hideDel: item.privacy == "P" || item.status == "I",
     };
   },
   hideActions: {


### PR DESCRIPTION
Prevent deletion of condominios with status "I" (inactive) in addition to those with privacy "P". This ensures data integrity by restricting operations on inactive records.