### PR TITLE
feat(Reel): support multiple image sources and avatar fallback

### DIFF
--- a/src/mk/utils/string.tsx
+++ b/src/mk/utils/string.tsx
@@ -124,16 +124,23 @@ export const capitalizeWords = (s: any) => {
   });
   return result.trim();
 };
-export const getUrlImages = (url: string) => {
-  const originalString = process.env.NEXT_PUBLIC_API_URL as string;
-  const lastIndexOfString = originalString.lastIndexOf("/api");
-  if (lastIndexOfString === -1) {
-    return originalString + url;
+export const getUrlImages = (
+  fallbackPath: string,
+  customUrl?: string | null,
+) => {
+  // Si existe la URL personalizada, se usa directamente
+  if (customUrl) {
+    return customUrl;
   }
-  const replacementString = "/storage";
-  const newUrl =
-    originalString.substring(0, lastIndexOfString) + replacementString + url;
-  return newUrl;
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL as string;
+  const apiIndex = baseUrl.lastIndexOf("/api");
+
+  if (apiIndex === -1) {
+    return baseUrl + fallbackPath;
+  }
+
+  return baseUrl.substring(0, apiIndex) + "/storage" + fallbackPath;
 };
 
 export const getFullName = (
@@ -143,7 +150,7 @@ export const getFullName = (
     last_name?: string;
     mother_last_name?: string;
   },
-  format: string = "NsLm"
+  format: string = "NsLm",
 ): string => {
   if (!data) {
     return "";
@@ -251,7 +258,7 @@ export const getInitials = (name = "", lastName = "") => {
 export const truncateText = (
   text: string,
   maxLength: number = 30,
-  ellipsis: string = "..."
+  ellipsis: string = "...",
 ): string => {
   if (!text) return "";
   if (text.length <= maxLength) return text;

--- a/src/modulos/Contents/Contents.tsx
+++ b/src/modulos/Contents/Contents.tsx
@@ -67,9 +67,9 @@ const rigthFile = (data: {
               "." +
               data.item.url +
               "?" +
-              data.item.updated_at
+              data.item.updated_at,
           ),
-          "_blank"
+          "_blank",
         );
       }}
     />
@@ -77,29 +77,29 @@ const rigthFile = (data: {
 };
 
 const getTypefilter = () => [
-  { id: 'ALL', name: 'Todos' },
-  { id: 'D', name: 'Documento' },
-  { id: 'V', name: 'Video' },
-  { id: 'I', name: 'Imagen' },
+  { id: "ALL", name: "Todos" },
+  { id: "D", name: "Documento" },
+  { id: "V", name: "Video" },
+  { id: "I", name: "Imagen" },
 ];
 
 const getTypeContentsfilter = () => [
-  { id: 'ALL', name: 'Todos' },
-  { id: 'P', name: 'Publicación' },
-  { id: 'N', name: 'Noticia' },
+  { id: "ALL", name: "Todos" },
+  { id: "P", name: "Publicación" },
+  { id: "N", name: "Noticia" },
 ];
 
 const getPeriodOptions = () => [
-  { id: 'ALL', name: 'Todos' },
-  { id: 'd', name: 'Hoy' },
-  { id: 'ld', name: 'Ayer' },
-  { id: 'w', name: 'Esta semana' },
-  { id: 'lw', name: 'Semana anterior' },
-  { id: 'm', name: 'Este mes' },
-  { id: 'lm', name: 'Mes anterior' },
-  { id: 'y', name: 'Este año' },
-  { id: 'ly', name: 'Año anterior' },
-  { id: 'custom', name: 'Personalizado' },
+  { id: "ALL", name: "Todos" },
+  { id: "d", name: "Hoy" },
+  { id: "ld", name: "Ayer" },
+  { id: "w", name: "Esta semana" },
+  { id: "lw", name: "Semana anterior" },
+  { id: "m", name: "Este mes" },
+  { id: "lm", name: "Mes anterior" },
+  { id: "y", name: "Este año" },
+  { id: "ly", name: "Año anterior" },
+  { id: "custom", name: "Personalizado" },
 ];
 
 const Contents = () => {
@@ -109,7 +109,8 @@ const Contents = () => {
     endDate?: string;
   }>({});
   const [isCommentModalOpen, setIsCommentModalOpen] = useState(false);
-  const [selectedContentIdForComments, setSelectedContentIdForComments] = useState<number | null>(null);
+  const [selectedContentIdForComments, setSelectedContentIdForComments] =
+    useState<number | null>(null);
   const [selectedContentData, setSelectedContentData] = useState<any>(null);
 
   const { user, showToast } = useAuth();
@@ -226,56 +227,70 @@ const Contents = () => {
 
   const { setStore, store } = useAuth();
   useEffect(() => {
-    setStore({ ...store, title: '' });
+    setStore({ ...store, title: "" });
   }, []);
 
   const fields = useMemo(
     () => ({
-      id: { rules: [], api: 'e' },
+      id: { rules: [], api: "e" },
       created_at: {
         rules: [],
-        api: 'e',
-        label: 'Fecha',
+        api: "e",
+        label: "Fecha",
         list: {
-          width: '220px',
-          onRender: (props: any) => getDateTimeStrMesShort(props?.item?.created_at),
+          width: "220px",
+          onRender: (props: any) =>
+            getDateTimeStrMesShort(props?.item?.created_at),
           form: false,
         },
         filter: {
-          key: 'created_at',
-          label: 'Periodo',
+          key: "created_at",
+          label: "Periodo",
           options: getPeriodOptions,
         },
       },
       user: {
         rules: [],
-        api: 'ae',
-        label: 'Creador',
+        api: "ae",
+        label: "Creador",
         list: {
-          width: '200px',
+          width: "200px",
           onRender: (item: any) => {
             const user = item?.item.user;
-            const nombreCompleto = getFullName(user);
-            const cedulaIdentidad = user?.ci;
+            const owner = item?.item.owner;
+            const nombreCompleto = getFullName(user || owner);
+            const cedulaIdentidad = user?.ci || owner?.ci;
+
+            const urlAvatar = user
+              ? getUrlImages(
+                  "/ADM-" + user?.id + ".webp?d=" + user?.updated_at,
+                  user?.url_avatar,
+                )
+              : getUrlImages(
+                  "/OWNER-" + owner?.id + ".webp?d=" + owner?.updated_at,
+                  owner?.url_avatar,
+                );
 
             return (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <Avatar
-                  hasImage={1}
-                  src={getUrlImages('/ADM-' + user?.id + '.webp?d=' + user?.updated_at)}
-                  name={nombreCompleto}
-                />
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <Avatar hasImage={1} src={urlAvatar} name={nombreCompleto} />
                 <div>
-                  <p style={{ marginBottom: '2px', fontWeight: 500, color: 'var(--cWhite)' }}>
+                  <p
+                    style={{
+                      marginBottom: "2px",
+                      fontWeight: 500,
+                      color: "var(--cWhite)",
+                    }}
+                  >
                     {nombreCompleto}
                   </p>
                   {cedulaIdentidad && (
                     <span
                       style={{
-                        fontSize: '11px',
-                        color: 'var(--cWhiteV1)',
-                        display: 'block',
-                        marginBottom: '4px',
+                        fontSize: "11px",
+                        color: "var(--cWhiteV1)",
+                        display: "block",
+                        marginBottom: "4px",
                       }}
                     >
                       CI: {cedulaIdentidad}
@@ -288,33 +303,33 @@ const Contents = () => {
         },
       },
       type: {
-        rules: ['required'],
-        api: 'ae',
-        label: 'Tipo',
+        rules: ["required"],
+        api: "ae",
+        label: "Tipo",
         list: {
-          width: '180px',
+          width: "180px",
         },
         form: {
-          type: 'select',
+          type: "select",
           options: lType,
         },
         filter: {
-          label: 'Tipo de contenido',
-          width: '180px',
+          label: "Tipo de contenido",
+          width: "180px",
           options: getTypefilter,
         },
       },
       title: {
-        rules: [''],
-        api: 'ae',
-        label: 'Titulo',
+        rules: [""],
+        api: "ae",
+        label: "Titulo",
         list: false,
-        form: { type: 'text' },
+        form: { type: "text" },
       },
       description: {
-        rules: ['required'],
-        api: 'ae',
-        label: 'Contenido',
+        rules: ["required"],
+        api: "ae",
+        label: "Contenido",
         list: {
           onRender: (item: any) => {
             const title = item?.item?.title;
@@ -323,73 +338,75 @@ const Contents = () => {
             return (
               <div className={styles.contentContainer}>
                 {title && <div className={styles.contentTitle}>{title}</div>}
-                {description && <div className={styles.contentDescription}>{description}</div>}
+                {description && (
+                  <div className={styles.contentDescription}>{description}</div>
+                )}
               </div>
             );
           },
         },
-        form: { type: 'textArea', lines: 6, isLimit: true, maxLength: 5000 },
+        form: { type: "textArea", lines: 6, isLimit: true, maxLength: 5000 },
       },
       reaction: {
-        api: 'ae',
-        label: 'Interacciones',
-        list: { width: '150px' },
+        api: "ae",
+        label: "Interacciones",
+        list: { width: "150px" },
         onHide: isType,
         form: {},
         onRender: (item: any) => (
-          <div style={{ display: 'flex', alignItems: 'center', fontSize: 14 }}>
-            <IconLike color={'var(--cAccent)'} size={24} />
+          <div style={{ display: "flex", alignItems: "center", fontSize: 14 }}>
+            <IconLike color={"var(--cAccent)"} size={24} />
             {formatNumber(item?.item?.likes, 0)} <IconComment size={24} />
             {formatNumber(item?.item?.comments_count, 0)}
           </div>
         ),
       },
       url: {
-        rules: ['requiredIf:type,V'],
-        api: 'a*e*',
-        label: 'Link del video',
+        rules: ["requiredIf:type,V"],
+        api: "a*e*",
+        label: "Link del video",
         list: false,
         onHide: isType,
-        form: { type: 'text' },
+        form: { type: "text" },
       },
       avatar: {
-        api: 'a*e*',
-        label: 'Suba una imagen',
+        api: "a*e*",
+        label: "Suba una imagen",
         list: false,
         onHide: isType,
         form: {
-          type: 'imageUploadMultiple',
-          prefix: 'CONT',
+          type: "imageUploadMultiple",
+          prefix: "CONT",
           maxFiles: 10,
-          images: 'images',
-          style: { width: '100%' },
+          images: "images",
+          style: { width: "100%" },
         },
       },
       file: {
-        rules: ['requiredFileIf:type,D'],
-        api: 'a*e*',
-        label: 'Suba un Documento',
+        rules: ["requiredFileIf:type,D"],
+        api: "a*e*",
+        label: "Suba un Documento",
         list: false,
         onHide: isType,
         form: {
-          type: 'fileUpload',
+          type: "fileUpload",
           onRigth: rigthFile,
-          style: { width: '100%' },
+          style: { width: "100%" },
         },
       },
       content: {
-        api: 'ae',
-        label: 'Contenido',
+        api: "ae",
+        label: "Contenido",
         list: false,
         form: false,
         filter: {
-          key: 'content',
-          label: 'Tipo de publicación',
+          key: "content",
+          label: "Tipo de publicación",
           options: getTypeContentsfilter,
         },
       },
     }),
-    []
+    [],
   );
 
   const _onChange = (
@@ -397,7 +414,7 @@ const Contents = () => {
     item: any,
     setItem: Function,
     setShowExtraModal: Function,
-    action: any
+    action: any,
   ) => {
     const { name, value } = e.target;
     let selDestinies: any = [];
@@ -406,7 +423,10 @@ const Contents = () => {
       if (value) {
         setItem({ ...item, lDestiny: [...item.lDestiny, id] });
       } else {
-        setItem({ ...item, lDestiny: item.lDestiny.filter((d: number) => d != id) });
+        setItem({
+          ...item,
+          lDestiny: item.lDestiny.filter((d: number) => d != id),
+        });
       }
       return true;
     }
@@ -437,14 +457,19 @@ const Contents = () => {
             setItem={setItem}
             selDestinies={selDestinies}
             setShowExtraModal={setShowExtraModal}
-          />
+          />,
         );
       else setShowExtraModal(null);
     }
     return false;
   };
 
-  const ModalDestiny = ({ item, setItem, selDestinies, setShowExtraModal }: {
+  const ModalDestiny = ({
+    item,
+    setItem,
+    selDestinies,
+    setShowExtraModal,
+  }: {
     item: any;
     setItem: Function;
     selDestinies: any;
@@ -462,7 +487,10 @@ const Contents = () => {
     const setOnSearch = (e: any) => setSearch(e);
 
     const normalizeText = (text: string) =>
-      text.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toUpperCase();
+      text
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toUpperCase();
 
     useEffect(() => {
       if (search == "") {
@@ -470,7 +498,7 @@ const Contents = () => {
         return;
       }
       const filtered = selDestinies.filter((d: any) =>
-        normalizeText(d.name).includes(normalizeText(search))
+        normalizeText(d.name).includes(normalizeText(search)),
       );
       setDestiniesFiltered(filtered);
     }, [search, selDestinies]);
@@ -494,8 +522,17 @@ const Contents = () => {
     };
 
     return (
-      <DataModal title="Destino" open={openDestiny} onClose={_onClose} onSave={_onSave}>
-        <DataSearch name="searchDestiny" setSearch={setOnSearch} value={search} />
+      <DataModal
+        title="Destino"
+        open={openDestiny}
+        onClose={_onClose}
+        onSave={_onSave}
+      >
+        <DataSearch
+          name="searchDestiny"
+          setSearch={setOnSearch}
+          value={search}
+        />
         {destiniesFiltered.map((d: any, i: number) => (
           <Check
             key={"check" + i}
@@ -546,7 +583,7 @@ const Contents = () => {
     mod,
     onEdit,
     onDel,
-    title: '',
+    title: "",
   });
 
   if (!userCan(mod.permiso, "R")) return <NotAccess />;
@@ -560,18 +597,18 @@ const Contents = () => {
           data={data?.message?.total || 0}
           icon={
             <IconDocs
-              color={'var(--cWhite)'}
-              style={{ backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
+              color={"var(--cWhite)"}
+              style={{ backgroundColor: "rgba(255, 255, 255, 0.1)" }}
               circle
               size={18}
             />
           }
-          style={{ minWidth: '160px', maxWidth: '268px', marginBottom: "16px" }}
+          style={{ minWidth: "160px", maxWidth: "268px", marginBottom: "16px" }}
         />
       )}
       <List
         actionsWidth="140px"
-        height={'calc(100vh - 440px)'}
+        height={"calc(100vh - 440px)"}
         emptyMsg="Lista de publicaciones vacía. Una vez empieces a publicar"
         emptyLine2="noticias las verás aquí."
         emptyIcon={<IconPublicacion size={80} color="var(--cWhiteV1)" />}
@@ -589,9 +626,15 @@ const Contents = () => {
           if (!endDate) err.endDate = "La fecha de fin es obligatoria";
           if (startDate && endDate && startDate > endDate)
             err.startDate = "La fecha de inicio no puede ser mayor a la de fin";
-          if (startDate && endDate && startDate.slice(0, 4) !== endDate.slice(0, 4)) {
-            err.startDate = "El periodo personalizado debe estar dentro del mismo año";
-            err.endDate = "El periodo personalizado debe estar dentro del mismo año";
+          if (
+            startDate &&
+            endDate &&
+            startDate.slice(0, 4) !== endDate.slice(0, 4)
+          ) {
+            err.startDate =
+              "El periodo personalizado debe estar dentro del mismo año";
+            err.endDate =
+              "El periodo personalizado debe estar dentro del mismo año";
           }
           if (Object.keys(err).length > 0) {
             setCustomDateErrors(err);

--- a/src/modulos/Contents/RenderView/RenderView.tsx
+++ b/src/modulos/Contents/RenderView/RenderView.tsx
@@ -15,7 +15,7 @@ import {
   IconArrowLeft,
   IconArrowRight,
   IconPDF,
-  IconImage
+  IconImage,
 } from "@/components/layout/icons/IconsBiblioteca";
 import Br from "@/components/Detail/Br";
 import useAxios from "@/mk/hooks/useAxios";
@@ -27,7 +27,6 @@ const RenderView = (props: {
   onEdit?: (item: any) => void;
   onDelete?: (item: any) => void;
   reLoad?: () => void;
-
   onOpenComments?: (contentId: number, contentData: any) => void;
   selectedContentData?: any;
   contentId?: number;
@@ -37,38 +36,77 @@ const RenderView = (props: {
   const { showToast } = useAuth();
   const [isExpanded, setIsExpanded] = useState(false);
   const [indexVisible, setIndexVisible] = useState(0);
-  const [contentData, setContentData] = useState(null);
+  const [contentData, setContentData] = useState<any>(null);
   const [loading, setLoading] = useState(false);
   const { execute } = useAxios();
 
   const currentData = props.selectedContentData || contentData || data;
 
+  // ── Normalizamos las imágenes ──
+  const normalizedImages = useMemo(() => {
+    // Prioridad: files > images
+    const raw = currentData?.files || currentData?.images || [];
+
+    return raw
+      .map((item: any, idx: number) => {
+        // Caso 1: files → array de URLs directas
+        if (typeof item === "string" && item.trim()) {
+          return {
+            type: "url",
+            url: item,
+            index: idx,
+          };
+        }
+
+        // Caso 2: images → array de objetos {id, ext, ...}
+        if (item && typeof item === "object" && "id" in item) {
+          const url = getUrlImages(
+            `/CONT-${currentData.id}-${item.id}.webp?${currentData?.updated_at || ""}`,
+          );
+          return {
+            type: "object",
+            url,
+            id: item.id,
+            index: idx,
+          };
+        }
+
+        return null;
+      })
+      .filter(Boolean); // quitamos nulos
+  }, [currentData]);
+
+  const hasImagesContent = normalizedImages.length > 0;
+
   useEffect(() => {
     const fetchContentDetails = async () => {
-      if (props.open && props.contentId && !props.selectedContentData && !data) {
+      if (
+        props.open &&
+        props.contentId &&
+        !props.selectedContentData &&
+        !data
+      ) {
         setLoading(true);
         try {
           const response = await execute(
-            '/contents',
-            'GET',
+            "/contents",
+            "GET",
             {
-              fullType: 'DET',
+              fullType: "DET",
               searchBy: props.contentId,
               page: 1,
               perPage: 1,
             },
             false,
-            true
+            true,
           );
 
           if (response?.data?.data) {
             setContentData(response.data.data);
           }
         } catch (error) {
-          console.error('Error fetching content details:', error);
-          if (showToast) {
-            showToast('Error al cargar los detalles del contenido', 'error');
-          }
+          console.error("Error fetching content details:", error);
+          showToast?.("Error al cargar los detalles del contenido", "error");
         } finally {
           setLoading(false);
         }
@@ -76,7 +114,14 @@ const RenderView = (props: {
     };
 
     fetchContentDetails();
-  }, [props.open, props.contentId, props.selectedContentData, data, execute, showToast]);
+  }, [
+    props.open,
+    props.contentId,
+    props.selectedContentData,
+    data,
+    execute,
+    showToast,
+  ]);
 
   useEffect(() => {
     if (!props.open) {
@@ -88,29 +133,33 @@ const RenderView = (props: {
 
   const commentsCount = useMemo(() => {
     return currentData?.comments?.length || currentData?.comments_count || 0;
-  }, [currentData?.comments, currentData?.comments_count]);
+  }, [currentData]);
 
-  const toggleExpanded = useCallback(() => setIsExpanded(!isExpanded), [isExpanded]);
+  const toggleExpanded = useCallback(
+    () => setIsExpanded(!isExpanded),
+    [isExpanded],
+  );
 
   const nextIndex = useCallback(() => {
-    setIndexVisible((prevIndex) => (prevIndex + 1) % currentData?.images?.length);
-  }, [currentData?.images?.length]);
+    setIndexVisible((prev) => (prev + 1) % normalizedImages.length);
+  }, [normalizedImages.length]);
 
   const prevIndex = useCallback(() => {
-    setIndexVisible((prevIndex) =>
-      prevIndex === 0 ? currentData?.images?.length - 1 : prevIndex - 1
+    setIndexVisible((prev) =>
+      prev === 0 ? normalizedImages.length - 1 : prev - 1,
     );
-  }, [currentData?.images?.length]);
+  }, [normalizedImages.length]);
 
   const handleEdit = useCallback(() => {
     const itemForEdit = {
       ...currentData,
       id: currentData.id,
-      title: currentData.title || '',
-      description: currentData.description || '',
+      title: currentData.title || "",
+      description: currentData.description || "",
       type: currentData.type,
-      url: currentData.url || '',
+      url: currentData.url || "",
       images: currentData.images || [],
+      files: currentData.files || [], // también lo pasamos
       user_id: currentData.user_id,
       destiny: currentData.destiny || 0,
       client_id: currentData.client_id,
@@ -122,240 +171,292 @@ const RenderView = (props: {
     };
 
     props.onClose();
-    if (props.onEdit) {
-      props.onEdit(itemForEdit);
-    }
+    props.onEdit?.(itemForEdit);
   }, [currentData, props]);
 
   const handleDelete = useCallback(() => {
-    if (props.onDelete) {
-      props.onDelete(currentData);
-    }
+    props.onDelete?.(currentData);
   }, [currentData, props]);
 
   const handleOpenComments = useCallback(() => {
-    if (props.onOpenComments) {
-      props.onOpenComments(currentData?.id, currentData);
-    }
+    props.onOpenComments?.(currentData?.id, currentData);
   }, [props.onOpenComments, currentData]);
 
   const getDocumentUrl = () => {
-    if (currentData?.type === 'D' && currentData?.id && currentData?.url) {
-      return getUrlImages(`/CONT-${currentData.id}.pdf?d=${currentData.updated_at}`);
+    if (currentData?.type === "D" && currentData?.id && currentData?.url) {
+      return getUrlImages(
+        `/CONT-${currentData.id}.pdf?d=${currentData.updated_at}`,
+      );
     }
     return null;
   };
 
-  const hasDocument = () => {
-    return currentData?.type === 'D' && currentData?.url && currentData?.url !== 'null';
-  };
+  const hasDocument = () =>
+    currentData?.type === "D" &&
+    currentData?.url &&
+    currentData?.url !== "null";
 
-  const hasImages = () => {
-    return currentData?.type === 'I' && currentData?.images && currentData?.images.length > 0 && currentData?.images[indexVisible]?.id;
-  };
-
+  const urlAvatar = currentData?.user
+    ? getUrlImages(
+        "/ADM-" +
+          currentData?.user?.id +
+          ".webp?d=" +
+          currentData?.user?.updated_at,
+        currentData?.user?.url_avatar,
+      )
+    : getUrlImages(
+        "/OWNER-" +
+          currentData?.owner?.id +
+          ".webp?d=" +
+          currentData?.owner?.updated_at,
+        currentData?.owner?.url_avatar,
+      );
+  console.log(currentData);
   return (
-
-      <DataModal
-        open={props.open}
-        onClose={props?.onClose}
-        title={'Detalle de la publicación'}
-        buttonText=""
-        buttonCancel=""
-        variant={"mini"}
-      >
-        <div className={styles.container}>
-          <div className={styles.header}>
-            <div className={styles.headerLeft}>
-              <p className={styles.text}>Publicado: {getDateTimeStrMesShort(currentData?.created_at)}</p>
-              <p className={styles.text}>Para: Todos</p>
-            </div>
-            <div className={styles.headerRight}>
-              {(props.showActions ?? true) && (
-                <>
-                  <button
-                    className={styles.actionButton}
-                    onClick={handleEdit}
-                  >
-                    <IconEdit size={24} />
-                  </button>
-                  <button
-                    className={styles.actionButton}
-                    onClick={handleDelete}
-                  >
-                    <IconTrash size={24} />
-                  </button>
-                </>
-              )}
-            </div>
+    <DataModal
+      open={props.open}
+      onClose={props.onClose}
+      title="Detalle de la publicación"
+      buttonText=""
+      buttonCancel=""
+      variant="mini"
+    >
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <div className={styles.headerLeft}>
+            <p className={styles.text}>
+              Publicado: {getDateTimeStrMesShort(currentData?.created_at)}
+            </p>
+            <p className={styles.text}>Para: Todos</p>
           </div>
-          <Br />
-          <div className={styles.content}>
-            <div className={styles.imageContainer}>
-              {currentData?.type === 'I' ? (
-                hasImages() ? (
-                  <div>
-                    <div className={styles.imageWrapper}>
-                      <Image
-                        alt="Imagen de la publicación"
-                        src={getUrlImages(
-                          '/CONT-' + currentData.id + '-' + currentData.images[indexVisible]?.id + '.webp' + '?' + currentData?.updated_at
-                        )}
-                        square={true}
-                        expandable={true}
-                        expandableIcon={false}
-                        objectFit="contain"
-                        borderRadius="var(--bRadiusM)"
-                        style={{ width: '100%', height: '100%' }}
-                      />
-                    </div>
-                    {currentData?.images?.length > 1 && (
-                      <div className={styles.containerButton}>
-                        <div className={styles.button} onClick={prevIndex}>
-                          <IconArrowLeft size={18} color="var(--cWhite)" />
-                        </div>
-                        <p style={{ color: "var(--cWhite)", fontSize: 10 }}>
-                          {indexVisible + 1} / {currentData?.images?.length}
-                        </p>
-                        <div className={styles.button} onClick={nextIndex}>
-                          <IconArrowRight size={18} color="var(--cWhite)" />
-                        </div>
+          <div className={styles.headerRight}>
+            {(props.showActions ?? true) && (
+              <>
+                <button className={styles.actionButton} onClick={handleEdit}>
+                  <IconEdit size={24} />
+                </button>
+                <button className={styles.actionButton} onClick={handleDelete}>
+                  <IconTrash size={24} />
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        <Br />
+
+        <div className={styles.content}>
+          <div className={styles.imageContainer}>
+            {currentData?.type === "I" ? (
+              hasImagesContent ? (
+                <div>
+                  <div className={styles.imageWrapper}>
+                    <Image
+                      alt="Imagen de la publicación"
+                      src={normalizedImages[indexVisible]?.url || ""}
+                      square={true}
+                      expandable={true}
+                      expandableIcon={false}
+                      objectFit="contain"
+                      borderRadius="var(--bRadiusM)"
+                      style={{ width: "100%", height: "100%" }}
+                    />
+                  </div>
+
+                  {normalizedImages.length > 1 && (
+                    <div className={styles.containerButton}>
+                      <div className={styles.button} onClick={prevIndex}>
+                        <IconArrowLeft size={18} color="var(--cWhite)" />
                       </div>
-                    )}
-                  </div>
-                ) : (
-                  /* Mostrar mensaje de imagen no disponible */
-                  <div className={styles.imageWrapper} style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: '16px',
-                    padding: '40px'
-                  }}>
-                    <IconImage size={120} color="var(--cWhiteV1)" />
-                    <div style={{ textAlign: 'center' }}>
-                      <p style={{ color: 'var(--cWhite)', fontSize: '16px', margin: '0 0 8px 0' }}>
-                        Imagen no disponible
+                      <p style={{ color: "var(--cWhite)", fontSize: 10 }}>
+                        {indexVisible + 1} / {normalizedImages.length}
                       </p>
-                      <p style={{ color: 'var(--cWhiteV1)', fontSize: '14px', margin: '0' }}>
-                        La imagen fue eliminada y no se pudo cargar.
-                      </p>
+                      <div className={styles.button} onClick={nextIndex}>
+                        <IconArrowRight size={18} color="var(--cWhite)" />
+                      </div>
                     </div>
-                  </div>
-                )
-              ) : currentData?.type === 'V' ? (
-                <ReactPlayer url={currentData?.url} width="100%" height="100%" controls />
-              ) : currentData?.type === 'D' ? (
-                /* Mostrar documento o mensaje de no disponible */
-                <div className={styles.imageWrapper} style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '16px',
-                  padding: '40px'
-                }}>
-                  <IconPDF size={120} color={hasDocument() ? "var(--cWhite)" : "var(--cWhiteV1)"} />
-                  <div style={{ textAlign: 'center' }}>
-                    <p style={{ color: 'var(--cWhite)', fontSize: '16px', margin: '0 0 8px 0' }}>
-                      {hasDocument() ? (currentData?.title || 'Documento') : 'Documento no disponible'}
-                    </p>
-                    <p style={{ color: 'var(--cWhiteV1)', fontSize: '14px', margin: '0 0 16px 0' }}>
-                      {hasDocument()
-                        ? (currentData?.description?.substring(0, 100) + (currentData?.description?.length > 100 ? '...' : ''))
-                        : 'El documento fue eliminado y no se pudo cargar.'
-                      }
-                    </p>
-                    {/* Solo mostrar el botón si el documento existe */}
-                    {hasDocument() && getDocumentUrl() && (
-                      <a
-                        href={getDocumentUrl() || undefined}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{
-                          color: 'var(--cAccent)',
-                          textDecoration: 'none',
-                          fontSize: '14px',
-                          fontWeight: '600',
-                          padding: '8px 16px',
-                          border: '1px solid var(--cAccent)',
-                          borderRadius: '6px',
-                          display: 'inline-block',
-                          transition: 'all 0.2s ease'
-                        }}
-                        onMouseOver={(e) => {
-                          e.currentTarget.style.backgroundColor = 'var(--cAccent)';
-                          e.currentTarget.style.color = 'var(--cWhite)';
-                        }}
-                        onMouseOut={(e) => {
-                          e.currentTarget.style.backgroundColor = 'transparent';
-                          e.currentTarget.style.color = 'var(--cAccent)';
-                        }}
-                      >
-                        Abrir documento
-                      </a>
-                    )}
-                  </div>
+                  )}
                 </div>
               ) : (
-                <div className={styles.noImageText}>Sin contenido disponible</div>
-              )}
+                <div
+                  className={styles.imageWrapper}
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: "16px",
+                    padding: "40px",
+                  }}
+                >
+                  <IconImage size={120} color="var(--cWhiteV1)" />
+                  <div style={{ textAlign: "center" }}>
+                    <p
+                      style={{
+                        color: "var(--cWhite)",
+                        fontSize: "16px",
+                        margin: "0 0 8px 0",
+                      }}
+                    >
+                      Imagen no disponible
+                    </p>
+                    <p
+                      style={{
+                        color: "var(--cWhiteV1)",
+                        fontSize: "14px",
+                        margin: "0",
+                      }}
+                    >
+                      No se encontraron imágenes válidas.
+                    </p>
+                  </div>
+                </div>
+              )
+            ) : currentData?.type === "V" ? (
+              <ReactPlayer
+                url={currentData?.url}
+                width="100%"
+                height="100%"
+                controls
+              />
+            ) : currentData?.type === "D" ? (
+              <div
+                className={styles.imageWrapper}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "16px",
+                  padding: "40px",
+                }}
+              >
+                <IconPDF
+                  size={120}
+                  color={hasDocument() ? "var(--cWhite)" : "var(--cWhiteV1)"}
+                />
+                <div style={{ textAlign: "center" }}>
+                  <p
+                    style={{
+                      color: "var(--cWhite)",
+                      fontSize: "16px",
+                      margin: "0 0 8px 0",
+                    }}
+                  >
+                    {hasDocument()
+                      ? currentData?.title || "Documento"
+                      : "Documento no disponible"}
+                  </p>
+                  <p
+                    style={{
+                      color: "var(--cWhiteV1)",
+                      fontSize: "14px",
+                      margin: "0 0 16px 0",
+                    }}
+                  >
+                    {hasDocument()
+                      ? currentData?.description?.substring(0, 100) +
+                        (currentData?.description?.length > 100 ? "..." : "")
+                      : "El documento fue eliminado y no se pudo cargar."}
+                  </p>
+                  {hasDocument() && getDocumentUrl() && (
+                    <a
+                      href={getDocumentUrl() ?? undefined}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        color: "var(--cAccent)",
+                        textDecoration: "none",
+                        fontSize: "14px",
+                        fontWeight: "600",
+                        padding: "8px 16px",
+                        border: "1px solid var(--cAccent)",
+                        borderRadius: "6px",
+                        display: "inline-block",
+                        transition: "all 0.2s ease",
+                      }}
+                      onMouseOver={(e) => {
+                        e.currentTarget.style.backgroundColor =
+                          "var(--cAccent)";
+                        e.currentTarget.style.color = "var(--cWhite)";
+                      }}
+                      onMouseOut={(e) => {
+                        e.currentTarget.style.backgroundColor = "transparent";
+                        e.currentTarget.style.color = "var(--cAccent)";
+                      }}
+                    >
+                      Abrir documento
+                    </a>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className={styles.noImageText}>Sin contenido disponible</div>
+            )}
+          </div>
+
+          <div className={styles.contentContainer}>
+            <div className={styles.userSection}>
+              <Avatar
+                hasImage={1}
+                name={getFullName(currentData?.user || currentData?.owner)}
+                src={urlAvatar}
+                w={48}
+                h={48}
+              />
+              <div className={styles.userInfo}>
+                <div className={styles.userName}>
+                  {getFullName(currentData?.user || currentData?.owner)}
+                </div>
+                <div className={styles.userRole}>
+                  {currentData?.user?.role1?.[0]?.name}
+                </div>
+              </div>
             </div>
 
-            <div className={styles.contentContainer}>
-              <div className={styles.userSection}>
-                <Avatar
-                  hasImage={1}
-                  name={getFullName(currentData?.user)}
-                  src={getUrlImages('/ADM-' + currentData?.user?.id + '.webp?d=' + currentData?.user?.updated_at)}
-                  w={48}
-                  h={48}
-                />
-                <div className={styles.userInfo}>
-                  <div className={styles.userName}>{getFullName(currentData?.user)}</div>
-                  <div className={styles.userRole}>Administrador</div>
-                </div>
-              </div>
+            {currentData?.title && (
+              <h2 className={styles.title}>{currentData.title}</h2>
+            )}
 
-              {currentData?.title && <h2 className={styles.title}>{currentData.title}</h2>}
+            <div className={styles.descriptionContainer}>
+              <p
+                className={`${styles.description} ${!isExpanded ? styles.descriptionTruncated : ""}`}
+              >
+                {currentData?.description}
+              </p>
 
-              <div className={styles.descriptionContainer}>
-                <p
-                  className={`${styles.description} ${
-                    !isExpanded ? styles.descriptionTruncated : ''
-                  }`}
-                >
-                  {currentData?.description}
-                </p>
-
-                {currentData?.description && currentData.description.length > 200 && (
-                  <button type="button" onClick={toggleExpanded} className={styles.expandButton}>
-                    {isExpanded ? 'Ver menos' : 'Ver más'}
+              {currentData?.description &&
+                currentData.description.length > 200 && (
+                  <button
+                    type="button"
+                    onClick={toggleExpanded}
+                    className={styles.expandButton}
+                  >
+                    {isExpanded ? "Ver menos" : "Ver más"}
                   </button>
                 )}
-              </div>
-              <Br />
+            </div>
 
-              <div className={styles.statsContainer}>
-                <div className={styles.statItem}>
-                  <IconLike color={'var(--cAccent)'} size={24} />
-                  <span>{currentData?.likes || 0} Apoyos</span>
-                </div>
-                <div
-                  className={styles.statItem}
-                  onClick={handleOpenComments}
-                  style={{ cursor: 'pointer' }}
-                >
-                  <IconComment color={'var(--cAccent)'} size={24} />
-                  <span>{commentsCount} Comentarios</span>
-                </div>
+            <Br />
+
+            <div className={styles.statsContainer}>
+              <div className={styles.statItem}>
+                <IconLike color="var(--cAccent)" size={24} />
+                <span>{currentData?.likes || 0} Apoyos</span>
+              </div>
+              <div
+                className={styles.statItem}
+                onClick={handleOpenComments}
+                style={{ cursor: "pointer" }}
+              >
+                <IconComment color="var(--cAccent)" size={24} />
+                <span>{commentsCount} Comentarios</span>
               </div>
             </div>
           </div>
         </div>
-      </DataModal>
-
+      </div>
+    </DataModal>
   );
 };
 

--- a/src/modulos/Reel/ImageMosaic/ImageMosaic.tsx
+++ b/src/modulos/Reel/ImageMosaic/ImageMosaic.tsx
@@ -13,7 +13,7 @@ interface ImageMosaicProps {
 const ImageMosaic: React.FC<ImageMosaicProps> = ({
   item,
   modoCompacto = false,
-  onImageClick
+  onImageClick,
 }) => {
   if (!item.images || item.images.length <= 1) {
     return null;
@@ -31,42 +31,58 @@ const ImageMosaic: React.FC<ImageMosaicProps> = ({
   }
 
   const renderImage = (image: any, index: number, isLast = false) => {
-    const imageUrl = getUrlImages(
-      `/CONT-${item.id}-${image.id}.webp?d=${item.updated_at}`
-    );
+    // Soporte para dos formatos:
+    // 1. Objeto con id → construimos la URL
+    // 2. String → usamos directamente como URL
+    let imageUrl: string;
 
-    const imageClass = index === 0 ?
-      `${styles.mosaicImage} ${styles.mosaicImageFirst}` :
-      styles.mosaicImage;
+    if (typeof image === "string") {
+      imageUrl = image;
+    } else if (image && typeof image === "object" && "id" in image) {
+      imageUrl = getUrlImages(
+        `/CONT-${item.id}-${image.id}.webp?d=${item.updated_at || ""}`,
+      );
+    } else {
+      // Fallback en caso de formato inválido
+      imageUrl = "/placeholder-image.jpg"; // o una imagen por defecto
+    }
+
+    const imageClass =
+      index === 0
+        ? `${styles.mosaicImage} ${styles.mosaicImageFirst}`
+        : styles.mosaicImage;
+
+    // Usamos un identificador único (id o índice)
+    const key =
+      typeof image === "string" ? `url-${index}` : `mosaic-${image.id}`;
 
     return (
       <div
-        key={`mosaic-${image.id}`}
+        key={key}
         className={isLast ? styles.mosaicImageLast : undefined}
         onClick={onImageClick}
       >
         <Image
           src={imageUrl}
-          alt={`Imagen ${index + 1} de ${item.title || 'contenido'}`}
+          alt={`Imagen ${index + 1} de ${item.title || "contenido"}`}
           width={300}
           height={200}
           className={imageClass}
           unoptimized
         />
         {isLast && imageCount > 4 && (
-          <div className={styles.mosaicOverlay}>
-            +{imageCount - 3}
-          </div>
+          <div className={styles.mosaicOverlay}>+{imageCount - 3}</div>
         )}
       </div>
     );
   };
 
+  // Mostramos hasta 4 imágenes (como antes)
   const imagesToShow = imageCount > 4 ? item.images.slice(0, 4) : item.images;
 
   return (
     <div className={containerClass}>
-      {imagesToShow.map((image, index) => {
+      {imagesToShow.map((image: any, index: any) => {
         const isLast = index === imagesToShow.length - 1 && imageCount > 4;
         return renderImage(image, index, isLast);
       })}

--- a/src/modulos/Reel/MediaRenderer/MediaRenderer.tsx
+++ b/src/modulos/Reel/MediaRenderer/MediaRenderer.tsx
@@ -3,11 +3,7 @@ import Image from "next/image";
 import { getUrlImages } from "@/mk/utils/string";
 import { ContentItem } from "../types";
 import ImageMosaic from "../ImageMosaic/ImageMosaic";
-import {
-  IconArrowLeft,
-  IconArrowRight,
-  IconPdfPro,
-} from "@/components/layout/icons/IconsBiblioteca";
+import { IconPdfPro } from "@/components/layout/icons/IconsBiblioteca";
 import styles from "./MediaRenderer.module.css";
 
 interface MediaRendererProps {
@@ -21,38 +17,56 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
   item,
   modoCompacto = false,
   onImageClick,
-  onNavigateImage
 }) => {
-  const isYouTubeUrl = (url: string) => {
-    const youtubeRegex = /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/;
-    return youtubeRegex.test(url);
-  };
+  // Normalizamos las imágenes (files > images)
+  const normalizedImages = React.useMemo(() => {
+    if (item.files && Array.isArray(item.files) && item.files.length > 0) {
+      return item?.files.filter(
+        (url): url is string => typeof url === "string" && url.trim() !== "",
+      );
+    }
+
+    if (item.images && Array.isArray(item.images) && item.images.length > 0) {
+      return item.images; // pasamos los objetos originales
+    }
+
+    return [];
+  }, [item.files, item.images]);
+
+  const hasImages = normalizedImages.length > 0;
+
+  // ── YouTube ──
+  const isYouTubeUrl = (url: string) =>
+    /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/.test(
+      url,
+    );
 
   const getYouTubeEmbedUrl = (url: string) => {
-    const match = url.match(/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/);
+    const match = url.match(
+      /(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/,
+    );
     return match ? `https://www.youtube.com/embed/${match[1]}` : null;
   };
 
-  const isInstagramUrl = (url: string) => {
-    return /instagram\.com\/(p|reel)\//.test(url);
-  };
+  // ── Instagram ──
+  const isInstagramUrl = (url: string) =>
+    /instagram\.com\/(p|reel)\//.test(url);
+  const getInstagramEmbedUrl = (url: string) => `${url}embed/`;
 
-  const getInstagramEmbedUrl = (url: string) => {
-    return `${url}embed/`;
-  };
-
-  if (item.type === "I" && item.images && item.images.length > 0) {
-    if (item.images.length === 1) {
-      const currentIndex = item.currentImageIndex || 0;
-      const currentImage = item.images[currentIndex];
-      const imageUrl = getUrlImages(
-        `/CONT-${item.id}-${currentImage.id}.webp?d=${item.updated_at}`
-      );
+  // Render
+  if (item.type === "I" && hasImages) {
+    if (normalizedImages.length === 1) {
+      const imageSrc =
+        typeof normalizedImages[0] === "string"
+          ? normalizedImages[0]
+          : getUrlImages(
+              `/CONT-${item.id}-${normalizedImages[0].id}.webp?d=${item.updated_at || ""}`,
+            );
 
       return (
         <div className={styles.contentMediaContainer}>
           <Image
-            src={imageUrl}
+            src={imageSrc}
             alt={item.title || "Imagen de contenido"}
             width={600}
             height={400}
@@ -62,17 +76,20 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
           />
         </div>
       );
-    } else {
-      return (
-        <ImageMosaic
-          item={item}
-          modoCompacto={modoCompacto}
-          onImageClick={onImageClick}
-        />
-      );
     }
+
+    // Múltiples imágenes → pasamos el array tal cual (ya sea strings o objetos)
+
+    return (
+      <ImageMosaic
+        item={item}
+        modoCompacto={modoCompacto}
+        onImageClick={onImageClick}
+      />
+    );
   }
 
+  // Video
   if (item.type === "V" && item.url) {
     if (isYouTubeUrl(item.url)) {
       const embedUrl = getYouTubeEmbedUrl(item.url);
@@ -91,7 +108,9 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
           </div>
         );
       }
-    } else if (isInstagramUrl(item.url)) {
+    }
+
+    if (isInstagramUrl(item.url)) {
       const embedUrl = getInstagramEmbedUrl(item.url);
       return (
         <div className={styles.contentMediaContainer}>
@@ -105,23 +124,24 @@ const MediaRenderer: React.FC<MediaRendererProps> = ({
           </div>
         </div>
       );
-    } else {
-      return (
-        <div className={styles.contentMediaContainer}>
-          <div className={styles.externalMediaLink}>
-            <a href={item.url} target="_blank" rel="noopener noreferrer">
-              Ver contenido externo
-            </a>
-            <div className={styles.externalMediaUrl}>{item.url}</div>
-          </div>
-        </div>
-      );
     }
+
+    return (
+      <div className={styles.contentMediaContainer}>
+        <div className={styles.externalMediaLink}>
+          <a href={item.url} target="_blank" rel="noopener noreferrer">
+            Ver contenido externo
+          </a>
+          <div className={styles.externalMediaUrl}>{item.url}</div>
+        </div>
+      </div>
+    );
   }
 
+  // Documento
   if (item.type === "D" && item.url) {
     const documentUrl = getUrlImages(
-      `/CONT-${item.id}.${item.url}?${item.updated_at}`
+      `/CONT-${item.id}.${item.url}?${item.updated_at || ""}`,
     );
 
     return (

--- a/src/modulos/Reel/Reel.tsx
+++ b/src/modulos/Reel/Reel.tsx
@@ -520,6 +520,19 @@ const Reel = () => {
     return <div className={styles.loadingState}>Cargando publicaciones...</div>;
   }
 
+  const urlAvatar = (item: ContentItem) => {
+    let img = item.user
+      ? getUrlImages(
+          "/ADM-" + item.user?.id + ".webp?d=" + item.user?.updated_at,
+          item.user?.url_avatar,
+        )
+      : getUrlImages(
+          "/OWNER-" + item.owner?.id + ".webp?d=" + item.owner?.updated_at,
+          item.owner?.url_avatar,
+        );
+    return img;
+  };
+
   return (
     <div className={styles.reelContainer}>
       {contents.length > 0
@@ -538,18 +551,17 @@ const Reel = () => {
                     <Avatar
                       hasImage={1}
                       name={getFullName(item.user)}
-                      src={getUrlImages(
-                        `/ADM-${item.user?.id}.webp?d=${item.user?.updated_at}`,
-                      )}
+                      src={urlAvatar(item)}
                       w={44}
                       h={44}
                     />
                     <div className={styles.userDetails}>
                       <span className={styles.userName}>
-                        {getFullName(item.user) || "Usuario Desconocido"}
+                        {getFullName(item.user || item.owner) ||
+                          "Usuario Desconocido"}
                       </span>
                       <span className={styles.userRole}>
-                        {item.user?.role1?.[0]?.name || ""}
+                        {item.user?.role1?.[0]?.name}
                       </span>
                     </div>
                   </div>
@@ -597,12 +609,13 @@ const Reel = () => {
                       </div>
                     </div>
                     <div className={styles.newsMediaContent}>
-                      {item.images && item.images.length > 0 && (
+                      {(item.images.length > 0 || item?.files?.length > 0) && (
                         <div className={styles.newsImageContainer}>
                           {/* Contador de imágenes - solo si hay más de una */}
-                          {item.images.length > 1 && (
+                          {(item.images.length > 1 ||
+                            item?.files?.length > 1) && (
                             <div className={styles.newsImageCounter}>
-                              +{item.images.length}
+                              +{item?.files?.length || item.images.length}
                             </div>
                           )}
 
@@ -621,9 +634,12 @@ const Reel = () => {
                             aria-label={`Ver imagen completa de ${item.title || "noticia"}`}
                           >
                             <img
-                              src={getUrlImages(
-                                `/CONT-${item.id}-${item.images[0].id}.webp?d=${item.updated_at}`,
-                              )}
+                              src={
+                                item?.files?.[0] ||
+                                getUrlImages(
+                                  `/CONT-${item.id}-${item.images[0].id}.webp?d=${item.updated_at}`,
+                                )
+                              }
                               alt={item.title || "Imagen de noticia"}
                               className={styles.newsImage}
                               style={{

--- a/src/modulos/Reel/types/index.ts
+++ b/src/modulos/Reel/types/index.ts
@@ -7,6 +7,7 @@ export type User = {
   mother_last_name?: string;
   updated_at: string;
   role1: Role[];
+  url_avatar?: string;
 };
 
 export type Role = {
@@ -63,8 +64,14 @@ export type ContentItem = {
   deleted_at: string | null;
   comments_count: number;
   liked: 0 | 1;
-  images: Image[];
+  images: {
+    id: number;
+    ext: string;
+    entity_id?: string;
+  }[];
+  files: string[];
   user: User;
   currentImageIndex?: number;
   isDescriptionExpanded?: boolean;
+  owner: User;
 };


### PR DESCRIPTION
- Extend ContentItem type to include `files` array and `owner` user
- Update `getUrlImages` utility to accept custom URLs as fallback
- Modify ImageMosaic to handle both string URLs and image objects
- Add avatar fallback logic to display owner avatar if user is missing
- Normalize image sources across Reel, MediaRenderer, and Contents modules