### PR TITLE
fix(Superadmins): change phone validation from required to phone format

### DIFF
--- a/src/modulos/Superadmins/RenderForm/RenderForm.tsx
+++ b/src/modulos/Superadmins/RenderForm/RenderForm.tsx
@@ -47,7 +47,7 @@ const RenderForm = ({
     });
     errors = checkRules({
       value: formState?.phone,
-      rules: ["required"],
+      rules: ["phone"],
       key: "phone",
       errors,
     });
@@ -172,7 +172,7 @@ const RenderForm = ({
           value={formState.phone || ""}
           onChange={handleChange}
           error={errors}
-          required
+          required={false}
         />
       </div>
       <InputFullName


### PR DESCRIPTION
Update the form validation logic to use a 'phone' format rule instead of a simple 'required' rule for the phone number field. This ensures the input matches a valid phone number pattern. Also set the InputPhone component's required prop to false as validation is now handled by the format rule.