### PR TITLE
fix(TextArea): remove character limit from form field

### DIFF
--- a/src/mk/components/forms/TextArea/TextArea.tsx
+++ b/src/mk/components/forms/TextArea/TextArea.tsx
@@ -35,7 +35,9 @@ const TextArea = ({
   const wrapperStyle: React.CSSProperties = fullHeight
     ? { height: "100%", display: "flex", flexDirection: "column" }
     : {};
-  const containerStyle: React.CSSProperties = fullHeight ? { height: "100%" } : {};
+  const containerStyle: React.CSSProperties = fullHeight
+    ? { height: "100%" }
+    : {};
   const fieldStyle: React.CSSProperties = fullHeight
     ? { height: "100%", display: "flex", flexDirection: "column" }
     : {};
@@ -68,7 +70,7 @@ const TextArea = ({
           disabled={disabled}
           required={required}
           rows={fullHeight ? undefined : lines}
-          maxLength={maxLength} // Aplica el límite de caracteres
+          maxLength={isLimit ? maxLength : undefined} // Aplica el límite de caracteres
           onChange={handleChange}
           onFocus={onFocus}
           onBlur={onBlur}

--- a/src/modulos/Assemblies/RenderForm/RenderForm.tsx
+++ b/src/modulos/Assemblies/RenderForm/RenderForm.tsx
@@ -517,8 +517,8 @@ const RenderForm = ({ open, onClose, item, setItem, execute, reLoad }: any) => {
               onChange={handleChange}
               error={errors}
               required
-              isLimit
-              maxLength={255}
+              // isLimit
+              // maxLength={255}
             />
           </section>
           <section className={styles.sectionCard}>


### PR DESCRIPTION
The character limit was unintentionally applied to the description field in the assembly form. This change removes the `isLimit` and `maxLength` props from the RenderForm component and updates the TextArea component to only apply the maxLength when the `isLimit` prop is explicitly set to true.