### PR TITLE
fix(MainMenu): enable permission check for visit reasons menu item

### DIFF
--- a/src/components/MainMenu/mainMenuConfig.ts
+++ b/src/components/MainMenu/mainMenuConfig.ts
@@ -51,7 +51,7 @@ export const menuConfig: MenuConfigItem[] = [
       { href: "/app-versions", perm: "superadmins", labelKey: "appVersions" },
       {
         href: "/visit-reasons",
-        perm: "", //"visit_reasons",
+        perm: "visit_reasons",
         labelKey: "Motivos de visitas",
       },
     ],


### PR DESCRIPTION
The menu item for "Motivos de visitas" was previously accessible to all users due to an empty permission string. Now it correctly requires the "visit_reasons" permission, restricting access to authorized users only.