### PR TITLE
fix: increase file upload size limit to 30MB

### DIFF
--- a/src/modulos/Assemblies/RenderForm/RenderForm.tsx
+++ b/src/modulos/Assemblies/RenderForm/RenderForm.tsx
@@ -538,7 +538,7 @@ const RenderForm = ({ open, onClose, item, setItem, execute, reLoad }: any) => {
                 name="files"
                 mode="all"
                 error={errors}
-                maxMB={5}
+                maxMB={30}
               />
             )}
           </section>


### PR DESCRIPTION
The previous 5MB limit was insufficient for user needs, particularly when uploading larger assembly-related files. This change increases the maximum allowed file size to 30MB to accommodate typical user workflows.