### PR TITLE
feat(Visitors): add first entry column to visitors table

### DIFF
--- a/src/modulos/Visitors/Visitors.tsx
+++ b/src/modulos/Visitors/Visitors.tsx
@@ -81,6 +81,20 @@ const Visitors = () => {
           ),
         },
       },
+      first_entry: {
+        rules: [""],
+        api: "",
+        label: "Primer acceso",
+        list: {
+          onRender: (props: any) => (
+            <div>
+              {props.item.first_entry
+                ? getDateTimeStrMesShort(props.item.first_entry)
+                : "-/-"}
+            </div>
+          ),
+        },
+      },
       last_entry: {
         rules: [""],
         api: "",


### PR DESCRIPTION
Add a new column to display the first access date for each visitor, providing a complete timeline alongside the existing last entry column.