### PR TITLE
style(ActiveOwner): adjust modal width and container styling

### DIFF
--- a/src/components/ActiveOwner/ActiveOwner.module.css
+++ b/src/components/ActiveOwner/ActiveOwner.module.css
@@ -1,16 +1,16 @@
-
 .activeContainer {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spL);
-    min-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spL);
+  width: 100%;
+  min-width: 0;
 }
 .textContent {
-    font-size: var(--sM);
-    color: var(--cWhiteV1);
-    margin-bottom: var(--spL);
+  font-size: var(--sM);
+  color: var(--cWhiteV1);
+  margin-bottom: var(--spL);
 }
 
 .resalted {
-    color: var(--cWhite);
+  color: var(--cWhite);
 }

--- a/src/components/ActiveOwner/ActiveOwner.tsx
+++ b/src/components/ActiveOwner/ActiveOwner.tsx
@@ -116,6 +116,7 @@ const ActiveOwner = ({
       buttonText="Guardar"
       onClose={onClose}
       variant={"mini"}
+      style={{ width: "min(92vw, 780px)" }}
     >
       {typeActive === "A" ? (
         <div className={styles.activeContainer}>


### PR DESCRIPTION
Improve responsive behavior by setting modal width to min(92vw, 780px) and making container width 100% with min-width: 0 to prevent overflow on smaller screens.