### PR TITLE
feat(Invitations): add badge for roles in use and set file size limit

### DIFF
--- a/src/mk/components/forms/UploadFileV3/UploadFileV3.tsx
+++ b/src/mk/components/forms/UploadFileV3/UploadFileV3.tsx
@@ -167,19 +167,16 @@ const UploadFileV3 = ({
         // alert(
         //   `Ningún archivo válido. Solo se permiten ${itemText} de hasta ${maxMB} MB.`
         // );
-        showToast({
-          message: `Ningún archivo válido. Solo se permiten ${itemText} de hasta ${maxMB} MB.`,
-          type: "error",
-        });
+        showToast(
+          `Ningún archivo válido. Solo se permiten ${itemText} de hasta ${maxMB} MB.`,
+          "error",
+        );
         return;
       }
 
       if (!isSingle && currentValues.length + validFiles.length > cant) {
         // alert(`Máximo ${cant} archivos permitidos`);
-        showToast({
-          message: `Máximo ${cant} archivos permitidos`,
-          type: "error",
-        });
+        showToast(`Máximo ${cant} archivos permitidos`, "error");
         return;
       }
 

--- a/src/modulos/Invitations/Invitations.module.css
+++ b/src/modulos/Invitations/Invitations.module.css
@@ -1,0 +1,12 @@
+.containerName {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.statusBadge {
+  background-color: #15392b;
+  padding: 4px 8px;
+  border-radius: 99px;
+  font-size: 12px;
+  color: var(--cAccent);
+}

--- a/src/modulos/Invitations/Invitations.tsx
+++ b/src/modulos/Invitations/Invitations.tsx
@@ -40,9 +40,21 @@ const Invitations = () => {
         rules: ["required"],
         api: "ae",
         label: "Nombre",
-        list: {},
+        list: {
+          onRender: ({ item }: any) => {
+            return (
+              <div className={styles.containerName}>
+                <p>{item?.name}</p>
+                {item.clients_count > 0 && (
+                  <div className={styles.statusBadge}>
+                    <p>En uso</p>
+                  </div>
+                )}
+              </div>
+            );
+          },
+        },
         form: { type: "text", label: "Nombre del rol" },
-        hide: true,
       },
       clients_count: {
         rules: ["required"],

--- a/src/modulos/Invitations/RenderForm/RenderForm.tsx
+++ b/src/modulos/Invitations/RenderForm/RenderForm.tsx
@@ -171,6 +171,7 @@ const RenderForm = ({
         setFormState={setFormState}
         name="images"
         error={errors}
+        maxMB={2}
       />
     </DataModalV2>
   );


### PR DESCRIPTION
- Add "En uso" badge to role names in the list view when clients_count > 0
- Set maxMB prop to 2 for the image upload field in the invitation form
- Simplify showToast calls in UploadFileV3 component