### PR TITLE
feat(surveys): add voters list modal for survey and assembly options

### DIFF
--- a/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.module.css
+++ b/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.module.css
@@ -319,6 +319,24 @@
   cursor: pointer;
 }
 
+.verVotantesBtn {
+  background: rgba(139, 92, 246, 0.15);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  color: #a78bfa;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.verVotantesBtn:hover {
+  background: rgba(139, 92, 246, 0.25);
+  border-color: rgba(139, 92, 246, 0.5);
+  color: #c4b5fd;
+}
+
 .modalContent {
   flex: 1;
   display: flex;

--- a/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.tsx
+++ b/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.tsx
@@ -41,6 +41,7 @@ import AssemblySurveyForm from "@/modulos/Surveys/components/AssemblySurveyForm/
 import AssemblyAttendanceForm from "../AssemblyAttendanceForm/AssemblyAttendanceForm";
 import AssemblyAttendanceList from "../AssemblyAttendanceList/AssemblyAttendanceList";
 import AssemblyManualVoteForm from "../AssemblyManualVoteForm/AssemblyManualVoteForm";
+import VotersListModal from "@/modulos/Surveys/components/VotersListModal/VotersListModal";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { useScreenSize } from "@/mk/hooks/useScreenSize";
 import useInstantMsg from "@/mk/hooks/useInstantMsg";
@@ -108,6 +109,12 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
   const [surveyToEdit, setSurveyToEdit] = useState<any>(null);
   const [surveyAction, setSurveyAction] = useState<"add" | "edit">("add");
   const [attendanceRefreshKey, setAttendanceRefreshKey] = useState(0);
+  const [votersModal, setVotersModal] = useState<{
+    open: boolean;
+    soptionId: number | string;
+    soptionText: string;
+    totalVoters: number;
+  } | null>(null);
   const { isMobile } = useScreenSize();
   const { showToast } = useAuth();
   const { notifySegmented, notifyAll } = useInstantMsg();
@@ -116,6 +123,28 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
   const [showDetails, setShowDetails] = useState(true);
   const [showDocs, setShowDocs] = useState(false);
   const [showParticipants, setShowParticipants] = useState(isMobile);
+
+  // Ordenamiento de votaciones: activas primero por published_at, luego por created_at
+  const getSortedSurveys = (surveys: any[]) => {
+    if (!surveys?.length) return [];
+    return [...surveys].sort((a, b) => {
+      const isActiveA = a.status === 'A';
+      const isActiveB = b.status === 'A';
+      // Si una está activa y otra no, la activa va primero
+      if (isActiveA && !isActiveB) return -1;
+      if (!isActiveA && isActiveB) return 1;
+      // Ordenar activas por published_at descendente (última publicada primero)
+      if (isActiveA && isActiveB) {
+        const dateA = a.published_at ? new Date(a.published_at).getTime() : 0;
+        const dateB = b.published_at ? new Date(b.published_at).getTime() : 0;
+        return dateB - dateA;
+      }
+      // Ordenar inactivas por created_at descendente (última creada primero)
+      const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
+      return dateB - dateA;
+    });
+  };
 
   useEffect(() => {
     if (isMobile) {
@@ -468,7 +497,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
           >
             {/* Dynamic Voting Questions */}
             {assembly.surveys && assembly.surveys.length > 0 ? (
-              assembly.surveys.map((survey: any) => (
+              getSortedSurveys(assembly.surveys).map((survey: any) => (
                 <div key={survey.id} className={styles.votacionCard}>
                   <div
                     style={{
@@ -638,10 +667,27 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                             <div key={opt.id} className={styles.optionItem}>
                               <div className={styles.optionHeader}>
                                 <span>{opt.option_text}</span>
-                                <span>
-                                  {percentage}% ({votes}{" "}
-                                  {votes === 1 ? "voto" : "votos"})
-                                </span>
+                                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                                  <span>
+                                    {percentage}% ({votes}{" "}
+                                    {votes === 1 ? "voto" : "votos"})
+                                  </span>
+                                  {votes > 0 && (
+                                    <button
+                                      className={styles.verVotantesBtn}
+                                      onClick={() => {
+                                        setVotersModal({
+                                          open: true,
+                                          soptionId: opt.id,
+                                          soptionText: opt.option_text || "",
+                                          totalVoters: votes,
+                                        });
+                                      }}
+                                    >
+                                      ver
+                                    </button>
+                                  )}
+                                </div>
                               </div>
                               <div className={styles.progressContainer}>
                                 <div
@@ -1007,6 +1053,17 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
           loadAssembly();
         }}
       />
+
+      {/* Modal para ver lista de votantes por opción */}
+      {votersModal && (
+        <VotersListModal
+          open={votersModal.open}
+          onClose={() => setVotersModal(null)}
+          soptionId={votersModal.soptionId}
+          soptionText={votersModal.soptionText}
+          totalVoters={votersModal.totalVoters}
+        />
+      )}
     </div>
   );
 };

--- a/src/modulos/Surveys/components/RenderView/SurveyStatsView.module.css
+++ b/src/modulos/Surveys/components/RenderView/SurveyStatsView.module.css
@@ -67,6 +67,47 @@
   color: var(--cWhiteV3);
 }
 
+.chartWrapper {
+  cursor: pointer;
+}
+
+.votersList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spS);
+  margin-top: var(--spS);
+}
+
+.voterOptionBtn {
+  display: flex;
+  align-items: center;
+  gap: var(--spS);
+  padding: 6px 12px;
+  background: linear-gradient(135deg, #d7fff014, #d7fff008);
+  border: 1px solid #d7fff030;
+  border-radius: var(--bRadius);
+  color: var(--cWhiteV1);
+  font-size: var(--sS);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.voterOptionBtn:hover {
+  background: linear-gradient(135deg, #d7fff028, #d7fff014);
+  border-color: var(--cPrimary);
+  color: var(--cWhite);
+  transform: translateY(-1px);
+}
+
+.voterOptionLabel {
+  font-weight: var(--bMedium);
+}
+
+.voterOptionCount {
+  color: var(--cPrimary);
+  font-weight: var(--bSemibold);
+}
+
 .textList {
   margin: 0;
   padding-left: 16px;

--- a/src/modulos/Surveys/components/RenderView/SurveyStatsView.tsx
+++ b/src/modulos/Surveys/components/RenderView/SurveyStatsView.tsx
@@ -1,8 +1,9 @@
 "use client";
-import React from "react";
+import React, { useState, useRef, useEffect } from "react";
 import dynamic from "next/dynamic";
 import styles from "./SurveyStatsView.module.css";
 import { formatNumber } from "@/mk/utils/numbers";
+import VotersListModal from "../VotersListModal/VotersListModal";
 
 const ReactApexChart = dynamic(() => import("react-apexcharts"), {
   ssr: false,
@@ -22,6 +23,7 @@ type SOption = {
   option_text?: string;
   text?: string;
   votes?: number;
+  answers_count?: number;
 };
 
 type SQuestion = {
@@ -37,6 +39,13 @@ type SQuestion = {
   text_responses_sample?: string[];
 };
 
+type VotersModalState = {
+  open: boolean;
+  soptionId: number | string;
+  soptionText: string;
+  totalVoters: number;
+} | null;
+
 function QuestionChart({
   question,
   index,
@@ -44,6 +53,8 @@ function QuestionChart({
   question: SQuestion;
   index: number;
 }) {
+  const chartRef = useRef<any>(null);
+  const [votersModal, setVotersModal] = useState<VotersModalState>(null);
   const isText = question.type === "T";
   const options = question.options || question.soptions || [];
   const userResponse = question.user_response;
@@ -106,16 +117,40 @@ function QuestionChart({
       toolbar: { show: false },
       background: "transparent",
       animations: { enabled: true, speed: 500 },
+      events: {
+        click: (_event: any, _chartContext: any, config: any) => {
+          // ApexCharts passes { dataPointIndex, seriesIndex } in config
+          if (config.dataPointIndex >= 0 && config.dataPointIndex < options.length) {
+            const selectedOption = options[config.dataPointIndex];
+            const votesCount = selectedOption.votes ?? selectedOption.answers_count ?? 0;
+            if (votesCount > 0) {
+              setVotersModal({
+                open: true,
+                soptionId: selectedOption.id,
+                soptionText: selectedOption.option_text || selectedOption.text || "",
+                totalVoters: votesCount,
+              });
+            }
+          }
+        },
+      },
     },
     plotOptions: {
       bar: {
         horizontal: true,
         borderRadius: 6,
-        distributed: true,
+        distributed: false, // Removed: was breaking dataPointSelection click events
         dataLabels: { position: "right" },
       },
     },
-    colors: colors,
+    // Colors per bar (index-based), applied via dataLabels.style when distributed: false
+    // Bar fill colors (array = one per bar when distributed: false)
+    fill: {
+      colors: options.map((o, i) => {
+        if (isMyResponse(o.id)) return "var(--cPrimary)";
+        return CHART_COLORS[i % CHART_COLORS.length].replace("0.9", "0.85)");
+      }),
+    },
     dataLabels: {
       enabled: true,
       formatter: (val: number) =>
@@ -123,7 +158,10 @@ function QuestionChart({
       style: {
         fontSize: "11px",
         fontWeight: "bold",
-        colors: ["var(--cBlack)"],
+        // Array of colors = one per bar (required when distributed: false)
+        colors: options.map((o, i) =>
+          isMyResponse(o.id) ? "var(--cWhite)" : "var(--cWhiteV1)"
+        ),
       },
       dropShadow: {
         enabled: true,
@@ -172,11 +210,54 @@ function QuestionChart({
       {total === 0 && !userResponse ? (
         <p className={styles.textHint}>Sin votos aún para esta pregunta.</p>
       ) : (
-        <ReactApexChart
-          options={chartOptions}
-          series={[{ name: "Votos", data }]}
-          type="bar"
-          height={Math.max(120, options.length * 48)}
+        <>
+          <div className={styles.chartWrapper}>
+            <ReactApexChart
+              options={chartOptions}
+              series={[{ name: "Votos", data }]}
+              type="bar"
+              height={Math.max(120, options.length * 48)}
+            />
+          </div>
+          {/* Lista clickeable de opciones para ver quién votó */}
+          <div className={styles.votersList}>
+            {options.map((o: any) => {
+              const votesCount = o.votes ?? o.answers_count ?? 0;
+              if (votesCount === 0) return null;
+              return (
+                <button
+                  key={o.id}
+                  className={styles.voterOptionBtn}
+                  onClick={() => {
+                    setVotersModal({
+                      open: true,
+                      soptionId: o.id,
+                      soptionText: o.option_text || o.text || "",
+                      totalVoters: votesCount,
+                    });
+                  }}
+                >
+                  <span className={styles.voterOptionLabel}>
+                    {o.option_text || o.text}
+                  </span>
+                  <span className={styles.voterOptionCount}>
+                    {votesCount} voto{votesCount !== 1 ? "s" : ""}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {/* Modal para mostrar lista de votantes */}
+      {votersModal && (
+        <VotersListModal
+          open={votersModal.open}
+          onClose={() => setVotersModal(null)}
+          soptionId={votersModal.soptionId}
+          soptionText={votersModal.soptionText}
+          totalVoters={votersModal.totalVoters}
         />
       )}
     </div>

--- a/src/modulos/Surveys/components/VotersListModal/VotersListModal.module.css
+++ b/src/modulos/Surveys/components/VotersListModal/VotersListModal.module.css
@@ -1,0 +1,100 @@
+.container {
+  padding: 0;
+}
+
+.header {
+  padding: 16px;
+  border-bottom: 1px solid var(--cWhiteV2, rgba(255, 255, 255, 0.1));
+}
+
+.optionBadge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.optionLabel {
+  font-size: 12px;
+  color: var(--cWhiteV2);
+}
+
+.optionText {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--cWhite);
+  background: var(--cPrimary);
+  padding: 4px 10px;
+  border-radius: 4px;
+}
+
+.totalCount {
+  font-size: 13px;
+  color: var(--cWhiteV1);
+  margin: 0;
+}
+
+.loading,
+.error,
+.empty {
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.loading p,
+.empty p {
+  color: var(--cWhiteV2);
+  font-size: 14px;
+}
+
+.error p {
+  color: var(--cError);
+  font-size: 14px;
+}
+
+.votersList {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.voterItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  transition: background-color 0.15s ease;
+}
+
+.voterItem:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.voterItem:last-child {
+  border-bottom: none;
+}
+
+.voterInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.voterName {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--cWhite);
+  margin: 0 0 4px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voterUnit {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--cWhiteV2);
+  margin: 0;
+}

--- a/src/modulos/Surveys/components/VotersListModal/VotersListModal.tsx
+++ b/src/modulos/Surveys/components/VotersListModal/VotersListModal.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import DataModal from "@/mk/components/ui/DataModal/DataModal";
+import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
+import { IconHousing } from "@/components/layout/icons/IconsBiblioteca";
+import useAxios from "@/mk/hooks/useAxios";
+import styles from "./VotersListModal.module.css";
+
+type Voter = {
+  respondent_id: string;
+  respondent_type: string;
+  dpto_nro: string;
+  owner_name: string;
+  owner_url_avatar?: string;
+};
+
+type VotersListModalProps = {
+  open: boolean;
+  onClose: () => void;
+  soptionId: number | string;
+  soptionText: string;
+  totalVoters: number;
+};
+
+const VotersListModal: React.FC<VotersListModalProps> = ({
+  open,
+  onClose,
+  soptionId,
+  soptionText,
+  totalVoters,
+}) => {
+  const [voters, setVoters] = useState<Voter[]>([]);
+  const { execute } = useAxios();
+  const fetchedRef = useRef<string | number | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data: response, loaded: loadedState } = await execute(
+        `/surveys/soptions/${soptionId}/voters`,
+        "GET",
+      );
+      setLoaded(loadedState);
+
+      if (response.success) {
+        // console.error("[VotersListModal] API error:", error);
+        console.log(response.data);
+        setVoters(response.data.voters || response.data?.data?.voters || []);
+      } else {
+        setVoters([]);
+      }
+    };
+
+    if (!open || !soptionId) {
+      setVoters([]);
+      fetchedRef.current = null;
+      return;
+    }
+    // Evitar llamada duplicada si ya sefetcheó este soptionId
+    if (fetchedRef.current === soptionId) {
+      return;
+    }
+    fetchedRef.current = soptionId;
+    fetchData();
+  }, [open, soptionId, execute]);
+
+  return (
+    <DataModal
+      open={open}
+      onClose={onClose}
+      title="Votantes"
+      buttonText=""
+      buttonCancel="Cerrar"
+      maxWidth={500}
+    >
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <div className={styles.optionBadge}>
+            <span className={styles.optionLabel}>Opción:</span>
+            <span className={styles.optionText}>{soptionText}</span>
+          </div>
+          <p className={styles.totalCount}>
+            {totalVoters} {totalVoters === 1 ? "votante" : "votantes"}
+          </p>
+        </div>
+
+        {loaded && (
+          <div className={styles.loading}>
+            <p>Cargando votantes...</p>
+          </div>
+        )}
+
+        {!loaded && voters.length === 0 && (
+          <div className={styles.empty}>
+            <p>No hay votantes para esta opción</p>
+          </div>
+        )}
+
+        {!loaded && voters.length > 0 && (
+          <div className={styles.votersList}>
+            {voters.map((voter, index) => (
+              <div key={index} className={styles.voterItem}>
+                <Avatar
+                  name={voter.owner_name || "?"}
+                  src={voter.owner_url_avatar}
+                  w={36}
+                  h={36}
+                />
+                <div className={styles.voterInfo}>
+                  <p className={styles.voterName}>{voter.owner_name}</p>
+                  <p className={styles.voterUnit}>
+                    <IconHousing size={14} />
+                    <span>Unidad {voter.dpto_nro || "N/A"}</span>
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </DataModal>
+  );
+};
+
+export default VotersListModal;

--- a/src/modulos/Surveys/components/VotersListModal/__tests__/VotersListModal.test.tsx
+++ b/src/modulos/Surveys/components/VotersListModal/__tests__/VotersListModal.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import VotersListModal from '../VotersListModal';
+
+// Mock DataModal
+vi.mock('@/mk/components/ui/DataModal/DataModal', () => ({
+  default: ({ children, open, title, onClose, buttonCancel }: any) => (
+    <div data-testid="data-modal" data-open={open}>
+      {open && (
+        <div>
+          <h2 data-testid="modal-title">{title}</h2>
+          {children}
+          {buttonCancel && (
+            <button onClick={onClose}>{buttonCancel}</button>
+          )}
+        </div>
+      )}
+    </div>
+  ),
+}));
+
+// Mock Avatar
+vi.mock('@/mk/components/ui/Avatar/Avatar', () => ({
+  Avatar: ({ name }: any) => (
+    <div data-testid="avatar" data-name={name}>
+      Avatar-{name}
+    </div>
+  ),
+}));
+
+// Mock IconHousing
+vi.mock('@/components/layout/icons/IconsBiblioteca', () => ({
+  IconHousing: () => <span data-testid="icon-housing">Housing</span>,
+}));
+
+// Mock useAxios
+const mockExecute = vi.fn();
+vi.mock('@/mk/hooks/useAxios', () => ({
+  default: () => ({
+    execute: mockExecute,
+    loaded: false,
+  }),
+}));
+
+describe('VotersListModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    soptionId: 123,
+    soptionText: 'Aprobar',
+    totalVoters: 3,
+  };
+
+  const mockVotersResponse = {
+    data: {
+      success: true,
+      data: {
+        soption_id: 123,
+        soption_text: 'Aprobar',
+        total_voters: 3,
+        voters: [
+          { respondent_id: '1', respondent_type: 'owner', dpto_nro: '101', owner_name: 'Juan Pérez' },
+          { respondent_id: '2', respondent_type: 'owner', dpto_nro: '102', owner_name: 'María García' },
+          { respondent_id: '3', respondent_type: 'owner', dpto_nro: '103', owner_name: 'Carlos López' },
+        ],
+      },
+    },
+    error: null,
+  };
+
+  it('renderiza correctamente cuando está abierto', async () => {
+    mockExecute.mockResolvedValueOnce(mockVotersResponse);
+
+    render(<VotersListModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-title')).toHaveTextContent('Votantes');
+    });
+    expect(screen.getByText('Aprobar')).toBeInTheDocument();
+    expect(screen.getByText('3 votantes')).toBeInTheDocument();
+  });
+
+  it('muestra mensaje de carga mientras espera respuesta', async () => {
+    // Simula un execute que tarda en responder
+    mockExecute.mockImplementation(() => {
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(mockVotersResponse), 100);
+      });
+    });
+
+    render(<VotersListModal {...defaultProps} />);
+
+    // Espera a que cargue
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra mensaje cuando no hay votantes', async () => {
+    mockExecute.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          soption_id: 123,
+          soption_text: 'Aprobar',
+          total_voters: 0,
+          voters: [],
+        },
+      },
+      error: null,
+    });
+
+    render(<VotersListModal {...defaultProps} totalVoters={0} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No hay votantes para esta opción')).toBeInTheDocument();
+    });
+  });
+
+  it('renderiza lista de votantes con datos correctos', async () => {
+    mockExecute.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          soption_id: 123,
+          soption_text: 'Aprobar',
+          total_voters: 2,
+          voters: [
+            { respondent_id: '1', respondent_type: 'owner', dpto_nro: '101', owner_name: 'Juan Pérez' },
+            { respondent_id: '2', respondent_type: 'owner', dpto_nro: '102', owner_name: 'María García' },
+          ],
+        },
+      },
+      error: null,
+    });
+
+    render(<VotersListModal {...defaultProps} totalVoters={2} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument();
+      expect(screen.getByText('María García')).toBeInTheDocument();
+      expect(screen.getByText('Unidad 101')).toBeInTheDocument();
+      expect(screen.getByText('Unidad 102')).toBeInTheDocument();
+    });
+  });
+
+  it('no hace llamada cuando no está abierto', () => {
+    render(<VotersListModal {...defaultProps} open={false} />);
+
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('llama a onClose cuando se presiona Cerrar', async () => {
+    mockExecute.mockResolvedValueOnce({
+      data: { success: true, data: { voters: [] } },
+      error: null,
+    });
+
+    render(<VotersListModal {...defaultProps} />);
+
+    await waitFor(() => {
+      const closeBtn = screen.getByRole('button', { name: /Cerrar/i });
+      if (closeBtn) fireEvent.click(closeBtn);
+    });
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Add a new VotersListModal component that displays the list of voters for a specific survey option. The modal is accessible from both the survey statistics view and assembly detail view via a "ver" button next to each option. The modal fetches voter data from the API and shows user names, avatars, and unit numbers.

- Create VotersListModal component with loading, error, and empty states
- Add clickable chart bars and option buttons in SurveyStatsView to open the modal
- Add "ver" button in AssemblyDetail for each voting option to show voters
- Include CSS styling for modal and interactive elements
- Add comprehensive unit tests for the new modal component