### PR TITLE
[codex] Sync prod35 back into dev and refine assemblies detail theme

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,22 @@
 import type { NextConfig } from "next";
 
+const apiUrl = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+
 const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
+  },
+  async rewrites() {
+    if (!apiUrl || !/^https?:\/\//.test(apiUrl)) {
+      return [];
+    }
+
+    return [
+      {
+        source: "/api-proxy/:path*",
+        destination: `${apiUrl}/:path*`,
+      },
+    ];
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@dayflow/core": "^3.5.2",
+    "@dayflow/react": "^3.5.2",
     "@fingerprintjs/fingerprintjs": "^5.0.1",
     "@instantdb/admin": "^0.17.12",
     "@instantdb/react": "^0.21.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@dayflow/core':
+        specifier: ^3.5.2
+        version: 3.5.2
+      '@dayflow/react':
+        specifier: ^3.5.2
+        version: 3.5.2(@dayflow/core@3.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@fingerprintjs/fingerprintjs':
         specifier: ^5.0.1
         version: 5.2.0
@@ -281,6 +287,30 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dayflow/blossom-color-picker@2.2.0':
+    resolution: {integrity: sha512-FkH5Ho6nk91F29TKvYRO/h6DKQbW+DE+tMo+/QZ6n+U8JFNt1ozbbCAJ1Kwm4w2i4owQ0JKqq+aZHmknEJBa1w==}
+
+  '@dayflow/core@3.5.2':
+    resolution: {integrity: sha512-jN4rY7qb1C7xwq1yS2jszgM3FwTpJGfzZN+V5eW/4npE3udBXKBYASQFkc2khV8cwcKXhZwnPnR3/6xDQV+iyA==}
+
+  '@dayflow/react@3.5.2':
+    resolution: {integrity: sha512-8+JA/yG4hwgeSfxWMSDEZcK2Pug6PZoMEbNHUf3vFizAVNfDOwfB8F9jiemO3MmE9tUgbt+cMXOiXKP3DdJdQw==}
+    peerDependencies:
+      '@dayflow/core': 3.5.2
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@dayflow/ui-context-menu@1.0.2':
+    resolution: {integrity: sha512-N6u0C69Ol+aUOJAQzFl0RUzkiJHJVkUD1ZBu/8otG4p/6BHdq3CTsfTFdLJIzIKaTEWepHM2Tif7MAGrrnyqpw==}
+    peerDependencies:
+      preact: '>=10'
+
+  '@dayflow/ui-range-picker@1.0.2':
+    resolution: {integrity: sha512-CjoZeXpH8NwGccaklu2WqyPtZYlBdTOaqV3m8ZeE+aNrxhCfLYvjXX6kTQKR5u7vggo7RhkFKMXqfwwALoxAPQ==}
+    peerDependencies:
+      preact: '>=10'
+      temporal-polyfill: '>=0.2'
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -705,105 +735,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -935,28 +949,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.15':
     resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.15':
     resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.15':
     resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.15':
     resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
@@ -1040,49 +1050,41 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -1166,42 +1168,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -1424,49 +1420,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2536,28 +2524,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3181,6 +3165,12 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  temporal-polyfill@0.3.2:
+    resolution: {integrity: sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==}
+
+  temporal-spec@0.3.1:
+    resolution: {integrity: sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==}
+
   text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
@@ -3667,6 +3657,32 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dayflow/blossom-color-picker@2.2.0': {}
+
+  '@dayflow/core@3.5.2':
+    dependencies:
+      '@dayflow/blossom-color-picker': 2.2.0
+      '@dayflow/ui-context-menu': 1.0.2(preact@10.29.1)
+      '@dayflow/ui-range-picker': 1.0.2(preact@10.29.1)(temporal-polyfill@0.3.2)
+      preact: 10.29.1
+      temporal-polyfill: 0.3.2
+      tslib: 2.8.1
+
+  '@dayflow/react@3.5.2(@dayflow/core@3.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dayflow/core': 3.5.2
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@dayflow/ui-context-menu@1.0.2(preact@10.29.1)':
+    dependencies:
+      preact: 10.29.1
+
+  '@dayflow/ui-range-picker@1.0.2(preact@10.29.1)(temporal-polyfill@0.3.2)':
+    dependencies:
+      preact: 10.29.1
+      temporal-polyfill: 0.3.2
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -6520,6 +6536,12 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
+
+  temporal-polyfill@0.3.2:
+    dependencies:
+      temporal-spec: 0.3.1
+
+  temporal-spec@0.3.1: {}
 
   text-segmentation@1.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+onlyBuiltDependencies:
+  - esbuild
+  - msw
+  - sharp
+  - unrs-resolver

--- a/src/app/create-reservas/page.tsx
+++ b/src/app/create-reservas/page.tsx
@@ -1,10 +1,67 @@
+"use client";
 
+import { useCallback, useContext, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import CreateReserva from "@/modulos/CreateReserva/CreateReserva";
+import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
+import { useAuth } from "@/mk/contexts/AuthProvider";
+import type { NewReservaExtraData } from "@/modulos/NewReserva/types";
 
-import CreateReserva from '@/modulos/CreateReserva/CreateReserva';
-import React from 'react'
+const CreateReservaPage = () => {
+  const router = useRouter();
+  const { contextInstance } = useContext(AxiosContext);
+  const { showToast } = useAuth();
+  const [extraData, setExtraData] = useState<NewReservaExtraData | null>(null);
+  const [loading, setLoading] = useState(true);
 
-const createReserva = () => {
-  return <CreateReserva />
-}
+  const loadExtraData = useCallback(async () => {
+    if (!contextInstance) return;
 
-export default createReserva;
+    setLoading(true);
+    try {
+      const response = await contextInstance.request({
+        method: "GET",
+        url: "/reservations",
+        params: {
+          perPage: -1,
+          page: 1,
+          fullType: "EXTRA",
+        },
+      });
+
+      setExtraData((response?.data?.data || {}) as NewReservaExtraData);
+    } catch (_error) {
+      setExtraData(null);
+      showToast("No pudimos cargar los datos para crear la reserva", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [contextInstance, showToast]);
+
+  useEffect(() => {
+    void loadExtraData();
+  }, [loadExtraData]);
+
+  if (loading) {
+    return <div style={{ color: "var(--cWhiteV1)" }}>Cargando flujo de reserva...</div>;
+  }
+
+  if (!extraData) {
+    return (
+      <div style={{ color: "var(--cWhiteV1)" }}>
+        No pudimos abrir el flujo de reserva en este momento.
+      </div>
+    );
+  }
+
+  return (
+    <CreateReserva
+      extraData={extraData}
+      setOpenList={() => {}}
+      onClose={() => router.push("/new-reserva")}
+      reLoad={() => {}}
+    />
+  );
+};
+
+export default CreateReservaPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // import { Geist, Geist_Mono } from "next/font/google";
 import "../styles/theme.css";
 import "../styles/utils.css";
+import "@dayflow/core/dist/styles.css";
 import AxiosInstanceProvider from "@/mk/contexts/AxiosInstanceProvider";
 import axiosInterceptors from "@/mk/interceptors/axiosInterceptors";
 import AuthProvider from "@/mk/contexts/AuthProvider";

--- a/src/app/new-reserva/page.tsx
+++ b/src/app/new-reserva/page.tsx
@@ -1,0 +1,7 @@
+import NewReserva from "@/modulos/NewReserva/NewReserva";
+
+const NewReservaPage = () => {
+  return <NewReserva />;
+};
+
+export default NewReservaPage;

--- a/src/components/CommentsModal/CommentsModal.module.css
+++ b/src/components/CommentsModal/CommentsModal.module.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: var(--cHoverModal);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13,14 +13,14 @@
 }
 
 .commentModalContent {
-  background-color: var(--cBlack);
+  background-color: var(--cBackground);
   border-radius: 12px;
   width: 100%;
   max-width: 500px;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--cWhiteV2);
+  border: 1px solid var(--cBorder);
 }
 
 .commentModalHeader {
@@ -28,7 +28,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--cWhiteV2);
+  border-bottom: 1px solid var(--cBorder);
 }
 
 .commentModalTitle {
@@ -52,7 +52,7 @@
 }
 
 .commentModalCloseButton:hover {
-  background-color: var(--cWhiteV2);
+  background-color: var(--cBackground-foreground);
 }
 
 .commentModalBody {
@@ -134,7 +134,7 @@
 
 .commentModalFooter {
   padding: 16px 20px;
-  border-top: 1px solid var(--cWhiteV2);
+  border-top: 1px solid var(--cBorder);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -142,8 +142,8 @@
 
 .commentInput {
   width: 100%;
-  background-color: var(--cWhiteV2);
-  border: 1px solid var(--cWhiteV1);
+  background-color: var(--cBackground-foreground);
+  border: 1px solid var(--cBorder);
   border-radius: 8px;
   padding: 12px;
   color: var(--cWhite);
@@ -170,7 +170,7 @@
 .commentPostButton {
   align-self: flex-end;
   background-color: var(--cAccent);
-  color: var(--cWhite);
+  color: var(--cBlack);
   border: none;
   border-radius: 6px;
   padding: 8px 16px;
@@ -181,11 +181,11 @@
 }
 
 .commentPostButton:hover:not(:disabled) {
-  background-color: var(--cAccentHover);
+  background-color: var(--accentv1);
 }
 
 .commentPostButton:disabled {
-  background-color: var(--cWhiteV2);
+  background-color: var(--cBackground-foreground);
   color: var(--cWhiteV1);
   cursor: not-allowed;
 }

--- a/src/components/Header/header.module.css
+++ b/src/components/Header/header.module.css
@@ -85,12 +85,12 @@
 .iconOuterContainer {
   width: 40px;
   height: 40px;
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   border-radius: 999px;
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cBorder);
   overflow: hidden;
   flex-shrink: 0;
 }
@@ -100,9 +100,9 @@
   cursor: pointer;
   width: 40px;
   height: 40px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cBorder);
   border-radius: 100%;
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -115,7 +115,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  color: #fafafa;
+  color: var(--cWhite);
   cursor: pointer;
   line-height: 0;
 }
@@ -220,6 +220,6 @@
 
 .mobileGreetingSub {
   font-size: 11px;
-  color: #a6a6a6;
+  color: var(--cWhiteV1);
   margin: 0;
 }

--- a/src/components/ImageModal/imageModal.module.css
+++ b/src/components/ImageModal/imageModal.module.css
@@ -5,7 +5,7 @@
   right: 0;
   bottom: 0;
   background-color: var(--cHoverModal);
-  backdrop-filter: blur(5px);
+  background-color: var(--cHoverModal);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -16,7 +16,10 @@
   position: relative;
   max-width: 90vw;
   max-height: 90vh;
-  background: transparent;
+  background: var(--cBackground);
+  border: 1px solid var(--cBorder);
+  border-radius: 20px;
+  padding: 12px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -33,13 +36,19 @@
 
 .closeButton {
   position: absolute !important;
-  top: 0 !important;
-  right: -52px !important;
+  top: -10px !important;
+  right: -10px !important;
   color: var(--cWhite) !important;
   cursor: pointer;
   transition: opacity 0.2s;
-  border: solid;
-  border-radius: 5px;
+  background-color: var(--cBackground-foreground);
+  border: 1px solid var(--cBorder);
+  border-radius: 999px;
+  width: 40px;
+  height: 40px;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
 }
 
 .closeButton:hover {

--- a/src/components/Index/index.module.css
+++ b/src/components/Index/index.module.css
@@ -50,8 +50,8 @@
 }
 
 .summaryWidgetEqualHeight {
-  background-color: #d7fff005 !important;
-  border: 1px solid #d7fff014 !important;
+  background-color: var(--cBackground) !important;
+  border: 1px solid var(--cBorder) !important;
   border-radius: 12px !important;
 }
 
@@ -106,7 +106,7 @@
 }
 
 .widgetBase {
-  background-color: var(--cBlackV2) !important;
+  background-color: var(--cBackground) !important;
 }
 
 .widgetsResumeContainer {
@@ -145,10 +145,10 @@
 }
 
 .widgetAlerts {
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   padding: var(--spL, 1rem);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cBorder);
   display: flex;
   flex-direction: column;
   gap: var(--spM, 1rem);
@@ -192,38 +192,21 @@
 }
 
 .levelLow {
-  /* Usamos el color base #00af90 -> rgb(0, 175, 144) con transparencia */
-  background-color: rgba(
-    0,
-    175,
-    144,
-    0.2
-  ); /* Ajusta el 0.2 (alfa) si quieres más o menos transparencia */
-  color: var(--cLowAlertText, #34a853);
-  /* Opcional: para un efecto neón más pronunciado en el texto y un pequeño resplandor */
-  /* text-shadow: 0 0 2px var(--cLowAlertText, #34a853); */
-  /* box-shadow: 0 0 8px rgba(0, 175, 144, 0.3); */
+  background-color: var(--cBackground-foreground);
+  border: 1px solid var(--cBorder);
+  color: var(--cSuccess);
 }
 
 .levelMedium {
-  /* Usamos el color base #e1c151 -> rgb(225, 193, 81) con transparencia */
-  background-color: rgba(225, 193, 81, 0.2); /* Ajusta el 0.2 (alfa) */
-  color: var(--cMediumAlertText, #e9b01e);
-  /* Opcional: para un efecto neón más pronunciado */
-  /* text-shadow: 0 0 2px var(--cMediumAlertText, #e9b01e); */
-  /* box-shadow: 0 0 8px rgba(225, 193, 81, 0.3); */
+  background-color: var(--cBackground-foreground);
+  border: 1px solid var(--cBorder);
+  color: var(--cWarning);
 }
 
 .levelHigh {
-  /* Usamos el color base #da5d5d -> rgb(218, 93, 93) con transparencia */
-  background-color: rgba(218, 93, 93, 0.2); /* Ajusta el 0.2 (alfa) */
-  color: var(
-    --cHightAlertText,
-    #e46055
-  ); /* Nota: el nombre original era --cHightAlertBg, asumo que querías --cHightAlertText o un color de texto similar */
-  /* Opcional: para un efecto neón más pronunciado */
-  /* text-shadow: 0 0 2px var(--cHightAlertText, #e46055); */
-  /* box-shadow: 0 0 8px rgba(218, 93, 93, 0.3); */
+  background-color: var(--cBackground-foreground);
+  border: 1px solid var(--cBorder);
+  color: var(--cError);
 }
 
 .itemRow {
@@ -240,7 +223,7 @@
   flex-shrink: 0;
   border-radius: 50%;
   overflow: hidden;
-  background-color: #555;
+  background-color: var(--cBackground-foreground);
 }
 
 .itemImage {
@@ -258,7 +241,7 @@
   font-size: 16px;
   font-weight: 500;
   color: #fff;
-  background-color: #777;
+  background-color: var(--cBackground-foreground);
 }
 
 .itemTextInfo {
@@ -292,7 +275,7 @@
 .itemDateText {
   font-weight: 400;
   font-size: 10px;
-  color: #888;
+  color: var(--cWhiteV3);
 }
 
 .itemActionContainer {
@@ -345,9 +328,9 @@
 .preRegistroItem {
   margin-bottom: 1rem;
   padding: 1rem;
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   border-radius: 0.5rem;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cBorder);
 }
 
 .preRegistroItem:last-child {

--- a/src/components/MainMenu/mainmenu.module.css
+++ b/src/components/MainMenu/mainmenu.module.css
@@ -2,10 +2,10 @@
   flex-direction: column;
   display: flex;
   height: 100vh;
-  border-right: 0.3px solid rgba(215, 255, 240, 0.22);
+  border-right: 1px solid var(--cBorder);
   padding: var(--spXl) var(--spL) 0;
   overflow: auto;
-  background-color: transparent;
+  background-color: var(--cBackground-muted);
 
   & > div:nth-child(2) {
     display: flex;
@@ -27,8 +27,8 @@
   flex-direction: column;
   align-items: flex-start;
   height: 198px;
-  background-color: rgba(215, 255, 240, 0.04);
-  border: 1px solid rgba(215, 255, 240, 0.08);
+  background-color: var(--cBackground);
+  border: 1px solid var(--cBorder);
   border-radius: 16px;
   padding: 8px;
   gap: 8px;
@@ -40,7 +40,7 @@
   border-radius: 12px;
   background-size: cover;
   background-position: 50% 50%;
-  background-color: rgba(18, 21, 25, 0.6);
+  background-color: var(--cBackground-foreground);
 }
 
 .titleContainer {
@@ -54,7 +54,7 @@
 }
 
 .headerTitle {
-  color: rgba(215, 255, 240, 0.6);
+  color: var(--cWhiteV1);
   font-size: 12px;
   font-family: "Roboto-Regular", Helvetica, sans-serif;
   font-weight: 400;
@@ -70,7 +70,7 @@
 .menuItem {
   & > a {
     text-decoration: none;
-    color: rgba(215, 255, 240, 0.6);
+    color: var(--cWhiteV1);
     font-weight: var(--bMedium);
     font-size: var(--sM);
     display: flex;
@@ -83,14 +83,14 @@
   }
 
   & > a:hover {
-    background-color: rgba(215, 255, 240, 0.08);
-    border: 1px solid transparent;
+    background-color: var(--cBackground);
+    border: 1px solid var(--cBorder);
     color: var(--cWhite);
   }
 
   & > a.active {
-    background-color: rgba(0, 227, 140, 0.2);
-    border: 1px solid transparent;
+    background-color: var(--cBackground-foreground);
+    border: 1px solid var(--cBorder);
     color: var(--cWhite);
   }
 
@@ -101,7 +101,7 @@
 
 .menuDropdown {
   position: relative;
-  color: rgba(215, 255, 240, 0.6);
+  color: var(--cWhiteV1);
   font-weight: var(--bMedium);
   font-size: var(--sM);
   cursor: pointer;
@@ -117,9 +117,9 @@
   border: 1px solid transparent;
 
   &:hover {
-    background-color: rgba(215, 255, 240, 0.08);
-    color: white;
-    border: 1px solid transparent;
+    background-color: var(--cBackground);
+    color: var(--cWhite);
+    border: 1px solid var(--cBorder);
   }
 
   /* &:hover::before,
@@ -143,11 +143,11 @@
   }
 
   &.isOpen {
-    background-color: rgba(11, 26, 23, 0.46);
+    background-color: var(--cBackground);
     color: var(--cWhite);
     padding-bottom: var(--spL);
-    border: 0.3px solid transparent;
-    box-shadow: inset 0 0 0 0.3px #00E38B, 0 0 0 0.3px #007B4C;
+    border: 1px solid var(--cBorder);
+    box-shadow: none;
     border-radius: var(--bRadius);
 
     &.collapsed {
@@ -156,14 +156,14 @@
   }
 
   &.isRouteActive {
-    background-color: rgba(0, 227, 140, 0.22);
-    color: white;
-    border: 0.3px solid transparent;
-    box-shadow: inset 0 0 0 0.3px #00E38B, 0 0 0 0.3px #007B4C;
+    background-color: var(--cBackground-foreground);
+    color: var(--cWhite);
+    border: 1px solid var(--cBorder);
+    box-shadow: none;
     border-radius: var(--bRadius);
 
     &.isOpen {
-      background-color: rgba(11, 26, 23, 0.46);
+      background-color: var(--cBackground);
     }
   }
 
@@ -176,12 +176,12 @@
   &.collapsed > div:nth-child(2) {
     position: fixed;
     left: 92px;
-    background-color: rgba(18, 21, 25, 0.96);
+    background-color: var(--cBackground);
     width: 200px;
     /* border-radius: var(--bRadiusS); */
     padding: var(--spS);
     margin-top: 0;
-    border: 0.3px solid rgba(215, 255, 240, 0.42);
+    border: 1px solid var(--cBorder);
   }
 
   & > div:nth-child(1) {
@@ -210,7 +210,7 @@
 
     & > a {
       text-decoration: none;
-      color: rgba(215, 255, 240, 0.6);
+      color: var(--cWhiteV1);
       padding: var(--spS) var(--spM);
       font-weight: var(--bRegular);
       font-size: var(--sM);
@@ -218,18 +218,18 @@
     }
 
     & > a.active {
-      background-color: rgba(0, 227, 140, 0.22);
+      background-color: var(--cBackground-foreground);
       color: var(--cWhite);
     }
 
     & > a:hover {
-      background-color: rgba(0, 227, 140, 0.16);
+      background-color: var(--cBackground);
       color: var(--cWhite);
     }
 
     & > a.active,
     & > a.active:hover {
-      background-color: rgba(0, 227, 140, 0.22);
+      background-color: var(--cBackground-foreground);
     }
   }
 }

--- a/src/components/NoData/EmptyData.module.css
+++ b/src/components/NoData/EmptyData.module.css
@@ -4,15 +4,22 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-width: 100%;
+  gap: 4px;
 }
 
 .centered {
   justify-content: center;
   align-items: center;
+  text-align: center;
 }
 
 .icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: var(--sXxl);
+  color: var(--cWhiteV3);
 }
 
 .message {
@@ -21,15 +28,20 @@
   margin-top: 12px;
   font-size: var(--sL);
   color: var(--cWhiteV1);
-
+  line-height: 1.35;
+  font-weight: var(--bMedium);
 }
+
 .line2 {
   margin: 0;
   padding: 0;
-  font-size: var(--sL);
-  color: var(--cWhiteV1);
+  font-size: var(--sM);
+  line-height: 1.35;
+  color: var(--cWhiteV3);
 }
+
 .singleLine {
-  /* white-space: nowrap; */
+  width: 100%;
   overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/components/NoData/EmptyData.tsx
+++ b/src/components/NoData/EmptyData.tsx
@@ -2,7 +2,6 @@
 import styles from "./EmptyData.module.css";
 import { IconTableEmpty } from "../layout/icons/IconsBiblioteca";
 import { FC, ReactNode, useEffect, useRef } from "react";
-import { wrap } from "module";
 
 interface EmptyDataProps {
   icon?: ReactNode;
@@ -30,7 +29,7 @@ const EmptyData: FC<EmptyDataProps> = ({
   fontSize,
   singleLine = false,
   minFontSize = 12,
-  textWrap
+  textWrap,
 }) => {
   const containerStyle = {
     height: h,
@@ -46,7 +45,6 @@ const EmptyData: FC<EmptyDataProps> = ({
     if (!singleLine) return;
 
     const fitElement = (el: HTMLElement | null, wrap = false) => {
-      
       if (!el) return;
       // Asegurar no wrap y ocultar overflow
       if (!wrap) {
@@ -64,7 +62,11 @@ const EmptyData: FC<EmptyDataProps> = ({
       let i = 0;
       // Reset font-size para recalcular correctamente en cada corrida
       el.style.fontSize = `${current}px`;
-      while (el.scrollWidth > el.clientWidth && current > minFontSize && i < safety) {
+      while (
+        el.scrollWidth > el.clientWidth &&
+        current > minFontSize &&
+        i < safety
+      ) {
         current -= 0.5;
         el.style.fontSize = `${current}px`;
         i++;
@@ -98,13 +100,15 @@ const EmptyData: FC<EmptyDataProps> = ({
       >
         {message ?? "No Hay elementos"}
       </div>
-      <div
-        ref={line2Ref}
-        className={`${styles.line2} ${singleLine ? styles.singleLine : ""}`}
-        style={!singleLine && fontSize ? { fontSize } : undefined}
-      >
-        {line2 ?? null}
-      </div>
+      {line2 ? (
+        <div
+          ref={line2Ref}
+          className={`${styles.line2} ${singleLine ? styles.singleLine : ""}`}
+          style={!singleLine && fontSize ? { fontSize } : undefined}
+        >
+          {line2}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/components/ProfileModal/ProfileModal.module.css
+++ b/src/components/ProfileModal/ProfileModal.module.css
@@ -20,9 +20,9 @@
   }
 
   & > section:nth-child(2) {
-    background-color: #d7fff005;
+    background-color: var(--cModalSection);
     border-radius: 12px;
-    border: 1px solid #d7fff014;
+    border: 1px solid var(--cModalBorder);
 
     & > div:nth-child(2) {
       display: flex;
@@ -103,7 +103,7 @@
   }
 
   .headerSubtitle {
-    color: #878f9a;
+    color: var(--cWhiteV1);
     font-size: 16px;
     font-style: normal;
     font-weight: 400;
@@ -133,7 +133,7 @@
 }
 
 .infoCard {
-  background-color: #d7fff005;
+  background-color: var(--cModalSection);
   border-radius: 16px;
   padding: 16px;
   display: flex;
@@ -143,7 +143,7 @@
   gap: 16px;
   align-self: stretch;
   height: 100%;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
 }
 
 .fieldGroup {
@@ -154,7 +154,7 @@
   /* Removed border-bottom as it's not in the Figma spec provided, but kept spacing logic if needed.
      If borders are needed between items, we can add them back, but based on the image,
      the gap seems to be the main separator. */
-  border-bottom: 0.3px solid rgba(215, 255, 240, 0.12);
+  border-bottom: 1px solid var(--cBorder);
   padding-bottom: 12px;
 
   &:last-child {
@@ -165,7 +165,7 @@
 
 .fieldLabel {
   font-size: 12px;
-  color: #878f9a;
+  color: var(--cWhiteV1);
   font-weight: 450;
 }
 
@@ -180,7 +180,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  border-bottom: 0.3px solid rgba(215, 255, 240, 0.12);
+  border-bottom: 1px solid var(--cBorder);
   padding-bottom: 16px;
 
   &:last-child {
@@ -197,9 +197,9 @@
 }
 
 .securityButton {
-  background-color: #d7fff005;
-  color: #878f9a;
-  border: 1px solid #d7fff014;
+  background-color: var(--cModalSurfaceRaised);
+  color: var(--cWhiteV1);
+  border: 1px solid var(--cModalBorder);
   padding: 6px 12px;
   border-radius: 16px;
   font-size: 10px;
@@ -208,9 +208,97 @@
   transition: background-color 0.2s;
 
   &:hover {
-    background-color: rgba(0, 227, 140, 0.14);
+    background-color: var(--cModalSection);
     color: var(--cWhite);
   }
+}
+
+.headerActions {
+  display: flex;
+  gap: var(--spS);
+}
+
+.iconActionButton {
+  background-color: var(--cModalSurfaceRaised);
+  padding: 8px;
+  border-radius: 12px;
+  cursor: pointer;
+  border: 1px solid var(--cModalBorder);
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.iconActionButton:hover {
+  background-color: var(--cModalSection);
+  border-color: var(--cDivider);
+}
+
+.coverImage {
+  width: 100%;
+  height: 300px;
+  border-top-left-radius: var(--bRadiusS);
+  border-top-right-radius: var(--bRadiusS);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: 1px solid var(--cModalDivider);
+  object-fit: cover;
+  background: var(--cModalSurfaceRaised);
+}
+
+.unitOwnership {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.contactAccent {
+  color: var(--cPrimary);
+}
+
+.unitLink {
+  cursor: pointer;
+  text-decoration: underline;
+  margin-right: 4px;
+}
+
+.securityValueGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.passwordValue {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.logoutRow {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.logoutButton {
+  background-color: transparent;
+  color: var(--cError);
+  border: none;
+  padding: 0;
+  width: auto;
+  min-width: auto;
+  text-decoration-line: underline;
+  cursor: pointer;
+  font: inherit;
+}
+
+.logoutButton:hover {
+  color: #f07b71;
 }
 
 .buttonChange {

--- a/src/components/ProfileModal/ProfileModal.tsx
+++ b/src/components/ProfileModal/ProfileModal.tsx
@@ -19,7 +19,6 @@ import Authentication from "@/modulos/Profile/Authentication";
 import useAxios from "@/mk/hooks/useAxios";
 import EditProfile from "./EditProfile/EditProfile";
 import GuardEditForm from "./GuardEditForm/GuardEditForm";
-import Button from "@/mk/components/forms/Button/Button";
 import Image from "next/image";
 import { generateWhatsAppLink } from "@/mk/utils/phone";
 import RenderForm from "@/modulos/Guards/RenderForm/RenderForm";
@@ -274,7 +273,6 @@ const ProfileModal = ({
         buttonText=""
         buttonCancel=""
         zIndex={zIndex}
-        style={{ backgroundColor: "#121519" }}
       >
         <div className={styles.ProfileModal}>
           <section>
@@ -284,22 +282,12 @@ const ProfileModal = ({
                 Gestiona tu información personal, rol y seguridad
               </span>
             </div>
-            <div>
+            <div className={styles.headerActions}>
               {edit && canEditThisProfile() && (
                 <button
                   type="button"
                   onClick={() => setOpenEdit(true)}
-                  style={{
-                    backgroundColor: "#d7fff005",
-                    padding: 8,
-                    borderRadius: "12px",
-                    cursor: "pointer",
-                    border: "1px solid #d7fff014",
-                    color: "inherit",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
+                  className={styles.iconActionButton}
                 >
                   <IconEdit className="" size={24} color={"var(--cWhite)"} />
                 </button>
@@ -307,17 +295,7 @@ const ProfileModal = ({
               {del && canDeleteThisProfile() && type === "guard" && (
                 <button
                   type="button"
-                  style={{
-                    backgroundColor: "#d7fff005",
-                    padding: 8,
-                    borderRadius: "12px",
-                    cursor: "pointer",
-                    border: "1px solid #d7fff014",
-                    color: "inherit",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
+                  className={styles.iconActionButton}
                   onClick={() => setOpenDel(true)}
                 >
                   <IconTrash size={24} color={"var(--cWhite)"} />
@@ -333,17 +311,7 @@ const ProfileModal = ({
               width={800}
               height={300}
               onError={() => setPortadaError(true)}
-              style={{
-                width: "100%",
-                height: 300,
-                borderTopLeftRadius: "var(--bRadiusS)",
-                borderTopRightRadius: "var(--bRadiusS)",
-                borderBottomLeftRadius: 0,
-                borderBottomRightRadius: 0,
-                borderBottom: "1px solid #d7fff014",
-                objectFit: "cover",
-                background: "#d7fff005",
-              }}
+              className={styles.coverImage}
               unoptimized
             />
             <div>
@@ -374,29 +342,16 @@ const ProfileModal = ({
                 )}
 
                 {data?.data[0]?.dptos && data?.data[0]?.dptos?.length > 0 && (
-                  <div
-                    style={{
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "8px",
-                    }}
-                  >
+                  <div className={styles.unitOwnership}>
                     {IconType}
-                    <div style={{ color: "var(--cPrimary)" }}>
+                    <div className={styles.contactAccent}>
                       <strong>Propietario de : </strong>
                       {data?.data[0]?.dptos
                         ?.map((dpto: any) => (
                           <span
                             key={dpto.id}
                             onClick={() => navigateToUnitDetail(dpto.id)}
-                            style={{
-                              cursor: "pointer",
-                              textDecoration: "underline",
-                              marginRight: "4px",
-                            }}
+                            className={styles.unitLink}
                           >
                             {`${dpto?.type?.name || "Unidad"} ${dpto?.nro}`}
                           </span>
@@ -526,7 +481,7 @@ const ProfileModal = ({
                 <div className={styles.infoCard}>
                   <div className={styles.securityItem}>
                     <div className={styles.securityHeader}>
-                      <div style={{ display: "flex", flexDirection: "column" }}>
+                      <div className={styles.securityValueGroup}>
                         <span className={styles.fieldLabel}>Email</span>
                         <span className={styles.fieldValue}>
                           {data?.data[0]?.email || "-"}
@@ -543,15 +498,9 @@ const ProfileModal = ({
                   </div>
                   <div className={styles.securityItem}>
                     <div className={styles.securityHeader}>
-                      <div style={{ display: "flex", flexDirection: "column" }}>
+                      <div className={styles.securityValueGroup}>
                         <span className={styles.fieldLabel}>Contraseña</span>
-                        <div
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 8,
-                          }}
-                        >
+                        <div className={styles.passwordValue}>
                           <span className={styles.fieldValue}>*********</span>
                           <IconLook size={16} color="var(--cWhiteV1)" />
                         </div>
@@ -570,24 +519,17 @@ const ProfileModal = ({
             )}
           </section>
           {user?.id === data?.data[0]?.id && setOnLogout && (
-            <div style={{ display: "flex", justifyContent: "flex-start" }}>
-              <Button
+            <div className={styles.logoutRow}>
+              <button
+                type="button"
                 onClick={() => {
                   onClose();
                   setOnLogout(true);
                 }}
-                style={{
-                  backgroundColor: "transparent",
-                  color: "var(--cError)",
-                  border: "none",
-                  padding: "0px 0px",
-                  width: "auto",
-                  minWidth: "auto",
-                  textDecorationLine: "underline",
-                }}
+                className={styles.logoutButton}
               >
                 Cerrar Sesión
-              </Button>
+              </button>
             </div>
           )}
         </div>

--- a/src/components/Widgets/WidgetBase/WidgetBase.module.css
+++ b/src/components/Widgets/WidgetBase/WidgetBase.module.css
@@ -1,7 +1,7 @@
 .widgetBase {
-  background-color: #212529;
+  background-color: var(--cBackground);
   border-radius: 16px;
-  border: 0.5px solid #393c3f;
+  border: 1px solid var(--cBorder);
   padding: var(--spL);
 }
 

--- a/src/components/Widgets/WidgetTableAffProv/WidgetTableAffProv.tsx
+++ b/src/components/Widgets/WidgetTableAffProv/WidgetTableAffProv.tsx
@@ -102,6 +102,7 @@ const WidgetTableAffProv = ({ widget, data, type, filters }: any) => {
     {
       key: "name",
       label: type == "dpto" ? "Departamento" : "Municipio",
+      width: "220px",
     },
     {
       key: "afiliados",
@@ -124,7 +125,7 @@ const WidgetTableAffProv = ({ widget, data, type, filters }: any) => {
     {
       key: "distribucion",
       label: "Distribución en %",
-      width: "100px",
+      width: "140px",
       style: {
         textAlign: "center",
         padding: 0,

--- a/src/components/Widgets/WidgetsDashboard/WidgetDashCard/WidgetDashCard.module.css
+++ b/src/components/Widgets/WidgetsDashboard/WidgetDashCard/WidgetDashCard.module.css
@@ -1,10 +1,10 @@
 .container {
   min-width: 200px;
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   padding: 12px;
   border-radius: 12px;
   position: relative;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cBorder);
   gap: 16px;
   display: flex;
   align-items: center;
@@ -88,7 +88,7 @@
   align-items: center;
   font-size: 12px;
   font-weight: 400;
-  color: #878f9a;
+  color: var(--cWhiteV1);
   gap: 6px;
   min-width: 0;
 }
@@ -104,13 +104,13 @@
   flex: 0 0 auto;
   display: flex;
   justify-content: center;
-  color: #878f9a;
+  color: var(--cWhiteV1);
 }
 
 .iconWrap :global(svg) {
-  color: #878f9a;
+  color: var(--cWhiteV1);
 }
 
 .iconWrap :global(svg path) {
-  fill: #878f9a;
+  fill: var(--cWhiteV1);
 }

--- a/src/components/Widgets/WidgetsDashboard/WidgetList/WidgetList.module.css
+++ b/src/components/Widgets/WidgetsDashboard/WidgetList/WidgetList.module.css
@@ -6,11 +6,11 @@
   gap: 1rem; /* Equivalente a gap-4 (16px) */
 
   min-height: 177px;
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   padding: 16px; /* Equivalente a p-4 (16px) */
   border-radius: 1rem; /* Equivalente a rounded-2xl (16px) */
-  border: 1px solid #d7fff014;
-  color: #fafafa; /* Color de texto por defecto, similar a text-neutral-50 */
+  border: 1px solid var(--cBorder);
+  color: var(--cWhite);
   box-sizing: border-box; /* Para que padding y border no incrementen el tamaño total si se usa width/height fijo */
 }
 
@@ -27,7 +27,7 @@
 .widgetListTitle {
   font-weight: 600; /* font-semibold */
   font-size: 20px; /* text-[20px] */
-  color: #fafafa; /* text-neutral-50. Tu CSS original usaba var(--cWhite) */
+  color: var(--cWhite);
 }
 
 .widgetListViewAll {
@@ -53,7 +53,7 @@
 }
 
 .widgetListEmptyMessage {
-  color: #a7a7a7; /* Un color más sutil que el 'red' original */
+  color: var(--cWhiteV1);
   font-size: 14px;
   text-align: center;
   padding: 1rem 0; /* Espaciado para el mensaje */

--- a/src/components/layout/layout.module.css
+++ b/src/components/layout/layout.module.css
@@ -8,12 +8,7 @@
   grid-template-rows: auto 1fr;
   height: 100vh;
   width: 100vw;
-  background: linear-gradient(
-      148deg,
-      rgba(0, 227, 140, 0.08) 0%,
-      rgba(0, 227, 140, 0) 50%,
-      rgba(0, 227, 140, 0) 100%
-    ), linear-gradient(0deg, rgba(18, 21, 25, 1) 0%, rgba(18, 21, 25, 1) 100%);
+  background-color: var(--cBackground-muted);
   overflow: hidden;
   transition: grid-template-columns 0.3s ease;
 

--- a/src/components/req/splash.module.css
+++ b/src/components/req/splash.module.css
@@ -5,8 +5,8 @@
     right: 0;
     bottom: 0;
     z-index: 50;
-    background-color: #1a1a1a;
-    color: #ffffff;
+    background-color: var(--cBackground-muted);
+    color: var(--cWhite);
   }
   
   .flexCenter {
@@ -18,7 +18,7 @@
   }
   
   .logo {
-    color: #ff6b6b;
+    color: var(--cWhiteV1);
   }
   
   .spinDot {

--- a/src/mk/components/notif/provider/useNotifInstandDB.tsx
+++ b/src/mk/components/notif/provider/useNotifInstandDB.tsx
@@ -18,9 +18,6 @@ export const initSocket = async () => {
       appId: process.env.NEXT_PUBLIC_INSTANTDB_APP_ID as string,
       devtool: false,
     });
-    console.log("iniciando conexion a InstantDB");
-  } else {
-    console.log("recuperando conexion a InstantDB");
   }
 
   if (typeof window !== "undefined") {
@@ -40,7 +37,6 @@ export const initSocket = async () => {
     _notif.notif.forEach((e: any) => {
       del.push(db.tx.notif[e.id].delete());
     });
-    console.log("notif", del.length);
     if (del.length > 0) db.transact(del);
   }
 
@@ -224,13 +220,12 @@ const useNotifInstandDB = (
               notif: latest,
               payload: parsedPayload,
               dispatch: dispatchModuleEvent,
-              showToast: showToast || ((msg: string) => console.log("Toast (no-op):", msg)),
+              showToast: showToast || (() => {}),
             });
           }
         });
 
         // Still dispatch the global onNotif event so legacy handlers work
-        console.log("notif enviada (admin)");
         dispatch(latest);
         last = latest.created_at;
         localStorage.setItem("lastNotifInstantDB", last);

--- a/src/mk/components/ui/DataModal/dataModal.module.css
+++ b/src/mk/components/ui/DataModal/dataModal.module.css
@@ -1,5 +1,5 @@
 .dataModal {
-  backdrop-filter: blur(5px);
+  background-color: var(--cHoverModal);
   position: fixed;
   top: 0;
   left: 0;
@@ -15,9 +15,10 @@
     display: flex;
     flex-direction: column;
     color: var(--cWhite);
-    background-color: var(--cBackground-muted);
+    background-color: var(--cModalSurface);
     border-radius: var(--bRadiusL);
-    border: 1px solid var(--cBorder);
+    border: 1px solid var(--cModalBorder);
+    box-shadow: 0 28px 64px rgba(0, 0, 0, 0.44);
     overflow: hidden;
     opacity: 0;
     transform: translateY(100%);
@@ -61,7 +62,7 @@
     }
     .headerDivider {
       height: 0.5px; /* Grosor de la línea, similar a borderWidth */
-      background-color: var(--cWhiteV1); /* Color del borde (#a7a7a7) */
+      background-color: var(--cModalDivider);
       width: 100%;
     }
     & > section {

--- a/src/mk/components/ui/DataModalV2/DataModalV2.tsx
+++ b/src/mk/components/ui/DataModalV2/DataModalV2.tsx
@@ -100,7 +100,7 @@ const DataModalV2 = ({
         <Br
           style={{
             margin: "8px 0px",
-            backgroundColor: "var(--cBackground)",
+            backgroundColor: "var(--cModalDivider)",
             height: 1,
           }}
         />

--- a/src/mk/components/ui/DataModalV2/dataModalV2.module.css
+++ b/src/mk/components/ui/DataModalV2/dataModalV2.module.css
@@ -1,5 +1,5 @@
 .dataModal {
-  backdrop-filter: blur(5px);
+  background-color: var(--cHoverModal);
   position: fixed;
   top: 0;
   left: 0;
@@ -15,9 +15,10 @@
     display: flex;
     flex-direction: column;
     color: var(--cWhite);
-    background-color: var(--cBackground-muted);
+    background-color: var(--cModalSurface);
     border-radius: 24px;
-    border: 1px solid var(--cBorder);
+    border: 1px solid var(--cModalBorder);
+    box-shadow: 0 28px 64px rgba(0, 0, 0, 0.44);
     overflow: hidden;
     opacity: 0;
     transform: translateY(100%);
@@ -60,7 +61,7 @@
     }
     .headerDivider {
       height: 0.5px; /* Grosor de la línea, similar a borderWidth */
-      background-color: var(--cWhiteV1); /* Color del borde (#a7a7a7) */
+      background-color: var(--cBorder);
       width: 100%;
     }
     & > section {
@@ -121,12 +122,12 @@
   }
   .headerIcon {
     padding: 12px;
-    background-color: var(--cBackground);
+    background-color: var(--cModalSurfaceRaised);
     display: flex;
     align-items: center;
     justify-content: center;
     border-radius: 100%;
-    border: 1px solid var(--cBackground-foreground);
+    border: 1px solid var(--cModalBorder);
   }
   .headerTitle {
     font-size: 18px;

--- a/src/mk/components/ui/DetailModal/detailModal.module.css
+++ b/src/mk/components/ui/DetailModal/detailModal.module.css
@@ -4,8 +4,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  backdrop-filter: blur(6px);
-  background: rgba(0, 0, 0, 0.32);
+  background: var(--cHoverModal);
   padding: 32px;
 }
 
@@ -23,16 +22,10 @@
   flex-direction: column;
   gap: 16px;
   padding: 24px;
-  border-radius: 28px;
-  border: 1.2px solid #d7fff014;
-  background:
-    linear-gradient(
-      180deg,
-      rgba(0, 227, 140, 0.08) 0%,
-      rgba(0, 227, 140, 0) 70%,
-      rgba(0, 227, 140, 0) 100%
-    ),
-    linear-gradient(0deg, #121519 0%, #121519 100%);
+  border-radius: 24px;
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSurface);
+  box-shadow: 0 28px 64px rgba(0, 0, 0, 0.44);
   color: var(--cWhite);
   opacity: 0;
   transform: translateY(28px);
@@ -49,14 +42,7 @@
 
 .detailModal > main::before {
   content: "";
-  position: absolute;
-  inset: 0;
-  background-image: url("/assets/images/grain.png");
-  background-repeat: repeat;
-  background-size: auto;
-  opacity: 0.4;
-  pointer-events: none;
-  z-index: 0;
+  display: none;
 }
 
 .detailModal > main > * {
@@ -99,13 +85,17 @@
   width: 40px;
   height: 40px;
   border-radius: 99px;
-  border: 1px solid #d7fff014;
-  background: #12151999;
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSurfaceRaised);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   flex-shrink: 0;
+}
+
+.closeButton:hover {
+  background: #202936;
 }
 
 .detailModal > main > section {
@@ -119,7 +109,7 @@
 .detailModal > main > section:hover,
 .detailModal > main > section:active {
   scrollbar-width: thin;
-  scrollbar-color: rgba(214, 255, 239, 0.22) transparent;
+  scrollbar-color: var(--cModalBorder) transparent;
 }
 
 .detailModal > main > section::-webkit-scrollbar {
@@ -137,13 +127,13 @@
 }
 
 .detailModal > main > section::-webkit-scrollbar-thumb {
-  background: rgba(214, 255, 239, 0.18);
+  background: var(--cModalBorder);
   border-radius: 999px;
 }
 
 .detailModal > main > section:hover::-webkit-scrollbar-thumb,
 .detailModal > main > section:active::-webkit-scrollbar-thumb {
-  background: rgba(214, 255, 239, 0.28);
+  background: var(--cNeutral-500);
 }
 
 .footer {

--- a/src/mk/components/ui/LoadingScreen/Loading/Loading.module.css
+++ b/src/mk/components/ui/LoadingScreen/Loading/Loading.module.css
@@ -5,94 +5,16 @@
   /* height: 200px; */
 }
 .loader {
-  width: 50px;
+  width: 48px;
   aspect-ratio: 1;
   border-radius: 50%;
-  border: 8px solid var(--cPrimary);
-  animation: l20-1 0.8s infinite linear alternate, l20-2 1.6s infinite linear;
+  border: 4px solid var(--cBorder);
+  border-top-color: var(--cWhiteV4);
+  border-right-color: var(--cWhiteV3);
+  animation: spin 0.9s linear infinite;
 }
-@keyframes l20-1 {
-  0% {
-    clip-path: polygon(50% 50%, 0 0, 50% 0%, 50% 0%, 50% 0%, 50% 0%, 50% 0%);
-  }
-  12.5% {
-    clip-path: polygon(
-      50% 50%,
-      0 0,
-      50% 0%,
-      100% 0%,
-      100% 0%,
-      100% 0%,
-      100% 0%
-    );
-  }
-  25% {
-    clip-path: polygon(
-      50% 50%,
-      0 0,
-      50% 0%,
-      100% 0%,
-      100% 100%,
-      100% 100%,
-      100% 100%
-    );
-  }
-  50% {
-    clip-path: polygon(
-      50% 50%,
-      0 0,
-      50% 0%,
-      100% 0%,
-      100% 100%,
-      50% 100%,
-      0% 100%
-    );
-  }
-  62.5% {
-    clip-path: polygon(
-      50% 50%,
-      100% 0,
-      100% 0%,
-      100% 0%,
-      100% 100%,
-      50% 100%,
-      0% 100%
-    );
-  }
-  75% {
-    clip-path: polygon(
-      50% 50%,
-      100% 100%,
-      100% 100%,
-      100% 100%,
-      100% 100%,
-      50% 100%,
-      0% 100%
-    );
-  }
-  100% {
-    clip-path: polygon(
-      50% 50%,
-      50% 100%,
-      50% 100%,
-      50% 100%,
-      50% 100%,
-      50% 100%,
-      0% 100%
-    );
-  }
-}
-@keyframes l20-2 {
-  0% {
-    transform: scaleY(1) rotate(0deg);
-  }
-  49.99% {
-    transform: scaleY(1) rotate(135deg);
-  }
-  50% {
-    transform: scaleY(-1) rotate(0deg);
-  }
-  100% {
-    transform: scaleY(-1) rotate(-135deg);
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
   }
 }

--- a/src/mk/components/ui/LoadingScreen/styles.module.css
+++ b/src/mk/components/ui/LoadingScreen/styles.module.css
@@ -10,9 +10,10 @@
       padding: 8px;
       aspect-ratio: 1;
       border-radius: 50%;
-      background: var(--cPrimary);
-      --_m: conic-gradient(#0000 10%, #00e38c),
-        linear-gradient(#00e38c 0 0) content-box;
+      background: var(--cBackground-foreground);
+      border: 1px solid var(--cBorder);
+      --_m: conic-gradient(#0000 10%, var(--cWhiteV4)),
+        linear-gradient(var(--cWhiteV4) 0 0) content-box;
       -webkit-mask: var(--_m);
       mask: var(--_m);
       -webkit-mask-composite: source-out;

--- a/src/mk/components/ui/NewModal/newModal.module.css
+++ b/src/mk/components/ui/NewModal/newModal.module.css
@@ -1,5 +1,5 @@
 .dataModal {
-  backdrop-filter: blur(5px);
+  background-color: var(--cHoverModal);
   position: fixed;
   top: 0;
   left: 0;
@@ -15,9 +15,10 @@
     display: flex;
     flex-direction: column;
     color: var(--cWhite);
-    background-color: var(--cBlack);
+    background-color: var(--cModalSurface);
     border-radius: var(--bRadiusL);
-    border: 1px solid var(--cBorder);
+    border: 1px solid var(--cModalBorder);
+    box-shadow: 0 28px 64px rgba(0, 0, 0, 0.44);
     overflow: hidden;
     opacity: 0;
     transform: translateY(100%);
@@ -61,7 +62,7 @@
     }
     .headerDivider {
       height: 0.5px; /* Grosor de la línea, similar a borderWidth */
-      background-color: var(--cWhiteV1); /* Color del borde (#a7a7a7) */
+      background-color: var(--cBorder);
       width: 100%;
     }
     & > section {
@@ -123,7 +124,8 @@
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  background-color: var(--cWhiteV2);
+  background-color: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
 }
 
 .titleContainer {
@@ -135,7 +137,7 @@
 }
 
 .modalTitle {
-  color: #fafafa;
+  color: var(--cWhite);
   font-family: Roboto, sans-serif;
   font-size: 18px;
   font-style: normal;
@@ -145,7 +147,7 @@
 }
 
 .modalSubtitle {
-  color: #a7a7a7;
+  color: var(--cWhiteV1);
   font-family: Roboto, sans-serif;
   font-size: 12.6px;
   font-style: normal;

--- a/src/mk/components/ui/Skeleton/styles.module.css
+++ b/src/mk/components/ui/Skeleton/styles.module.css
@@ -1,61 +1,3 @@
-.cardSkeleton {
-  position: relative;
-  background-color: #00e38c;
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    transform: translateX(-100%);
-    animation: shimmer 2s infinite;
-    background: linear-gradient(
-      to right,
-      transparent,
-      rgba(255, 255, 255, 0.2),
-      transparent
-    );
-  }
-
-  & > div {
-    display: flex;
-    padding: 1rem;
-
-    &:first-child {
-      & > div {
-        height: 1.25rem;
-        width: 1.25rem;
-        border-radius: 0.375rem;
-        background-color: var(--cBlackV2);
-
-        &:nth-child(2) {
-          margin-left: 0.5rem;
-          height: 1.5rem;
-          width: 4rem;
-          font-size: 0.875rem;
-          font-weight: 500;
-        }
-      }
-    }
-
-    &:nth-child(2) {
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      border-radius: 0.75rem;
-      background-color: var(--cBlackV2);
-      padding: 2rem 1rem;
-
-      & > div {
-        height: 1.75rem;
-        width: 5rem;
-        border-radius: 0.375rem;
-        background-color: var(--cBlackV2);
-      }
-    }
-  }
-}
-
 @keyframes shimmer {
   0% {
     transform: translateX(-100%);
@@ -63,6 +5,33 @@
 
   100% {
     transform: translateX(100%);
+  }
+}
+
+@keyframes pulse-animation {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.7;
+  }
+}
+
+@keyframes l3 {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes loading {
+  0% {
+    left: -100%;
+  }
+
+  100% {
+    left: 100%;
   }
 }
 
@@ -82,9 +51,11 @@
   padding: 8px;
   aspect-ratio: 1;
   border-radius: 50%;
-  background: var(--cPrimary);
+  background: var(--cBackground-foreground);
+  border: 1px solid var(--cBorder);
   --_m:
-    conic-gradient(#0000 10%, #00e38c), linear-gradient(#00e38c 0 0) content-box;
+    conic-gradient(#0000 10%, var(--cWhiteV4)),
+    linear-gradient(var(--cWhiteV4) 0 0) content-box;
   -webkit-mask: var(--_m);
   mask: var(--_m);
   -webkit-mask-composite: source-out;
@@ -92,35 +63,20 @@
   animation: l3 1s infinite linear;
 }
 
-@keyframes borderAnimation {
-  0% {
-    width: 0;
-  }
-
-  100% {
-    width: 100%;
-  }
-}
-
-@keyframes l3 {
-  to {
-    transform: rotate(1turn);
-  }
-}
-
 .tableSkeleton {
   display: flex;
   flex-grow: 1;
   flex-direction: column;
   justify-content: space-between;
+  width: 100%;
   border-radius: var(--bRadius);
 
   & > div {
     border-radius: var(--bRadius);
-    background-color: #121519;
-    border: 0.3px solid rgba(215, 255, 240, 0.12);
-    padding-left: var(--spXl);
-    padding-right: var(--spXl);
+    background-color: var(--cBackground);
+    border: 1px solid var(--cBorder);
+    padding-inline: var(--spXl);
+    overflow: hidden;
   }
 }
 
@@ -129,114 +85,95 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 0.3px solid rgba(215, 255, 240, 0.12);
-  padding: var(--sL);
+  gap: var(--spL);
+  border-bottom: 1px solid var(--cBorder);
+  padding: var(--spL) 0;
   animation: pulse-animation 1.5s infinite ease-in-out;
 
   & > div:nth-child(1) {
     display: flex;
     align-items: center;
+    min-width: 0;
 
     & > div:nth-child(1) {
       margin-right: var(--spS);
       height: var(--spXxl);
       width: var(--spXxl);
+      flex-shrink: 0;
       border-radius: 100%;
-      background-color: rgba(215, 255, 240, 0.08);
-      animation-name: pulse-animation;
-      animation-duration: 1.5s;
-      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
-      animation-iteration-count: infinite;
+      background-color: rgba(244, 247, 250, 0.08);
     }
 
     & > div:nth-child(2) {
-      min-width: 0px;
+      min-width: 0;
 
       & > div:nth-child(1) {
         height: var(--sL);
-        width: 10rem;
-        border-radius: var(--bRadius);
-        background-color: rgba(215, 255, 240, 0.08);
-        animation: pulse-animation 1.5s infinite;
+        width: min(10rem, 35vw);
+        border-radius: var(--bRadiusS);
+        background-color: rgba(244, 247, 250, 0.1);
       }
 
       & > div:nth-child(2) {
         margin-top: var(--spS);
         height: var(--sL);
         width: 3rem;
-        border-radius: var(--bRadius);
-        background-color: rgba(215, 255, 240, 0.08);
-        animation: pulse-animation 1.5s infinite;
+        border-radius: var(--bRadiusS);
+        background-color: rgba(244, 247, 250, 0.06);
       }
     }
   }
 
   & > div:nth-child(2) {
-    margin-top: var(--spS);
     height: var(--sL);
     width: 3rem;
-    /* w-12 */
-    border-radius: var(--bRadius);
-    background-color: rgba(215, 255, 240, 0.08);
-    animation: pulse-animation 1.5s infinite;
-  }
-}
-
-@keyframes pulse-animation {
-  0% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.5;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes pulse {
-  0% {
-    opacity: 0.9;
-  }
-
-  50% {
-    opacity: 1;
-  }
-
-  100% {
-    opacity: 0.9;
+    flex-shrink: 0;
+    border-radius: var(--bRadiusS);
+    background-color: rgba(244, 247, 250, 0.08);
   }
 }
 
 .cardSkeleton {
   position: relative;
   overflow: hidden;
-  border-radius: var(--sM);
-  background-color: var(--cBlackV2);
-  padding: var(--spS);
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  animation: pulse-animation 1.5s infinite ease-in-out alternate;
+  border-radius: var(--bRadius);
+  background-color: var(--cBackground);
+  border: 1px solid var(--cBorder);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    animation: shimmer 2s infinite;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(244, 247, 250, 0.08),
+      transparent
+    );
+    pointer-events: none;
+  }
 
   & > div:nth-child(1) {
     display: flex;
-    padding: var(--sL);
+    align-items: center;
+    padding: var(--spL);
+
     & > div:nth-child(1) {
-      height: var(--sL);
-      width: var(--sL);
-      border-radius: var(--spS);
-      background-color: var(--cBlackV2);
+      height: 1.25rem;
+      width: 1.25rem;
+      border-radius: 0.375rem;
+      background-color: rgba(244, 247, 250, 0.08);
     }
 
     & > div:nth-child(2) {
-      margin-left: var(--spS);
-      height: 300px;
+      margin-left: 0.5rem;
+      height: 1.5rem;
       width: 4rem;
-      border-radius: var(--spS);
-      background-color: var(--cBlackV2);
-      font-size: var(--sM);
-      font-weight: var(--bSemiBold);
+      border-radius: 0.375rem;
+      background-color: rgba(244, 247, 250, 0.1);
     }
   }
 
@@ -244,19 +181,17 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    border-radius: var(--spS);
-    background-color: var(--cBlackV2);
-    padding: var(--spXxl);
+    padding: 2rem 1rem;
+    margin: 0 var(--spL) var(--spL);
+    border-radius: 0.75rem;
+    background-color: var(--cBackground-foreground);
 
-    /* & > div {
+    & > div {
       height: 1.75rem;
       width: 5rem;
-      border-radius: var(--spS);
-      background-color: #e5e7eb;
-    } */
+      border-radius: 0.375rem;
+      background-color: rgba(244, 247, 250, 0.1);
+    }
   }
 }
 
@@ -264,11 +199,7 @@
   position: relative;
   width: 100%;
   overflow: hidden;
-
-  animation-name: pulse-animation;
-  animation-duration: 2s;
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
+  animation: pulse-animation 2s infinite ease-in-out;
 
   @media (min-width: 768px) {
     grid-column: span 4;
@@ -278,17 +209,14 @@
     margin-bottom: var(--sL);
     height: var(--spXxl);
     width: 9rem;
-    border-radius: var(--spS);
-    background-color: #f3f4f6;
-    animation-name: pulse-animation;
-    animation-duration: 1.5s;
-    animation-timing-function: ease-in-out;
-    animation-iteration-count: infinite;
+    border-radius: var(--bRadiusS);
+    background-color: rgba(244, 247, 250, 0.08);
   }
 
   & > div:nth-child(2) {
     border-radius: var(--spXl);
-    background-color: #f3f4f6;
+    background-color: var(--cBackground);
+    border: 1px solid var(--cBorder);
     padding: var(--sL);
 
     & > div:nth-child(1) {
@@ -299,7 +227,7 @@
       align-items: flex-end;
       gap: var(--spS);
       border-radius: var(--spS);
-      background-color: #ffffff;
+      background-color: var(--cBackground-foreground);
       padding: var(--sL);
 
       @media (min-width: 640px) {
@@ -318,8 +246,7 @@
         height: 1.25rem;
         width: 1.25rem;
         border-radius: 100%;
-        background-color: #e5e7eb;
-        animation: pulse-animation 1.5s infinite;
+        background-color: rgba(244, 247, 250, 0.08);
       }
 
       & > div:nth-child(2) {
@@ -327,34 +254,22 @@
         height: var(--sL);
         width: 5rem;
         border-radius: var(--spS);
-        background-color: #e5e7eb;
-        animation: pulse-animation 1.5s infinite;
+        background-color: rgba(244, 247, 250, 0.1);
       }
     }
   }
 }
 
 .skeletonWrapper {
-  --skeleton-bg-color: rgba(215, 255, 240, 0.08);
+  --skeleton-bg-color: rgba(244, 247, 250, 0.08);
   --skeleton-border-radius: 16px;
-  --skeleton-animation-duration: 3s;
-  --skeleton-gradient-color: rgba(0, 227, 140, 0.12);
+  --skeleton-animation-duration: 2.2s;
+  --skeleton-gradient-color: rgba(244, 247, 250, 0.12);
   --skeleton-gap: 8px;
   --skeleton-container-gap: 16px;
+  --skeleton-margin-inline: 0;
 }
 
-/* Animación */
-@keyframes loading {
-  0% {
-    left: -100%;
-  }
-
-  100% {
-    left: 100%;
-  }
-}
-
-/* Clase base para el esqueleto */
 .skeleton {
   width: 100%;
   background-color: var(--skeleton-bg-color);
@@ -405,7 +320,6 @@
 
 .skeletonBottom {
   height: 500px;
-  animation: pulse-animation 1.5s infinite ease-in-out;
 }
 
 .skeletonContainer {

--- a/src/mk/components/ui/Table/Table.tsx
+++ b/src/mk/components/ui/Table/Table.tsx
@@ -66,12 +66,25 @@ type PropsType = {
 };
 
 const getWidth = (width: any) => {
-  if (!width || width == "" || width == "100%") return { flex: "1" };
+  if (!width || width == "" || width == "100%") {
+    return {
+      flexGrow: 1,
+      flexShrink: 1,
+      flexBasis: "var(--table-cell-min-width)",
+      minWidth: "var(--table-cell-min-width)",
+    };
+  }
   width = ("" + width).replace("px", "");
   return {
     flex: `0 0 ${width}px`,
     width: `${width}px`,
+    minWidth: `${width}px`,
   };
+};
+
+const getCssSize = (value?: string) => {
+  if (!value) return undefined;
+  return /^\d+$/.test(value) ? `${value}px` : value;
 };
 
 const Table = ({
@@ -97,52 +110,63 @@ const Table = ({
   onSort,
 }: PropsType) => {
   const isMobile = false;
-  const [scrollbarWidth, setScrollbarWidth] = useState();
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  const resolvedHeight = getCssSize(height);
   return (
     <div
       className={styles.table + " " + styles[className] + " " + className}
       style={style}
     >
-      {(!isMobile || !onTabletRow) && showHeader && !onRenderCard && (
-        <Head
-          header={header}
-          actionsWidth={actionsWidth}
-          onRenderHead={onRenderHead}
-          onButtonActions={onButtonActions}
-          scrollbarWidth={scrollbarWidth}
-          extraData={extraData}
-          sortCol={sortCol}
-          onSort={onSort}
-        />
-      )}
-      <div style={height ? { height: height, overflowY: "auto" } : {}}>
-        <Body
-          onTabletRow={onTabletRow}
-          onRenderCard={onRenderCard}
-          onRowClick={onRowClick}
-          data={data}
-          header={header}
-          actionsWidth={actionsWidth}
-          renderBody={onRenderBody}
-          onButtonActions={onButtonActions}
-          height={height}
-          setScrollbarWidth={setScrollbarWidth}
-          onRenderBody={onRenderBody}
-          extraData={extraData}
-          id={id}
-        />
+      <div className={styles.scrollArea}>
+        <div className={styles.canvas}>
+          {(!isMobile || !onTabletRow) && showHeader && !onRenderCard && (
+            <Head
+              header={header}
+              actionsWidth={actionsWidth}
+              onRenderHead={onRenderHead}
+              onButtonActions={onButtonActions}
+              scrollbarWidth={scrollbarWidth}
+              extraData={extraData}
+              sortCol={sortCol}
+              onSort={onSort}
+            />
+          )}
+          <div
+            className={
+              styles.bodyViewport +
+              (resolvedHeight ? " " + styles.withHeight : "")
+            }
+            style={resolvedHeight ? { height: resolvedHeight } : undefined}
+          >
+            <Body
+              onTabletRow={onTabletRow}
+              onRenderCard={onRenderCard}
+              onRowClick={onRowClick}
+              data={data}
+              header={header}
+              actionsWidth={actionsWidth}
+              renderBody={onRenderBody}
+              onButtonActions={onButtonActions}
+              height={resolvedHeight}
+              setScrollbarWidth={setScrollbarWidth}
+              onRenderBody={onRenderBody}
+              extraData={extraData}
+              id={id}
+            />
+          </div>
+          {sumarize && (
+            <Sumarize
+              header={header}
+              data={data}
+              actionsWidth={actionsWidth}
+              onRenderFoot={onRenderFoot}
+              onButtonActions={onButtonActions}
+              scrollbarWidth={scrollbarWidth}
+              extraData={extraData}
+            />
+          )}
+        </div>
       </div>
-      {sumarize && (
-        <Sumarize
-          header={header}
-          data={data}
-          actionsWidth={actionsWidth}
-          onRenderFoot={onRenderFoot}
-          onButtonActions={onButtonActions}
-          scrollbarWidth={scrollbarWidth}
-          extraData={extraData}
-        />
-      )}
       {footer && <footer>{footer}</footer>}
     </div>
   );
@@ -281,7 +305,13 @@ const Sumarize = memo(function Sumarize({
   }, [data]);
 
   return (
-    <summary style={{ width: `calc(100% - ${scrollbarWidth || 0}px)` }}>
+    <summary
+      style={
+        scrollbarWidth
+          ? { paddingRight: `${scrollbarWidth}px` }
+          : undefined
+      }
+    >
       {header.map((item: any, index: number) => (
         <div
           key={"foot" + index}
@@ -368,7 +398,7 @@ const Body = ({
       ref={divRef}
       style={
         height
-          ? { height: height, overflowY: "auto" }
+          ? { height: "100%", overflowY: "auto" }
           : {
               display: onRenderCard ? "grid" : "flex",
               flexDirection: onRenderCard ? "row" : "column",

--- a/src/mk/components/ui/Table/styles.module.css
+++ b/src/mk/components/ui/Table/styles.module.css
@@ -1,193 +1,218 @@
 .table {
-  /* display: grid; */
+  --table-surface: var(--cTableSurface);
+  --table-surface-alt: var(--cTableSurfaceAlt);
+  --table-header: var(--cTableHeader);
+  --table-hover: var(--cTableHover);
+  --table-border: var(--cTableBorder);
+  --table-cell-min-width: 152px;
+  width: 100%;
+  min-width: 0;
   font-size: var(--sM);
-  overflow: auto;
+  border-radius: 14px;
+  border: 1px solid var(--table-border);
+  background-color: var(--table-surface);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
+  overflow: hidden;
+}
 
-  border-radius: 12px;
-  border: 0.3px solid rgba(215, 255, 240, 0.12);
-  background-color: #121519;
-  @media (width <= 1024px) {
-    background-color: transparent;
-    border: none;
+.table > footer {
+  border-top: 1px solid var(--table-border);
+  background-color: var(--table-surface-alt);
+}
+
+.scrollArea {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  background-color: var(--table-surface);
+  scrollbar-width: thin;
+  scrollbar-color: var(--cWhiteV2) transparent;
+}
+
+.scrollArea::-webkit-scrollbar {
+  height: 10px;
+}
+
+.scrollArea::-webkit-scrollbar-thumb {
+  background-color: rgba(170, 182, 195, 0.38);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.scrollArea::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.canvas {
+  width: max-content;
+  min-width: 100%;
+}
+
+.bodyViewport {
+  min-width: 100%;
+  background-color: var(--table-surface);
+}
+
+.bodyViewport.withHeight {
+  overflow: hidden;
+}
+
+.table {
+  & header,
+  & main,
+  & summary {
+    width: max-content;
+    min-width: 100%;
   }
 
   & header {
-    width: 100%;
     display: flex;
     align-items: stretch;
     flex-direction: row;
     color: var(--cWhite);
-    font-weight: var(--bSemiBold);
-    overflow: auto;
-    background-color: #121519;
-    border-top-left-radius: var(--bRadius);
-    border-top-right-radius: var(--bRadius);
-    overflow: hidden;
+    font-weight: var(--bSemibold);
+    overflow: visible;
+    background-color: var(--table-header);
     min-height: 55px;
+    box-shadow: inset 0 -1px 0 var(--table-border);
+
     & > div {
-      padding: var(--spL);
-      /* padding-bottom: var(--spS); */
       width: 100%;
-      font-size: var(--sL);
-      font-weight: 600;
-      /* border-left: 1px solid var(--cBlackV1); */
+      padding: 14px var(--spL);
+      font-size: 15px;
+      font-weight: var(--bSemibold);
       box-sizing: border-box;
       display: flex;
-      align-items: center; /* Centra el contenido verticalmente */
-      justify-content: left; /* Centra el contenido horizontalmente */
-      text-align: left; /* Centra el texto */
-      border-bottom: 0.3px solid rgba(215, 255, 240, 0.12);
-      border-left: 0.3px solid rgba(215, 255, 240, 0.12);
+      align-items: center;
+      justify-content: left;
+      text-align: left;
+      color: var(--cWhiteV4);
+      border-bottom: 1px solid var(--table-border);
+      border-left: 1px solid var(--table-border);
     }
+
     & > div:first-child {
       border-left: 0;
     }
+
     & > div:last-child {
-      border-right: 0.3px solid rgba(215, 255, 240, 0.12);
+      border-right: 1px solid var(--table-border);
     }
   }
 
   & summary {
-    width: 100%;
     display: flex;
     align-items: center;
     flex-direction: row;
-    color: var(--cWhite);
-    font-weight: var(--bSemiBold);
-    overflow: auto;
+    color: var(--cWhiteV4);
+    font-weight: var(--bSemibold);
+    overflow: visible;
+    background-color: var(--table-surface-alt);
+
     & > div {
       overflow: visible;
       padding: var(--spL);
-      padding-bottom: var(--spS);
+      padding-bottom: var(--spM);
       height: 100%;
       align-items: center;
       width: 100%;
+      border-left: 1px solid var(--table-border);
     }
+
+    & > div:first-child {
+      border-left: 0;
+    }
+
     & > div > div {
-      margin-right: -12px;
-      margin-left: -12px;
-      border: 0.3px solid rgba(215, 255, 240, 0.12);
+      margin-right: -16px;
+      margin-left: -16px;
+      border: 1px solid var(--table-border);
       border-bottom-left-radius: var(--bRadius);
       border-bottom-right-radius: var(--bRadius);
-      margin-top: -12px;
-      padding: 12px;
-      background-color: #121519;
-      color: var(--cBlackV2);
-      font-size: 16px;
+      margin-top: -10px;
+      padding: 12px 16px;
+      background-color: var(--table-surface);
+      font-size: 15px;
+      font-weight: var(--bSemibold);
       color: var(--cWhite);
-    }
-  }
-  /* & summary {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    color: var(--cWhite);
-    font-weight: var(--bSemiBold);
-    overflow: hidden;
-    & > div {
-      overflow: visible;
-      padding: var(--spM);
-      padding-bottom: var(--spS);
-      height: 100%;
-      align-items: center;
-    }
-    & > div > div {
-      background-color: red;
-      margin-right: -12px;
-      margin-left: -12px;
-      border: 1px solid var(--cWhiteV3);
-      border-bottom-left-radius: var(--bRadius);
-      border-bottom-right-radius: var(--bRadius);
-      margin-top: -12px;
-      padding: 12px;
-      background-color: var(--cWhiteV3);
-      color: var(--cBlackV2);
-      font-size: 16px;
-      color: var(--cWhite);
-    }
-  } */
-  & > div {
-    /* min-height: 400px; */
-    @media (width <= 1280px) {
-      /* min-height: 500px; */
-    }
-    @media (width <= 1024px) {
-      /* min-height: 360px; */
-    }
-  }
-  & main {
-    display: flex;
-    flex-direction: column;
-    gap: 0px;
-    border-bottom-left-radius: var(--bRadius);
-    border-bottom-right-radius: var(--bRadius);
-    border-bottom: 0.3px solid rgba(215, 255, 240, 0.12);
-    /* min-height: 300px; */
-    /* border: 1px solid var(--cWhiteV3); */
-    @media (width <= 1280px) {
-      /* min-height: 500px; */
-    }
-    @media (width <= 1024px) {
-      /* min-height: 360px; */
-    }
-    & > div {
-      display: flex;
-      align-items: stretch; /* Hace que todas las celdas tengan la misma altura */
-      gap: 0px;
-      background-color: #121519;
-      color: var(--cWhiteV2);
-      /* overflow: hidden; */
-      /* height: 48px; */
-      cursor: pointer;
-      @media (width <= 1024px) {
-        background-color: transparent;
-      }
-      & > span {
-        display: flex;
-        align-items: center;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        overflow: hidden;
-        padding: var(--spL);
-        /* border: 1px solid var(--cWhiteV3); */
-        width: 100%;
-        color: var(--cWhiteV1);
-        display: flex; /* Permite la alineación del contenido interno */
-        align-items: center; /* Centra verticalmente el contenido */
-        box-sizing: border-box; /* Asegura que padding y border se incluyan en el tamaño total */
-        border-top: 0.3px solid rgba(215, 255, 240, 0.12);
-        border-left: 0.3px solid rgba(215, 255, 240, 0.12);
-        /* border-bottom: 0.5px solid var(--cWhiteV1); */
-      }
-      & > span:first-child {
-        border-left: 0;
-      }
-      & > span:last-child {
-        border-right: 0.3px solid rgba(215, 255, 240, 0.12);
-      }
-    }
-    & > div:last-child > span {
-      border-bottom: 0.3px solid rgba(215, 255, 240, 0.12);
     }
   }
 
+  & > div {
+    min-width: 100%;
+  }
+
+  & main {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    background-color: var(--table-surface);
+
+    & > div {
+      width: max-content;
+      min-width: 100%;
+      display: flex;
+      align-items: stretch;
+      gap: 0;
+      min-height: 56px;
+      background-color: var(--table-surface);
+      color: var(--cWhiteV2);
+      cursor: pointer;
+      transition: background-color 0.18s ease;
+
+      & > span {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        padding: 14px var(--spL);
+        width: 100%;
+        color: var(--cWhiteV1);
+        line-height: 1.35;
+        box-sizing: border-box;
+        border-top: 1px solid var(--table-border);
+        border-left: 1px solid var(--table-border);
+      }
+
+      & > span:first-child {
+        border-left: 0;
+      }
+
+      & > span:last-child {
+        border-right: 1px solid var(--table-border);
+      }
+    }
+
+    & > div:last-child > span {
+      border-bottom: 1px solid var(--table-border);
+    }
+  }
+
+  & header > div.desktop,
+  & main > div > span.desktop,
   & header > div.onlyDesktop,
   & main > div > span.onlyDesktop {
     @media (width <= 768px) {
       display: none;
     }
   }
+
   & header > div.tablet,
   & main > div > span.tablet {
     display: none;
+
     @media (width <= 768px) {
       display: flex;
     }
   }
+
   & header > div.mobile,
   & main > div > span.mobile {
     display: none;
+
     @media (width <= 480px) {
       display: flex;
     }
@@ -196,18 +221,12 @@
 
 .table.striped {
   & main {
-    & > div:nth-child(even) {
-      background-color: #11161b;
+    & > div {
+      background-color: var(--table-surface);
       color: var(--cWhiteV1);
+
       &:hover {
-        background-color: rgba(0, 227, 140, 0.08);
-      }
-    }
-    & > div:nth-child(odd) {
-      background-color: #121519;
-      color: var(--cWhiteV1);
-      &:hover {
-        background-color: rgba(0, 227, 140, 0.08);
+        background-color: var(--table-hover);
       }
     }
   }
@@ -215,11 +234,39 @@
 
 .table.V1 {
   @media (width <= 1024px) {
-    border: var(--cWhiteV2) solid 1px;
+    border: 1px solid var(--table-border);
   }
+
   & header {
     @media (width <= 1024px) {
-      border: var(--cWhiteV2) solid 1px;
+      border: 1px solid var(--table-border);
     }
+  }
+}
+
+@media (width <= 1024px) {
+  .table {
+    --table-cell-min-width: 140px;
+    border-radius: 12px;
+  }
+}
+
+@media (width <= 768px) {
+  .table {
+    font-size: 13px;
+  }
+
+  .table header > div,
+  .table main > div > span,
+  .table summary > div {
+    padding: 12px;
+  }
+
+  .table header > div {
+    font-size: 13px;
+  }
+
+  .table main > div {
+    min-height: 52px;
   }
 }

--- a/src/mk/contexts/AuthProvider.tsx
+++ b/src/mk/contexts/AuthProvider.tsx
@@ -128,6 +128,7 @@ const AuthProvider = ({ children, noAuth = false }: any): any => {
           localStorage.removeItem("condaty_client_id");
           setUser(false);
           setWaiting(-1, "-getUser");
+          setSplash(false);
           // setSplash(false);
           // router.reload();
           // router.reload();

--- a/src/mk/contexts/AxiosInstanceProvider.tsx
+++ b/src/mk/contexts/AxiosInstanceProvider.tsx
@@ -8,6 +8,27 @@ export type AxiosContextType = {
   setWaiting: Function;
 };
 export const AxiosContext = createContext({} as AxiosContextType);
+
+const resolveApiBaseUrl = (apiUrl?: string) => {
+  if (!apiUrl) return apiUrl;
+  if (typeof window === "undefined") return apiUrl;
+
+  try {
+    const resolvedUrl = new URL(apiUrl, window.location.origin);
+
+    if (
+      /^https?:$/.test(resolvedUrl.protocol) &&
+      resolvedUrl.origin !== window.location.origin
+    ) {
+      return "/api-proxy";
+    }
+  } catch (_error) {
+    return apiUrl;
+  }
+
+  return apiUrl;
+};
+
 const AxiosInstanceProvider = ({
   config = {},
   interceptors = null,
@@ -22,9 +43,10 @@ const AxiosInstanceProvider = ({
   };
   const API_URL = process.env.NEXT_PUBLIC_API_URL;
   if (!config.baseURL) {
-    config = { ...config, baseURL: API_URL };
+    config = { ...config, baseURL: resolveApiBaseUrl(API_URL) };
   }
   const instanceRef = useRef(axios.create(config));
+  instanceRef.current.defaults.baseURL = config.baseURL;
   instanceRef.current.defaults.withCredentials = true;
   useEffect(() => {
     setWaiting2(0, "useEffect AxiosProvider");

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -295,7 +295,7 @@ const useCrud = ({
         ...(mod.loadView !== true ? mod.loadView : {}),
       },
       false,
-      mod?.noWaiting,
+      true,
     );
     if (data?.success) {
       return data?.data;
@@ -1070,13 +1070,13 @@ const useCrud = ({
                   error={false}
                   inputStyle={{
                     height: 44,
-                    backgroundColor: "#d7fff005",
-                    border: "1px solid #d7fff014",
+                    backgroundColor: "var(--cModalSurfaceRaised)",
+                    border: "1px solid var(--cModalBorder)",
                     borderRadius: 12,
                     padding: "16px",
                     fontSize: 15,
                     fontWeight: 600,
-                    color: "#878f9a",
+                    color: "var(--cWhiteV1)",
                     ...(filterSel[f.key] &&
                       filterSel[f.key] != "" &&
                       filterSel[f.key] != "T" &&
@@ -1114,13 +1114,13 @@ const useCrud = ({
                 optionValue={f?.optionValue}
                 inputStyle={{
                   height: 44,
-                  backgroundColor: "#d7fff005",
-                  border: "1px solid #d7fff014",
+                  backgroundColor: "var(--cModalSurfaceRaised)",
+                  border: "1px solid var(--cModalBorder)",
                   borderRadius: 12,
                   padding: "16px",
                   fontSize: 15,
                   fontWeight: 600,
-                  color: "#878f9a",
+                  color: "var(--cWhiteV1)",
                   ...(filterSel[f.key] &&
                     filterSel[f.key] != "" &&
                     filterSel[f.key] != "T" &&
@@ -1530,7 +1530,7 @@ const useCrud = ({
             breakPoint={props.filterBreakPoint}
           />
         )}
-        <LoadingScreen type="TableSkeleton">
+        <LoadingScreen type="TableSkeleton" loaded={data !== null}>
           {openList && (
             <div
               style={{

--- a/src/mk/hooks/useCrud/useCrudStyle.module.css
+++ b/src/mk/hooks/useCrud/useCrudStyle.module.css
@@ -58,8 +58,8 @@
       justify-content: center;
       align-items: center;
       border-radius: 8px;
-      background-color: rgba(18, 21, 25, 0.56);
-      border: 0.1px solid rgba(215, 255, 240, 0.22);
+      background-color: var(--cBackground);
+      border: 1px solid var(--cBorder);
       overflow: hidden;
     }
     & div:first-child {
@@ -78,20 +78,20 @@
   & > div {
     padding: 12px;
     color: var(--cWhiteV1);
-    background-color: var(--cBlackV1);
+    background-color: var(--cBackground);
     cursor: pointer;
   }
   & > div:nth-child(1) {
-    border: 1px solid var(--cBlackV1);
+    border: 1px solid var(--cBorder);
     border-radius: 8px 0px 0px 8px;
   }
   & > div:nth-child(2) {
-    border: 1px solid var(--cBlackV1);
+    border: 1px solid var(--cBorder);
     border-radius: 0px 8px 8px 0px;
   }
   .active {
     border: 1px solid var(--cAccent);
-    background-color: var(--cHoverSuccess);
+    background-color: var(--cBackground-foreground);
   }
 }
 
@@ -129,11 +129,11 @@
   padding: 12px 16px;
   font-size: 14px;
   font-weight: 400;
-  color: #878f9a;
+  color: var(--cWhiteV1);
   gap: 8px;
   border-radius: 12px;
-  border: 1px solid #d7fff014;
-  background-color: #d7fff005;
+  border: 1px solid var(--cBorder);
+  background-color: var(--cBackground);
   width: auto;
   display: inline-flex;
   align-items: center;
@@ -190,14 +190,14 @@
 .icons,
 .extraButtons > div > svg {
   cursor: pointer;
-  color: #878f9a;
-  background-color: #d7fff005;
-  border: 1px solid #d7fff014;
+  color: var(--cWhiteV1);
+  background-color: var(--cBackground);
+  border: 1px solid var(--cBorder);
   min-width: 44px;
   padding: 12px;
   height: 44px;
   border-radius: 12px;
   &:hover {
-    background-color: rgba(0, 227, 140, 0.12);
+    background-color: var(--cBackground-foreground);
   }
 }

--- a/src/mk/v2/Components/ui/Card/Card.module.css
+++ b/src/mk/v2/Components/ui/Card/Card.module.css
@@ -1,12 +1,12 @@
 .card {
-  background: var(--cNeutral-800);
+  background: var(--cBackground-foreground);
   backdrop-filter: blur(10px);
-  border: 1px solid var(--cBlackV3);
+  border: 1px solid var(--cModalBorder);
   border-radius: 12px;
   padding: var(--spL);
   position: relative;
   &.v2 {
-    background: #000;
+    background: var(--cBackground-foreground);
   }
 }
 /* Accordion sections on the right */
@@ -14,12 +14,12 @@
   display: flex;
   flex-direction: column;
   /* gap: 12px; */
-  border: 1px solid var(--cBlackV3);
+  border: 1px solid var(--cModalBorder);
   border-radius: var(--bRadiusM);
   padding: var(--spS);
-  background: #000;
+  background: var(--cBackground);
   &.v2 {
-    background: var(--cNeutral-800);
+    background: var(--cBackground);
   }
 }
 
@@ -33,6 +33,6 @@
 .sectionTitle {
   font-size: 12px;
   font-weight: 700;
-  color: #888;
+  color: var(--cNeutral-100);
   letter-spacing: 1px;
 }

--- a/src/modulos/Activities/AccessTab/ModalAccessExpand/ModalAccessExpand.module.css
+++ b/src/modulos/Activities/AccessTab/ModalAccessExpand/ModalAccessExpand.module.css
@@ -1,221 +1,371 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
   width: 100%;
   color: var(--cWhite);
 }
 
+.summaryCard,
+.sectionCard,
+.factCard,
+.galleryGroup,
+.deviceCard,
+.emptyCard,
+.actionItem {
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSection);
+  border-radius: 16px;
+}
+
+.summaryCard,
+.sectionCard,
+.galleryGroup,
+.deviceCard,
+.emptyCard,
+.actionItem {
+  padding: 14px;
+}
+
 .summaryCard {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px;
-  background-color: #12151999;
-  border-radius: 14px;
-  border: 1px solid #d7fff014;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: flex-start;
 }
 
-.summaryIcon {
-  width: 38px;
-  height: 38px;
-  border-radius: 999px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: #1a1f2499;
-  border: 1.2px solid rgba(0, 227, 140, 0.35);
-  box-shadow: 0 0 32px 2px #00e38c29;
-  flex-shrink: 0;
-}
-
-.summaryTextWrap {
+.summaryBody {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 8px;
   min-width: 0;
 }
 
-.summaryTitle {
-  font-size: 14px;
-  line-height: 1.35;
-  color: var(--cWhite);
+.badgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.summaryStrong {
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 12px;
   font-weight: 600;
-  color: #e0e8f1;
 }
 
-.summarySoft {
-  color: #d7fff066;
+.toneSuccess {
+  color: #7ee2a8;
+  background: rgba(52, 168, 83, 0.14);
+  border-color: rgba(52, 168, 83, 0.28);
+}
+
+.toneDanger {
+  color: #ff9299;
+  background: rgba(228, 96, 85, 0.14);
+  border-color: rgba(228, 96, 85, 0.26);
+}
+
+.toneWarning {
+  color: #f4cb65;
+  background: rgba(233, 176, 30, 0.14);
+  border-color: rgba(233, 176, 30, 0.24);
+}
+
+.toneInfo {
+  color: #8eb8ff;
+  background: rgba(66, 133, 250, 0.14);
+  border-color: rgba(66, 133, 250, 0.24);
+}
+
+.toneAccent {
+  color: var(--cAccent);
+  background: rgba(0, 227, 140, 0.12);
+  border-color: rgba(0, 227, 140, 0.24);
+}
+
+.summaryTitle {
+  font-size: 15px;
+  line-height: 1.35;
+  font-weight: 600;
+  color: var(--cWhite);
 }
 
 .summaryDate {
   font-size: 12px;
-  color: #d6ffef66;
+  line-height: 1.45;
+  color: var(--cWhiteV1);
 }
 
-.sectionBlock {
+.sectionCard {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
 .sectionTitle {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--cWhite);
 }
 
-.separator {
-  width: 100%;
-  height: 1px;
-  background-color: #d7fff014;
-}
-
-.detailsGrid {
+.factsGrid,
+.deviceGrid {
   display: grid;
-  grid-template-columns: 200px minmax(240px, auto);
-  row-gap: 6px;
-  column-gap: 10px;
-  width: fit-content;
-  max-width: 100%;
+  gap: 10px;
 }
 
-.rowLabel {
-  color: #d6ffef66;
-  font-size: 13px;
-  min-height: 18px;
+.factsGrid {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.deviceGrid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.factCard {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--cModalSurface);
 }
 
-.rowValue {
+.factLabel,
+.galleryCount,
+.timelineMeta,
+.deviceMeta,
+.guardText,
+.actionMeta {
+  color: var(--cWhiteV1);
+}
+
+.factLabel {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.factValue {
+  font-size: 13px;
+  line-height: 1.4;
   color: var(--cWhite);
-  font-size: 13px;
-  min-height: 18px;
-  display: flex;
-  align-items: center;
   word-break: break-word;
 }
 
-.personValue {
-  display: inline-flex;
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.timelineItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--cModalDivider);
+}
+
+.timelineItem:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.timelineHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.timelineLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--cWhite);
+}
+
+.timelineDate {
+  font-size: 12px;
+  color: var(--cWhiteV1);
+}
+
+.timelineMeta {
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.galleryStack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.galleryGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.galleryHeader {
+  display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.galleryTitle,
+.deviceName {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--cWhite);
+}
+
+.galleryCount,
+.deviceMeta,
+.guardText,
+.actionMeta {
+  font-size: 12px;
 }
 
 .imagesCarousel {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
   align-items: center;
-  gap: var(--spS);
 }
 
 .imagesRow {
   display: flex;
-  gap: var(--spS);
+  gap: 10px;
   overflow-x: auto;
-  padding: var(--spS) 0;
+  padding: 4px 2px 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--cModalBorder) transparent;
+}
+
+.imagesRow > * {
+  flex: 0 0 auto;
+}
+
+.imagesRow::-webkit-scrollbar {
+  height: 6px;
+}
+
+.imagesRow::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.imagesRow::-webkit-scrollbar-thumb {
+  background: var(--cModalBorder);
+  border-radius: 999px;
 }
 
 .carouselBtn {
-  background: transparent;
-  border: none;
-  padding: 4px;
-  cursor: pointer;
-}
-
-.devicesContainer {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 100%;
-}
-
-.deviceCard {
-  border: 1px solid #d7fff014;
-  background-color: #12151999;
-  border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.deviceHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.deviceGuard {
-  color: var(--cWhite);
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.deviceBlock {
-  border: 1px solid #d7fff014;
-  border-radius: 10px;
-  padding: 10px;
-}
-
-.deviceNameWrap {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.deviceIcon {
-  width: 22px;
-  height: 22px;
+  width: 34px;
+  height: 34px;
   border-radius: 999px;
-  background: #00e38c14;
-  border: 1px solid #00e38c33;
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSurfaceRaised);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+}
+
+.deviceCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.deviceTitleRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.deviceTitleWrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.deviceIcon {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background: rgba(0, 227, 140, 0.1);
+  border: 1px solid rgba(0, 227, 140, 0.22);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.guardText {
+  text-align: right;
 }
 
 .actionList {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
 }
 
-.actionRow {
+.actionItem {
   display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.actionBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 34px;
-  border-radius: 8px;
-  padding: 4px 6px;
-  background-color: #00e38c14;
-  color: #00e38c;
-  font-size: 12px;
-  font-weight: 600;
+  align-items: flex-start;
+  gap: 10px;
 }
 
 .actionText {
-  color: var(--cWhiteV1);
-  font-size: 12px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--cWhite);
 }
 
-@media (max-width: 900px) {
-  .detailsGrid {
+.emptyCard {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--cWhiteV1);
+}
+
+@media (max-width: 720px) {
+  .summaryCard,
+  .imagesCarousel {
     grid-template-columns: 1fr;
-    row-gap: 3px;
-    width: 100%;
   }
 
-  .rowLabel {
-    margin-top: 8px;
+  .deviceTitleRow,
+  .galleryHeader,
+  .timelineHead {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .guardText {
+    text-align: left;
+  }
+
+  .carouselBtn {
+    display: none;
+  }
+}
+
+@media (max-width: 540px) {
+  .container {
+    gap: 12px;
+  }
+
+  .factsGrid,
+  .deviceGrid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/modulos/Activities/AccessTab/ModalAccessExpand/ModalAccessExpand.tsx
+++ b/src/modulos/Activities/AccessTab/ModalAccessExpand/ModalAccessExpand.tsx
@@ -1,18 +1,28 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
 import DetailModal from "@/mk/components/ui/DetailModal/DetailModal";
 import LoadingScreen from "@/mk/components/ui/LoadingScreen/LoadingScreen";
 import useAxios from "@/mk/hooks/useAxios";
 import { formatToDayFdMYH } from "@/mk/utils/date";
-import { getFullName } from "@/mk/utils/string";
 import { Image } from "@/mk/components/ui/Image/Image";
 import styles from "./ModalAccessExpand.module.css";
 import {
   IconArrowLeft,
   IconArrowRight,
-  IconCheck,
   IconPhone,
 } from "@/components/layout/icons/IconsBiblioteca";
+import {
+  collectUniqueImages,
+  flattenAccessDevices,
+  getAccessHeadline,
+  getAccessStatusInfo,
+  getAccessTypeLabel,
+  getEntityAvatar,
+  getEntityGallery,
+  getEntityName,
+  getMovementMode,
+  getUnitLabel,
+} from "../shared/accessDetailUtils";
 
 interface PropsType {
   id: string | number | null;
@@ -29,13 +39,110 @@ const typeText: any = {
   P: "pedido",
 };
 
-const typeMap: Record<string, string> = {
-  C: "Sin QR",
-  I: "QR Individual",
-  G: "QR Grupal",
-  F: "QR Frecuente",
-  P: "Pedido",
-  O: "Llave QR",
+type Tone = "success" | "danger" | "warning" | "info" | "accent";
+
+const toneClassMap: Record<Tone, string> = {
+  success: styles.toneSuccess,
+  danger: styles.toneDanger,
+  warning: styles.toneWarning,
+  info: styles.toneInfo,
+  accent: styles.toneAccent,
+};
+
+const formatDetailDate = (dateStr: string | null = "") => {
+  const formatted = formatToDayFdMYH(dateStr, true, true, false) || "";
+  if (!formatted) return "-/-";
+  return formatted.replace(/ del (\d{4}) - /, ", $1 - ");
+};
+
+const Badge = ({
+  label,
+  tone,
+}: {
+  label: React.ReactNode;
+  tone: Tone;
+}) => {
+  return (
+    <span className={`${styles.badge} ${toneClassMap[tone]}`}>{label}</span>
+  );
+};
+
+const FactCard = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) => (
+  <div className={styles.factCard}>
+    <span className={styles.factLabel}>{label}</span>
+    <div className={styles.factValue}>{value || "-/-"}</div>
+  </div>
+);
+
+const GalleryGroup = ({
+  title,
+  images,
+}: {
+  title: string;
+  images: string[];
+}) => {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [showControls, setShowControls] = useState(false);
+
+  useEffect(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    const check = () => setShowControls(el.scrollWidth > el.clientWidth + 2);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [images]);
+
+  return (
+    <div className={styles.galleryGroup}>
+      <div className={styles.galleryHeader}>
+        <p className={styles.galleryTitle}>{title}</p>
+        <span className={styles.galleryCount}>{images.length} foto(s)</span>
+      </div>
+      <div className={styles.imagesCarousel}>
+        {showControls ? (
+          <button
+            className={styles.carouselBtn}
+            onClick={() =>
+              rowRef.current?.scrollBy({ left: -220, behavior: "smooth" })
+            }
+          >
+            <IconArrowLeft color="var(--cWhite)" />
+          </button>
+        ) : null}
+        <div className={styles.imagesRow} ref={rowRef}>
+          {images.map((src, index) => (
+            <Image
+              key={`${title}-${src}-${index}`}
+              src={src}
+              alt={title}
+              h={108}
+              w={144}
+              expandable
+              square
+            />
+          ))}
+        </div>
+        {showControls ? (
+          <button
+            className={styles.carouselBtn}
+            onClick={() =>
+              rowRef.current?.scrollBy({ left: 220, behavior: "smooth" })
+            }
+          >
+            <IconArrowRight color="var(--cWhite)" />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
 };
 
 const ModalAccessExpand = ({ id, open, onClose, type }: PropsType) => {
@@ -43,58 +150,6 @@ const ModalAccessExpand = ({ id, open, onClose, type }: PropsType) => {
   const [accessDevices, setAccessDevices]: any[] = useState([]);
   const { execute } = useAxios();
   const [loading, setLoading] = useState(false);
-  const [images, setImages] = useState<string[]>([]);
-  const rowRef = React.useRef<HTMLDivElement>(null);
-  const [showControls, setShowControls] = useState(false);
-
-  const formatDetailDate = (dateStr: string | null = "") => {
-    const formatted = formatToDayFdMYH(dateStr, true, true, false) || "";
-    if (!formatted) return "-/-";
-    return formatted.replace(/ del (\d{4}) - /, ", $1 - ");
-  };
-
-  const cleanUrl = (value: any) => {
-    if (!value) return "";
-    const sanitized = String(value).replace(/[`"']/g, "").trim();
-    if (!sanitized || sanitized.includes("undefined")) return "";
-    return sanitized;
-  };
-
-  const normalizeImageUrls = (arr: any) => {
-    if (!Array.isArray(arr)) return [];
-    return arr.map(cleanUrl).filter(Boolean);
-  };
-
-  const getEntityAvatar = (entity: any) => {
-    const fromAvatar = cleanUrl(entity?.url_avatar);
-    if (fromAvatar) return fromAvatar;
-    const fromArray = normalizeImageUrls(entity?.url_image_a)?.[0];
-    if (fromArray) return fromArray;
-    const fromRear = cleanUrl(entity?.url_image_r);
-    if (fromRear) return fromRear;
-    return "";
-  };
-
-  const getStatus = () => {
-    if (accessDetail?.out_at) return "Completado";
-    if (accessDetail?.in_at) return "Por salir";
-    if (!accessDetail?.confirm_at) return "Por confirmar";
-    if (accessDetail?.confirm === "Y") return "Por entrar";
-    return "Rechazado";
-  };
-
-  const getTypeAccess = () => {
-    if (accessDetail?.type === "P") {
-      return "Pedido/" + (accessDetail?.other?.other_type?.name || "-/-");
-    }
-    return typeMap[accessDetail?.type] || "-/-";
-  };
-
-  const getActionNameEs = (actionName: string) => {
-    if (actionName === "In") return "Entrada";
-    if (actionName === "Out") return "Salida";
-    return actionName || "-/-";
-  };
 
   const getAccess = async () => {
     if (!id) {
@@ -127,30 +182,93 @@ const ModalAccessExpand = ({ id, open, onClose, type }: PropsType) => {
 
   useEffect(() => {
     if (!open) return;
-    if (type != "I" && type != "P") {
-      getAccess();
-    }
+    getAccess();
   }, [type, id, open]);
 
-  useEffect(() => {
-    const imgs = [
-      ...normalizeImageUrls((accessDetail as any)?.url_image_p),
-      ...normalizeImageUrls((accessDetail as any)?.url_image),
-      ...normalizeImageUrls((accessDetail as any)?.visit?.url_image_a),
-      ...normalizeImageUrls((accessDetail as any)?.visit?.url_image_r),
-    ];
-    setImages(Array.from(new Set(imgs)));
-  }, [accessDetail]);
+  const accessType = accessDetail?.type || "";
+  const owner = accessDetail?.owner || {};
+  const visit = accessDetail?.visit || {};
+  const statusInfo = getAccessStatusInfo(accessDetail);
+  const movementMode = getMovementMode(accessDetail);
+  const deviceData = useMemo(
+    () => flattenAccessDevices(accessDevices),
+    [accessDevices],
+  );
+  const deviceItems = deviceData.devices;
+  const actionItems = deviceData.actions;
+  const subject = accessType === "O" ? owner : visit;
+  const subjectName = getEntityName(subject) || "Sin nombre";
+  const unitLabel = getUnitLabel(owner);
+  const startedAt = accessDetail?.in_at || accessDetail?.begin_at;
 
-  useEffect(() => {
-    const el = rowRef.current;
-    if (!el) return;
-    const check = () => setShowControls(el.scrollWidth > el.clientWidth + 2);
-    check();
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [images]);
+  const imageGroups = useMemo(() => {
+    const groups = [
+      {
+        key: "subject",
+        title: type === "T" ? "Fotos del taxista" : "Fotos del visitante",
+        images: getEntityGallery(subject),
+      },
+      {
+        key: "host",
+        title: "Fotos del residente destino",
+        images: accessType === "O" ? [] : getEntityGallery(owner),
+      },
+      {
+        key: "access",
+        title: "Fotos del registro",
+        images: collectUniqueImages(
+          accessDetail?.url_image_p,
+          accessDetail?.url_image,
+        ),
+      },
+    ];
+
+    const used = new Set<string>();
+    return groups
+      .map((group) => ({
+        ...group,
+        images: group.images.filter((image) => {
+          if (used.has(image)) return false;
+          used.add(image);
+          return true;
+        }),
+      }))
+      .filter((group) => group.images.length > 0);
+  }, [accessDetail, accessType, owner, subject, type]);
+
+  const timelineItems = [
+    accessDetail?.begin_at
+      ? {
+          label: "Solicitud",
+          date: formatDetailDate(accessDetail.begin_at),
+          meta: "Acceso registrado",
+        }
+      : null,
+    accessDetail?.confirm_at
+      ? {
+          label:
+            accessDetail?.confirm === "N" || accessDetail?.rejected_guard_id != null
+              ? "Rechazo"
+              : "Validacion",
+          date: formatDetailDate(accessDetail.confirm_at),
+          meta: accessDetail?.obs_confirm || "",
+        }
+      : null,
+    accessDetail?.in_at
+      ? {
+          label: "Ingreso",
+          date: formatDetailDate(accessDetail.in_at),
+          meta: accessDetail?.obs_in || "",
+        }
+      : null,
+    accessDetail?.out_at
+      ? {
+          label: "Salida",
+          date: formatDetailDate(accessDetail.out_at),
+          meta: accessDetail?.obs_out || "",
+        }
+      : null,
+  ].filter(Boolean) as Array<{ label: string; date: string; meta?: string }>;
 
   return (
     <DetailModal
@@ -160,249 +278,211 @@ const ModalAccessExpand = ({ id, open, onClose, type }: PropsType) => {
       buttonText=""
       buttonCancel=""
       zIndex={320}
-      maxWidth={640}
+      maxWidth={760}
       style={{
-        width: "min(640px, calc(100vw - 140px))",
-        maxHeight: "calc(100vh - 180px)",
-        padding: "16px",
+        width: "min(760px, calc(100vw - 32px))",
+        maxHeight: "calc(100vh - 48px)",
+        padding: "18px",
       }}
     >
-      <LoadingScreen onlyLoading={loading || !accessDetail?.id}>
+      <LoadingScreen onlyLoading={loading || (!!id && !accessDetail?.id)}>
         <div className={styles.container}>
           <section className={styles.summaryCard}>
-            <div className={styles.summaryIcon}>
-              <IconCheck size={22} color="var(--cAccent)" />
-            </div>
-            <div className={styles.summaryTextWrap}>
+            <Avatar
+              name={subjectName}
+              src={getEntityAvatar(subject)}
+              w={52}
+              h={52}
+            />
+            <div className={styles.summaryBody}>
+              <div className={styles.badgeRow}>
+                <Badge label={statusInfo.label} tone={statusInfo.tone} />
+                <Badge
+                  label={getAccessTypeLabel(accessType, accessDetail)}
+                  tone="accent"
+                />
+                <Badge label={movementMode} tone="info" />
+              </div>
               <p className={styles.summaryTitle}>
-                <span className={styles.summaryStrong}>
-                  {getFullName(accessDetail?.visit) || "Sin nombre"}
-                </span>{" "}
-                <span className={styles.summarySoft}>visitó a </span>
-                <span className={styles.summaryStrong}>
-                  {getFullName(accessDetail?.owner) || "-/-"}
-                </span>
+                {getAccessHeadline(accessDetail)}
               </p>
               <p className={styles.summaryDate}>
-                {formatDetailDate(
-                  accessDetail?.in_at || accessDetail?.begin_at,
-                )}
+                {unitLabel} · {formatDetailDate(startedAt)}
               </p>
             </div>
           </section>
 
-          <section className={styles.sectionBlock}>
-            <p className={styles.sectionTitle}>Detalles del acceso</p>
-            <div className={styles.detailsGrid}>
-              <div className={styles.rowLabel}>Visitante</div>
-              <div className={styles.rowValue}>
-                <div className={styles.personValue}>
-                  <Avatar
-                    name={getFullName(accessDetail?.visit)}
-                    src={getEntityAvatar(accessDetail?.visit)}
-                    w={24}
-                    h={24}
-                  />
-                  <span>{getFullName(accessDetail?.visit) || "-/-"}</span>
-                </div>
-              </div>
-              <div className={styles.rowLabel}>C.I.</div>
-              <div className={styles.rowValue}>
-                {accessDetail?.visit?.ci || "-/-"}
-              </div>
-              <div className={styles.rowLabel}>Estado</div>
-              <div className={styles.rowValue}>{getStatus()}</div>
-              <div className={styles.rowLabel}>Tipo de acceso</div>
-              <div className={styles.rowValue}>{getTypeAccess()}</div>
-              <div className={styles.rowLabel}>Ingreso</div>
-              <div className={styles.rowValue}>
-                {formatDetailDate(accessDetail?.in_at)}
-              </div>
-              <div className={styles.rowLabel}>Salida</div>
-              <div className={styles.rowValue}>
-                {formatDetailDate(accessDetail?.out_at)}
-              </div>
-              <div className={styles.rowLabel}>Guardia de ingreso</div>
-              <div className={styles.rowValue}>
-                <div className={styles.personValue}>
-                  <Avatar
-                    name={getFullName(accessDetail?.guardia)}
-                    src={getEntityAvatar(accessDetail?.guardia)}
-                    w={24}
-                    h={24}
-                  />
-                  <span>{getFullName(accessDetail?.guardia) || "-/-"}</span>
-                </div>
-              </div>
-              <div className={styles.rowLabel}>Guardia de salida</div>
-              <div className={styles.rowValue}>
-                {accessDetail?.out_guard ? (
-                  <div className={styles.personValue}>
-                    <Avatar
-                      name={getFullName(accessDetail?.out_guard)}
-                      src={getEntityAvatar(accessDetail?.out_guard)}
-                      w={24}
-                      h={24}
-                    />
-                    <span>{getFullName(accessDetail?.out_guard) || "-/-"}</span>
-                  </div>
-                ) : (
-                  "-/-"
-                )}
-              </div>
-              <div className={styles.rowLabel}>Observación de ingreso</div>
-              <div className={styles.rowValue}>
-                {accessDetail?.obs_in || "-/-"}
-              </div>
-              <div className={styles.rowLabel}>Observación de salida</div>
-              <div className={styles.rowValue}>
-                {accessDetail?.obs_out || "-/-"}
-              </div>
+          <section className={styles.sectionCard}>
+            <p className={styles.sectionTitle}>Resumen</p>
+            <div className={styles.factsGrid}>
+              <FactCard
+                label={type === "T" ? "Taxista" : "Visitante"}
+                value={subjectName}
+              />
+              <FactCard
+                label="Documento"
+                value={subject?.ci ? `C.I. ${subject.ci}` : "-/-"}
+              />
+              <FactCard
+                label="Residente destino"
+                value={getEntityName(owner) || "-/-"}
+              />
+              <FactCard label="Unidad" value={unitLabel} />
+              <FactCard
+                label="Estado"
+                value={<Badge label={statusInfo.label} tone={statusInfo.tone} />}
+              />
+              <FactCard label="Movimiento" value={movementMode} />
+              {accessDetail?.plate ? (
+                <FactCard label="Placa" value={accessDetail.plate} />
+              ) : null}
+              {accessType === "P" ? (
+                <FactCard
+                  label="Tipo de pedido"
+                  value={accessDetail?.other?.other_type?.name || "-/-"}
+                />
+              ) : null}
             </div>
           </section>
 
-          {accessDevices.length > 0 && (
-            <>
-              <div className={styles.separator} />
-              <section className={styles.sectionBlock}>
-                <p className={styles.sectionTitle}>Dispositivos de registro</p>
-                <div className={styles.devicesContainer}>
-                  {accessDevices.map((group: any, idx: number) => (
-                    <div
-                      className={styles.deviceCard}
-                      key={(group?.guard_id || "guard") + idx}
-                    >
-                      <div className={styles.deviceHeader}>
-                        <span className={styles.deviceGuard}>
-                          {group?.guard_name || "Guardia"}
-                        </span>
-                      </div>
-                      {(group?.devices || []).map((dev: any, i: number) => (
-                        <div
-                          className={styles.deviceBlock}
-                          key={`${group?.guard_id || "g"}-d-${i}`}
-                        >
-                          <div className={styles.detailsGrid}>
-                            <div className={styles.rowLabel}>Dispositivo</div>
-                            <div className={styles.rowValue}>
-                              <div className={styles.deviceNameWrap}>
-                                <span className={styles.deviceIcon}>
-                                  <IconPhone size={14} color="var(--cAccent)" />
-                                </span>
-                                <span>{dev?.device_name || "Dispositivo"}</span>
-                              </div>
-                            </div>
-                            <div className={styles.rowLabel}>
-                              Marca / modelo
-                            </div>
-                            <div className={styles.rowValue}>
-                              {(dev?.brand || "-/-") +
-                                " / " +
-                                (dev?.model || "-/-")}
-                            </div>
-                            <div className={styles.rowLabel}>Sistema</div>
-                            <div className={styles.rowValue}>
-                              {(dev?.os || "-/-") +
-                                " " +
-                                (dev?.os_version || "")}
-                            </div>
-                            <div className={styles.rowLabel}>Red</div>
-                            <div className={styles.rowValue}>
-                              {"IP " +
-                                (dev?.ip_address || "-/-") +
-                                " · " +
-                                (dev?.carrier || "-/-")}
-                            </div>
-                            <div className={styles.rowLabel}>App</div>
-                            <div className={styles.rowValue}>
-                              {"v" +
-                                (dev?.app_version || "-/-") +
-                                " (" +
-                                (dev?.build_number || "-/-") +
-                                ")"}
-                            </div>
-                            <div className={styles.rowLabel}>Emulador</div>
-                            <div className={styles.rowValue}>
-                              {dev?.is_emulator ? "Sí" : "No"}
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                      <div className={styles.actionList}>
-                        {(group?.actions || []).map(
-                          (action: any, i: number) => (
-                            <div
-                              className={styles.actionRow}
-                              key={`${group?.guard_id || "g"}-a-${i}`}
-                            >
-                              <span className={styles.actionBadge}>
-                                {getActionNameEs(action?.action_name)}
-                              </span>
-                              <span className={styles.actionText}>
-                                {(action?.description || "Sin descripción") +
-                                  " · " +
-                                  formatDetailDate(action?.date_at)}
-                              </span>
-                            </div>
-                          ),
-                        )}
-                      </div>
+          <section className={styles.sectionCard}>
+            <p className={styles.sectionTitle}>Movimiento</p>
+            {timelineItems.length > 0 ? (
+              <div className={styles.timeline}>
+                {timelineItems.map((entry) => (
+                  <div
+                    className={styles.timelineItem}
+                    key={`${entry.label}-${entry.date}`}
+                  >
+                    <div className={styles.timelineHead}>
+                      <span className={styles.timelineLabel}>{entry.label}</span>
+                      <span className={styles.timelineDate}>{entry.date}</span>
                     </div>
-                  ))}
-                </div>
-              </section>
-            </>
-          )}
-
-          {images.length > 0 && (
-            <>
-              <div className={styles.separator} />
-              <section className={styles.sectionBlock}>
-                <p className={styles.sectionTitle}>Imágenes</p>
-                <div className={styles.imagesCarousel}>
-                  {showControls && (
-                    <button
-                      className={styles.carouselBtn}
-                      onClick={() =>
-                        rowRef.current?.scrollBy({
-                          left: -200,
-                          behavior: "smooth",
-                        })
-                      }
-                    >
-                      <IconArrowLeft color="var(--cWhite)" />
-                    </button>
-                  )}
-                  <div className={styles.imagesRow} ref={rowRef}>
-                    {images.map((src, i) => (
-                      <Image
-                        key={src + i}
-                        src={src}
-                        alt="img"
-                        h={90}
-                        w={120}
-                        expandable
-                        square
-                      />
-                    ))}
+                    {entry.meta ? (
+                      <p className={styles.timelineMeta}>{entry.meta}</p>
+                    ) : null}
                   </div>
-                  {showControls && (
-                    <button
-                      className={styles.carouselBtn}
-                      onClick={() =>
-                        rowRef.current?.scrollBy({
-                          left: 200,
-                          behavior: "smooth",
-                        })
-                      }
-                    >
-                      <IconArrowRight color="var(--cWhite)" />
-                    </button>
-                  )}
-                </div>
-              </section>
-            </>
-          )}
+                ))}
+              </div>
+            ) : (
+              <div className={styles.emptyCard}>
+                Todavia no hay movimientos registrados para este acceso.
+              </div>
+            )}
+          </section>
+
+          <section className={styles.sectionCard}>
+            <p className={styles.sectionTitle}>Fotos</p>
+            {imageGroups.length > 0 ? (
+              <div className={styles.galleryStack}>
+                {imageGroups.map((group) => (
+                  <GalleryGroup
+                    key={group.key}
+                    title={group.title}
+                    images={group.images}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className={styles.emptyCard}>
+                No se registraron imagenes para este detalle.
+              </div>
+            )}
+          </section>
+
+          <section className={styles.sectionCard}>
+            <p className={styles.sectionTitle}>Registro tecnico</p>
+            {deviceItems.length > 0 ? (
+              <div className={styles.deviceGrid}>
+                {deviceItems.map((device, index) => (
+                  <div
+                    className={styles.deviceCard}
+                    key={`${device?.device_name || "device"}-${index}`}
+                  >
+                    <div className={styles.deviceTitleRow}>
+                      <div className={styles.deviceTitleWrap}>
+                        <span className={styles.deviceIcon}>
+                          <IconPhone size={14} color="var(--cAccent)" />
+                        </span>
+                        <div>
+                          <p className={styles.deviceName}>
+                            {device?.device_name || "Dispositivo"}
+                          </p>
+                          <p className={styles.deviceMeta}>
+                            {(device?.brand || "-/-") +
+                              " / " +
+                              (device?.model || "-/-")}
+                          </p>
+                        </div>
+                      </div>
+                      {device?.guardNames?.length > 0 ? (
+                        <span className={styles.guardText}>
+                          {device.guardNames.join(", ")}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className={styles.factsGrid}>
+                      <FactCard
+                        label="Sistema"
+                        value={`${device?.os || "-/-"} ${
+                          device?.os_version || ""
+                        }`.trim()}
+                      />
+                      <FactCard
+                        label="Red"
+                        value={`IP ${device?.ip_address || "-/-"}${
+                          device?.carrier && device?.carrier !== "unknown"
+                            ? ` · ${device.carrier}`
+                            : ""
+                        }`}
+                      />
+                      <FactCard
+                        label="App"
+                        value={`v${device?.app_version || "-/-"} (${
+                          device?.build_number || "-/-"
+                        })`}
+                      />
+                      <FactCard
+                        label="Emulador"
+                        value={device?.is_emulator ? "Si" : "No"}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className={styles.emptyCard}>
+                No se registraron dispositivos para este detalle.
+              </div>
+            )}
+
+            {actionItems.length > 0 ? (
+              <div className={styles.actionList}>
+                {actionItems.map((action) => (
+                  <div className={styles.actionItem} key={action._key}>
+                    <Badge
+                      label={action?.action_name === "Out" ? "Salida" : "Entrada"}
+                      tone={action?.action_name === "Out" ? "info" : "success"}
+                    />
+                    <div>
+                      <p className={styles.actionText}>
+                        {action?.description || "Sin descripcion"}
+                      </p>
+                      <p className={styles.actionMeta}>
+                        {[
+                          action?.guardName || "",
+                          action?.deviceName || "",
+                          formatDetailDate(action?.date_at),
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </section>
         </div>
       </LoadingScreen>
     </DetailModal>

--- a/src/modulos/Activities/AccessTab/RenderView/RenderView.module.css
+++ b/src/modulos/Activities/AccessTab/RenderView/RenderView.module.css
@@ -1,306 +1,819 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   width: 100%;
   color: var(--cWhite);
 }
 
 .modalTitle {
-  font-size: 20px;
-  font-weight: 700;
-  line-height: 1.1;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
+  font-size: 20px;
+  line-height: 1.1;
+  font-weight: 700;
 }
 
 .modalTitleMain {
-  color: #e0e8f1;
+  color: var(--cWhite);
 }
 
 .modalTitleId {
-  color: #d6ffef66;
+  color: var(--cWhiteV1);
 }
 
-.summaryCard {
-  display: flex;
-  align-items: center;
+.heroCard,
+.sectionCard {
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSection);
+  border-radius: 18px;
+}
+
+.heroCard {
+  display: grid;
+  grid-template-columns: auto 1fr;
   gap: 16px;
-  padding: 16px;
-  background-color: #12151999;
-  border-radius: 16px;
-  border: 1px solid #d7fff014;
+  padding: 18px;
+  align-items: flex-start;
 }
 
-.summaryIcon {
-  width: 56px;
-  height: 56px;
-  border-radius: 999px;
+.heroBody {
   display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.heroBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.heroTitle {
+  font-size: 18px;
+  line-height: 1.35;
+  font-weight: 600;
+  color: var(--cWhite);
+}
+
+.heroMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--cWhiteV1);
+  font-size: 13px;
+}
+
+.heroMeta > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: #1a1f2499;
-  border: 1.2px solid rgba(0, 227, 140, 0.35);
-  box-shadow: 0 0 40px 4px #00e38c29;
-  flex-shrink: 0;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  white-space: nowrap;
 }
 
-.summaryTextWrap {
+.toneSuccess {
+  color: #7ee2a8;
+  background: rgba(52, 168, 83, 0.14);
+  border-color: rgba(52, 168, 83, 0.28);
+}
+
+.toneDanger {
+  color: #ff9299;
+  background: rgba(228, 96, 85, 0.14);
+  border-color: rgba(228, 96, 85, 0.26);
+}
+
+.toneWarning {
+  color: #f4cb65;
+  background: rgba(233, 176, 30, 0.14);
+  border-color: rgba(233, 176, 30, 0.24);
+}
+
+.toneInfo {
+  color: #8eb8ff;
+  background: rgba(66, 133, 250, 0.14);
+  border-color: rgba(66, 133, 250, 0.24);
+}
+
+.toneAccent {
+  color: var(--cAccent);
+  background: rgba(0, 227, 140, 0.12);
+  border-color: rgba(0, 227, 140, 0.24);
+}
+
+.sectionCard {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sectionTitle {
+  font-size: 15px;
+  line-height: 1.2;
+  font-weight: 600;
+  color: var(--cWhite);
+}
+
+.infoTable {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--cModalBorder);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--cModalSurface);
+}
+
+.infoRow {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  border-bottom: 1px solid var(--cModalDivider);
+}
+
+.infoRow:last-child {
+  border-bottom: 0;
+}
+
+.infoKey {
+  padding: 9px 12px;
+  border-right: 1px solid var(--cModalDivider);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--cWhiteV1);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.infoContent {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 8px 12px;
+  color: var(--cWhite);
+  font-size: 13px;
+  min-width: 0;
+}
+
+.personInline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.personInlineMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.personInlineTitle {
+  color: var(--cWhite);
+  font-size: 13px;
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.personInlineSubtitle {
+  color: var(--cWhiteV1);
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.personGrid,
+.factsGrid,
+.deviceGrid,
+.relatedGrid {
+  display: grid;
+  gap: 12px;
+}
+
+.personGrid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.factsGrid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.deviceGrid {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.personCard,
+.infoCard,
+.emptyCard,
+.deviceCard,
+.galleryGroup,
+.relatedCard,
+.relatedColumn {
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSurface);
+  border-radius: 14px;
+}
+
+.personCard,
+.infoCard,
+.emptyCard,
+.deviceCard,
+.galleryGroup {
+  padding: 14px;
+}
+
+.personCard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.personLabel,
+.infoLabel,
+.galleryCount,
+.relatedSubtitle,
+.timelineMeta,
+.timelineNote,
+.actionMeta,
+.deviceSubtitle,
+.deviceGuardList {
+  color: var(--cWhiteV1);
+}
+
+.personLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.personCardBody {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.personMeta {
   display: flex;
   flex-direction: column;
   gap: 4px;
   min-width: 0;
 }
 
-.summaryTitle {
-  font-size: 16px;
-  line-height: 1.4;
+.personName,
+.relatedTitle,
+.deviceTitle,
+.timelineLabel,
+.galleryTitle {
+  color: var(--cWhite);
+  font-weight: 600;
+}
+
+.personName,
+.relatedTitle,
+.deviceTitle {
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.personSubtitle,
+.infoValue,
+.actionText {
   color: var(--cWhite);
 }
 
-.summaryStrong {
-  font-weight: 600;
-  color: #e0e8f1;
+.personSubtitle,
+.infoValue {
+  font-size: 13px;
+  line-height: 1.45;
 }
 
-.summarySoft {
-  color: #d7fff066;
+.infoCard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 100%;
 }
 
-.summaryDate {
+.infoLabelRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.infoIcon {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 227, 140, 0.1);
+  border: 1px solid rgba(0, 227, 140, 0.2);
+  flex-shrink: 0;
+}
+
+.infoLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.infoValue {
   font-size: 14px;
-  color: #d6ffef66;
+  word-break: break-word;
 }
 
-.sectionBlock {
+.historyList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  position: relative;
+}
+
+.historyItem {
+  display: grid;
+  grid-template-columns: 10px 1fr;
+  gap: 12px;
+  position: relative;
+}
+
+.historyItem::before {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 0;
+  bottom: -10px;
+  width: 2px;
+  background: var(--cModalDivider);
+}
+
+.historyItem:last-child::before {
+  bottom: 0;
+}
+
+.historyDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  margin-top: 5px;
+  border: 0;
+  box-shadow: none;
+  position: relative;
+  z-index: 1;
+  opacity: 1;
+}
+
+.historyDot.toneSuccess {
+  background: var(--cSuccess);
+}
+
+.historyDot.toneDanger {
+  background: var(--cError);
+}
+
+.historyDot.toneWarning {
+  background: var(--cWarning);
+}
+
+.historyDot.toneInfo {
+  background: var(--cInfo);
+}
+
+.historyDot.toneAccent {
+  background: var(--cAccent);
+}
+
+.historyBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px 14px;
+  border: 1px solid var(--cModalBorder);
+  border-radius: 14px;
+  background: var(--cModalSurface);
+  margin-bottom: 10px;
+}
+
+.historyItem:last-child .historyBody {
+  margin-bottom: 0;
+}
+
+.historySentence {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--cWhiteV1);
+}
+
+.historySentence strong,
+.historyMuted strong {
+  color: var(--cWhite);
+  font-weight: 700;
+}
+
+.historyDate {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--cWhiteV3);
+}
+
+.historyMuted {
+  color: var(--cWhiteV1);
+}
+
+.timeline {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.sectionTitle {
-  font-size: 16px;
+.timelineItem {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  gap: 12px;
+}
+
+.timelineDot {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  margin-top: 4px;
+  border: 1px solid transparent;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.02);
+}
+
+.timelineBody {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--cModalDivider);
+}
+
+.timelineItem:last-child .timelineBody {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.timelineHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.timelineLabel {
+  font-size: 14px;
+}
+
+.timelineDate {
+  font-size: 12px;
+  color: var(--cWhiteV1);
+  white-space: nowrap;
+}
+
+.timelineMeta,
+.timelineNote {
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.relatedColumns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.relatedColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+
+.relatedColumnHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.relatedColumnTitle {
+  font-size: 14px;
   font-weight: 600;
   color: var(--cWhite);
 }
 
-.separator {
-  width: 100%;
-  height: 1px;
-  background-color: #d7fff014;
-}
-
-.detailsGrid {
-  display: grid;
-  grid-template-columns: 220px minmax(260px, auto);
-  row-gap: 10px;
-  column-gap: 12px;
-  width: fit-content;
-  max-width: 100%;
-  justify-content: flex-start;
-}
-
-.rowLabel {
-  color: #d6ffef66;
-  font-size: 14px;
-  min-height: 20px;
-  display: flex;
-  align-items: center;
-}
-
-.rowValue {
-  color: var(--cWhite);
-  font-size: 14px;
-  min-height: 20px;
-  display: flex;
-  align-items: center;
-  word-break: break-word;
-}
-
-.personValue {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.personRole {
-  color: #d6ffef66;
-}
-
-.statusBadge {
+.relatedColumnCount {
+  min-width: 26px;
+  height: 26px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--cBackground-foreground);
+  color: var(--cWhiteV1);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
-  padding: 8px 10px;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 12px;
+  font-weight: 600;
 }
 
-.statusOk {
-  background-color: #00e38c14;
-  color: #00e38c;
+.relatedCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  padding: 14px;
+  cursor: pointer;
 }
 
-.statusError {
-  background-color: rgba(244, 63, 94, 0.15);
-  color: #fb7185;
+.relatedCard:hover {
+  border-color: var(--cBorder);
+  background: var(--cBackground-foreground);
 }
 
-.statusPending {
-  background-color: rgba(234, 179, 8, 0.16);
-  color: #facc15;
+.relatedCardHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.relatedAvatarWrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.relatedMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.relatedTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.relatedTimes {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--cWhiteV1);
+}
+
+.galleryStack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.galleryGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.galleryHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.galleryCount {
+  font-size: 12px;
 }
 
 .imagesCarousel {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
   align-items: center;
-  gap: var(--spS);
 }
 
 .imagesRow {
   display: flex;
-  gap: var(--spS);
+  gap: 10px;
   overflow-x: auto;
-  padding: var(--spS) 0;
+  padding: 4px 2px 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--cModalBorder) transparent;
+}
+
+.imagesRow > * {
+  flex: 0 0 auto;
+}
+
+.imagesRow::-webkit-scrollbar {
+  height: 6px;
+}
+
+.imagesRow::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.imagesRow::-webkit-scrollbar-thumb {
+  background: var(--cModalBorder);
+  border-radius: 999px;
 }
 
 .carouselBtn {
-  background: transparent;
-  border: none;
-  padding: 4px;
-  cursor: pointer;
-}
-
-.listContainer {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: var(--spM);
-  width: 100%;
-}
-
-.devicesContainer {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 100%;
-}
-
-.deviceCard {
-  border: 1px solid #d7fff014;
-  background-color: #12151999;
-  border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.deviceHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.deviceGuard {
-  color: var(--cWhite);
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.deviceBlock {
-  border: 1px solid #d7fff014;
-  border-radius: 10px;
-  padding: 10px;
-}
-
-.deviceNameWrap {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.deviceIcon {
-  width: 22px;
-  height: 22px;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSurfaceRaised);
   border-radius: 999px;
-  background: #00e38c14;
-  border: 1px solid #00e38c33;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
 }
 
-.deviceList {
+.carouselBtn:hover {
+  background: var(--cBackground-foreground);
+}
+
+.emptyCard {
+  color: var(--cWhiteV1);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.deviceCard {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
-.deviceRow {
+.deviceHead {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.deviceName {
-  color: var(--cWhite);
-  font-size: 14px;
-  font-weight: 600;
+.deviceTitleWrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-.deviceMeta {
-  color: #d6ffef99;
+.deviceSubtitle,
+.deviceGuardList,
+.actionMeta {
   font-size: 12px;
+  line-height: 1.45;
+}
+
+.deviceGuardList {
+  text-align: right;
+  max-width: 180px;
+}
+
+.deviceFacts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.deviceIcon {
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background: rgba(0, 227, 140, 0.1);
+  border: 1px solid rgba(0, 227, 140, 0.22);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .actionList {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
 }
 
-.actionRow {
+.actionItem {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--cModalBorder);
+  background: var(--cModalSurface);
 }
 
-.actionBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 34px;
-  border-radius: 8px;
-  padding: 4px 6px;
-  background-color: #00e38c14;
-  color: #00e38c;
-  font-size: 12px;
-  font-weight: 600;
+.actionBody {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
 }
 
 .actionText {
-  color: var(--cWhiteV1);
-  font-size: 12px;
+  font-size: 13px;
+  line-height: 1.45;
 }
 
 @media (max-width: 900px) {
   .modalTitle {
-    font-size: 28px;
+    font-size: 18px;
   }
 
-  .sectionTitle {
-    font-size: 24px;
-  }
-
-  .detailsGrid {
+  .heroCard {
     grid-template-columns: 1fr;
-    row-gap: 4px;
-    width: 100%;
   }
 
-  .rowLabel {
-    margin-top: 10px;
+  .timelineHead,
+  .deviceHead,
+  .galleryHeader,
+  .relatedColumnHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .deviceGuardList {
+    text-align: left;
+    max-width: none;
+  }
+
+  .imagesCarousel {
+    grid-template-columns: 1fr;
+  }
+
+  .carouselBtn {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .container {
+    gap: 12px;
+  }
+
+  .heroCard,
+  .sectionCard,
+  .personCard,
+  .infoCard,
+  .emptyCard,
+  .deviceCard,
+  .galleryGroup,
+  .relatedCard,
+  .relatedColumn,
+  .actionItem {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .heroTitle {
+    font-size: 16px;
+  }
+
+  .infoRow {
+    grid-template-columns: 1fr;
+  }
+
+  .infoKey {
+    border-right: 0;
+    border-bottom: 1px solid var(--cModalDivider);
+  }
+
+  .infoContent {
+    min-height: auto;
+  }
+
+  .factsGrid,
+  .deviceFacts,
+  .personGrid,
+  .relatedColumns {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/modulos/Activities/AccessTab/RenderView/RenderView.tsx
+++ b/src/modulos/Activities/AccessTab/RenderView/RenderView.tsx
@@ -1,22 +1,38 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import DetailModal from "@/mk/components/ui/DetailModal/DetailModal";
 import styles from "./RenderView.module.css";
-import { getFullName } from "@/mk/utils/string";
 import { formatToDayFdMYH } from "@/mk/utils/date";
 import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
 import { Image } from "@/mk/components/ui/Image/Image";
 import useAxios from "@/mk/hooks/useAxios";
 import LoadingScreen from "@/mk/components/ui/LoadingScreen/LoadingScreen";
-import Br from "@/components/Detail/Br";
-import ItemList from "@/mk/components/ui/ItemList/ItemList";
 import {
   IconArrowLeft,
   IconArrowRight,
+  IconCalendar,
   IconCheck,
+  IconDelivery,
   IconExpand,
+  IconHome,
   IconPhone,
+  IconTaxi,
+  IconUser,
+  IconVehicle,
 } from "@/components/layout/icons/IconsBiblioteca";
 import ModalAccessExpand from "../ModalAccessExpand/ModalAccessExpand";
+import {
+  collectUniqueImages,
+  flattenAccessDevices,
+  getAccessStatusInfo,
+  getAccessTypeLabel,
+  getEntityAvatar,
+  getEntityGallery,
+  getEntityName,
+  getMovementMode,
+  getRequestActorInfo,
+  getUnitLabel,
+  splitRelatedAccesses,
+} from "../shared/accessDetailUtils";
 
 interface AccessRenderViewProps {
   open: boolean;
@@ -25,20 +41,208 @@ interface AccessRenderViewProps {
   extraData?: any;
 }
 
-const Row = ({
+type Tone = "success" | "danger" | "warning" | "info" | "accent";
+
+const toneClassMap: Record<Tone, string> = {
+  success: styles.toneSuccess,
+  danger: styles.toneDanger,
+  warning: styles.toneWarning,
+  info: styles.toneInfo,
+  accent: styles.toneAccent,
+};
+
+const formatDetailDate = (dateStr: string | null = "") => {
+  const formatted = formatToDayFdMYH(dateStr, true, true, false) || "";
+  if (!formatted) return "-/-";
+  return formatted.replace(/ del (\d{4}) - /, ", $1 - ");
+};
+
+const DetailBadge = ({
+  label,
+  tone,
+}: {
+  label: React.ReactNode;
+  tone: Tone;
+}) => {
+  return (
+    <span className={`${styles.badge} ${toneClassMap[tone]}`}>{label}</span>
+  );
+};
+
+const InfoCard = ({
   label,
   value,
-  valueClassName = "",
+  icon = null,
 }: {
   label: string;
   value: React.ReactNode;
-  valueClassName?: string;
+  icon?: React.ReactNode;
+}) => (
+  <div className={styles.infoCard}>
+    <div className={styles.infoLabelRow}>
+      {icon ? <span className={styles.infoIcon}>{icon}</span> : null}
+      <span className={styles.infoLabel}>{label}</span>
+    </div>
+    <div className={styles.infoValue}>{value || "-/-"}</div>
+  </div>
+);
+
+const AccessRow = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) => (
+  <div className={styles.infoRow}>
+    <div className={styles.infoKey}>{label}</div>
+    <div className={styles.infoContent}>{value || "-/-"}</div>
+  </div>
+);
+
+const PersonValue = ({
+  person,
+  subtitle,
+}: {
+  person: any;
+  subtitle?: React.ReactNode;
 }) => {
+  const personName = getEntityName(person) || "-/-";
+  return (
+    <div className={styles.personInline}>
+      <Avatar name={personName} src={getEntityAvatar(person)} w={28} h={28} />
+      <div className={styles.personInlineMeta}>
+        <p className={styles.personInlineTitle}>{personName}</p>
+        {subtitle ? (
+          <p className={styles.personInlineSubtitle}>{subtitle}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+const appendObservation = (
+  sentence: React.ReactNode,
+  note?: string,
+) => {
+  if (!note) return sentence;
   return (
     <>
-      <div className={styles.rowLabel}>{label}</div>
-      <div className={`${styles.rowValue} ${valueClassName}`}>{value}</div>
+      {sentence}{" "}
+      <span className={styles.historyMuted}>
+        Tambien registró una observación{" "}
+      </span>
+      <strong>"{note}"</strong>.
     </>
+  );
+};
+
+const RelatedAccessCard = ({
+  label,
+  access,
+  onOpen,
+}: {
+  label: string;
+  access: any;
+  onOpen: () => void;
+}) => {
+  const visitor = access?.visit || access?.owner || {};
+  const statusInfo = getAccessStatusInfo(access);
+  return (
+    <button type="button" className={styles.relatedCard} onClick={onOpen}>
+      <div className={styles.relatedCardHead}>
+        <div className={styles.relatedAvatarWrap}>
+          <Avatar
+            name={getEntityName(visitor) || "Sin nombre"}
+            src={getEntityAvatar(visitor)}
+            w={40}
+            h={40}
+          />
+          <div className={styles.relatedMeta}>
+            <p className={styles.relatedTitle}>
+              {getEntityName(visitor) || "Sin nombre"}
+            </p>
+            <p className={styles.relatedSubtitle}>
+              {visitor?.ci ? `C.I. ${visitor.ci}` : "Sin documento"}
+            </p>
+          </div>
+        </div>
+        <IconExpand color="var(--cWhiteV1)" />
+      </div>
+      <div className={styles.relatedTags}>
+        <DetailBadge label={label} tone="accent" />
+        <DetailBadge label={statusInfo.label} tone={statusInfo.tone} />
+      </div>
+      <div className={styles.relatedTimes}>
+        <span>Ingreso: {formatDetailDate(access?.in_at || access?.begin_at)}</span>
+        <span>Salida: {formatDetailDate(access?.out_at)}</span>
+      </div>
+    </button>
+  );
+};
+
+const GalleryGroup = ({
+  title,
+  images,
+}: {
+  title: string;
+  images: string[];
+}) => {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [showControls, setShowControls] = useState(false);
+
+  useEffect(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    const check = () => setShowControls(el.scrollWidth > el.clientWidth + 2);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [images]);
+
+  return (
+    <div className={styles.galleryGroup}>
+      <div className={styles.galleryHeader}>
+        <p className={styles.galleryTitle}>{title}</p>
+        <span className={styles.galleryCount}>{images.length} foto(s)</span>
+      </div>
+      <div className={styles.imagesCarousel}>
+        {showControls ? (
+          <button
+            className={styles.carouselBtn}
+            onClick={() =>
+              rowRef.current?.scrollBy({ left: -240, behavior: "smooth" })
+            }
+          >
+            <IconArrowLeft color="var(--cWhite)" />
+          </button>
+        ) : null}
+        <div className={styles.imagesRow} ref={rowRef}>
+          {images.map((src, index) => (
+            <Image
+              key={`${title}-${src}-${index}`}
+              src={src}
+              alt={title}
+              h={120}
+              w={156}
+              expandable
+              square
+            />
+          ))}
+        </div>
+        {showControls ? (
+          <button
+            className={styles.carouselBtn}
+            onClick={() =>
+              rowRef.current?.scrollBy({ left: 240, behavior: "smooth" })
+            }
+          >
+            <IconArrowRight color="var(--cWhite)" />
+          </button>
+        ) : null}
+      </div>
+    </div>
   );
 };
 
@@ -47,11 +251,14 @@ const RenderView: React.FC<AccessRenderViewProps> = ({
   onClose,
   item,
 }) => {
-  const [openExpand, setOpenExpand]: any = useState({
+  const [openExpand, setOpenExpand] = useState<{
+    open: boolean;
+    id: string | number | null;
+    type: "A" | "T" | "";
+  }>({
     open: false,
     id: null,
     type: "",
-    invitation: null,
   });
 
   const { data } = useAxios(
@@ -66,170 +273,261 @@ const RenderView: React.FC<AccessRenderViewProps> = ({
     true,
   );
 
-  const accessDetail = data?.data?.access || data?.data?.[0] || {};
-  const accessDevices =
+  const accessDetail = data?.data?.access || data?.data?.[0] || item || {};
+  const accessDevicesRaw =
     data?.data?.accessDevices || data?.data?.access_devices || [];
-  const {
-    visit,
-    in_at,
-    out_at,
-    guardia,
-    out_guard,
-    obs_in,
-    obs_out,
-    confirm_at,
-    confirm,
-    owner,
-    accesses,
-    begin_at,
-    plate,
-  } = accessDetail;
-  const accessType = accessDetail?.type || item?.type;
 
-  const getStatus = () => {
-    if (out_at) return "Completado";
-    if (in_at) return "Por salir";
-    if (!confirm_at) return "Por confirmar";
-    if (confirm === "Y") return "Por entrar";
-    return "Rechazado";
-  };
-
-  const typeMap: Record<string, string> = {
-    C: "Sin QR",
-    I: "QR Individual",
-    G: "QR Grupal",
-    F: "QR Frecuente",
-    P: "Pedido",
-    O: "Llave QR",
-  };
-
-  const getTypeAccess = (type: string, param: any) => {
-    if (type === "P") return "Pedido/" + param?.other?.other_type?.name;
-    return typeMap[type] || "-/-";
-  };
-
-  const getAcomData = () =>
-    accesses?.filter((it: any) => it.taxi !== "C") || [];
-  const getTaxiData = () =>
-    accesses?.filter((it: any) => it.taxi === "C") || [];
-
-  const cleanUrl = (value: any) => {
-    if (!value) return "";
-    const sanitized = String(value).replace(/[`"']/g, "").trim();
-    if (!sanitized || sanitized.includes("undefined")) return "";
-    return sanitized;
-  };
-
-  const normalizeImageUrls = (arr: any) => {
-    if (!Array.isArray(arr)) return [];
-    return arr.map(cleanUrl).filter(Boolean);
-  };
-
-  const getEntityAvatar = (entity: any) => {
-    const fromAvatar = cleanUrl(entity?.url_avatar);
-    if (fromAvatar) return fromAvatar;
-    const fromArray = normalizeImageUrls(entity?.url_image_a)?.[0];
-    if (fromArray) return fromArray;
-    const fromRear = cleanUrl(entity?.url_image_r);
-    if (fromRear) return fromRear;
-    return "";
-  };
-
-  const PersonValue = ({
-    person,
-    text,
-    roleText = "",
-  }: {
-    person: any;
-    text: string;
-    roleText?: string;
-  }) => {
-    const src = getEntityAvatar(person);
-    return (
-      <div className={styles.personValue}>
-        <Avatar name={text} src={src} w={24} h={24} />
-        <span>
-          {text || "-/-"}
-          {roleText ? (
-            <span className={styles.personRole}> {roleText}</span>
-          ) : null}
-        </span>
-      </div>
-    );
-  };
-
-  const accessImages = [
-    ...normalizeImageUrls((accessDetail as any)?.url_image_p),
-    ...normalizeImageUrls((accessDetail as any)?.url_image),
-  ];
-
-  const entityImages =
-    accessType === "O"
-      ? [
-          ...normalizeImageUrls((owner as any)?.url_image_a),
-          ...normalizeImageUrls((owner as any)?.url_image_r),
-        ]
-      : [
-          ...normalizeImageUrls((visit as any)?.url_image_a),
-          ...normalizeImageUrls((visit as any)?.url_image_r),
-        ];
-
-  const images = Array.from(
-    new Set([...(entityImages || []), ...(accessImages || [])]),
+  const accessType = accessDetail?.type || item?.type || "";
+  const owner = accessDetail?.owner || item?.owner || {};
+  const visit = accessDetail?.visit || item?.visit || {};
+  const statusInfo = getAccessStatusInfo(accessDetail);
+  const approvalInfo = getRequestActorInfo(accessDetail);
+  const { companions, taxis } = splitRelatedAccesses(accessDetail);
+  const technicalData = useMemo(
+    () => flattenAccessDevices(accessDevicesRaw),
+    [accessDevicesRaw],
   );
-  const rowRef = React.useRef<HTMLDivElement>(null);
-  const [showControls, setShowControls] = useState(false);
 
-  useEffect(() => {
-    const el = rowRef.current;
-    if (!el) return;
-    const check = () => setShowControls(el.scrollWidth > el.clientWidth + 2);
-    check();
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [images]);
-
-  const displayName =
-    accessType === "O" ? getFullName(owner) : getFullName(visit);
-  const displayCi = accessType === "O" ? owner?.ci : visit?.ci;
-  const status = getStatus();
-  const statusClassName =
-    status === "Completado"
-      ? styles.statusOk
-      : status === "Rechazado"
-        ? styles.statusError
-        : styles.statusPending;
+  const subject = accessType === "O" ? owner : visit;
+  const subjectName = getEntityName(subject) || "Sin nombre";
+  const subjectDocument = accessType === "O" ? owner?.ci : visit?.ci;
+  const unitLabel = getUnitLabel(owner);
+  const movementMode = getMovementMode(accessDetail);
+  const approvalSummary = approvalInfo.actorName
+    ? `${approvalInfo.actorName}${
+        approvalInfo.roleText ? ` (${approvalInfo.roleText})` : ""
+      }`
+    : "-/-";
   const approvalLabel =
-    accessType === "C"
-      ? confirm === "N"
-        ? "Rechazado por"
-        : "Aprobado por"
-      : "Aprobado por";
-  const approvedByGuard =
-    confirm == "G" || accessDetail?.rejected_guard_id !== null;
-  const approvalName = approvedByGuard
-    ? getFullName(guardia)
-    : getFullName(owner);
-  const approvalRole = approvedByGuard ? "(Guardia)" : "(Propietario)";
-  const reasonLabel =
-    accessDetail?.rejected_guard_id !== null
-      ? accessDetail?.confirm !== "N"
-        ? "Motivo de aprobación"
-        : "Motivo de rechazo"
-      : accessDetail?.confirm === "N"
-        ? "Motivo de rechazo"
-        : "Motivo";
-  const getActionNameEs = (actionName: string) => {
-    if (actionName === "In") return "Entrada";
-    if (actionName === "Out") return "Salida";
-    return actionName || "-/-";
-  };
-  const formatDetailDate = (dateStr: string | null = "") => {
-    const formatted = formatToDayFdMYH(dateStr, true, true, false) || "";
-    if (!formatted) return "-/-";
-    return formatted.replace(/ del (\d{4}) - /, ", $1 - ");
-  };
+    statusInfo.tone === "danger" ? "Rechazado por" : "Validado por";
+  const guardInName = getEntityName(accessDetail?.guardia);
+  const guardOutName = getEntityName(accessDetail?.out_guard);
+  const actorRolePrefix =
+    approvalInfo.roleText === "Guardia" ? "El guardia" : "El residente";
+  const infoRows = [
+    {
+      label: accessType === "O" ? "Residente" : "Visitante",
+      value: (
+        <PersonValue
+          person={subject}
+          subtitle={
+            subjectDocument
+              ? `C.I. ${subjectDocument}`
+              : "Sin documento registrado"
+          }
+        />
+      ),
+    },
+    accessType !== "O"
+      ? {
+          label: "Residente destino",
+          value: <PersonValue person={owner} subtitle={unitLabel} />,
+        }
+      : null,
+    { label: "Unidad", value: unitLabel },
+    {
+      label: "Tipo de acceso",
+      value: getAccessTypeLabel(accessType, accessDetail),
+    },
+    {
+      label: "Estado",
+      value: <DetailBadge label={statusInfo.label} tone={statusInfo.tone} />,
+    },
+    { label: "Movimiento", value: movementMode },
+    { label: approvalLabel, value: approvalSummary },
+    { label: "Fecha de solicitud", value: formatDetailDate(accessDetail?.begin_at) },
+    { label: "Ingreso", value: formatDetailDate(accessDetail?.in_at) },
+    { label: "Salida", value: formatDetailDate(accessDetail?.out_at) },
+    {
+      label: "Guardia de ingreso",
+      value: guardInName ? <PersonValue person={accessDetail?.guardia} /> : "-/-",
+    },
+    {
+      label: "Guardia de salida",
+      value: guardOutName ? <PersonValue person={accessDetail?.out_guard} /> : "-/-",
+    },
+    accessDetail?.plate
+      ? {
+          label: "Placa",
+          value: accessDetail.plate,
+        }
+      : null,
+    accessType === "G"
+      ? {
+          label: "Evento",
+          value: accessDetail?.invitation?.title || "-/-",
+        }
+      : null,
+    accessType === "G"
+      ? {
+          label: "Invitados del QR",
+          value: accessDetail?.invitation?.guests?.length || 0,
+        }
+      : null,
+    accessType === "P"
+      ? {
+          label: "Tipo de pedido",
+          value: accessDetail?.other?.other_type?.name || "-/-",
+        }
+      : null,
+    accessDetail?.obs_confirm
+      ? {
+          label:
+            statusInfo.tone === "danger"
+              ? "Motivo de rechazo"
+              : "Observacion",
+          value: accessDetail.obs_confirm,
+        }
+      : null,
+  ].filter(Boolean) as Array<{ label: string; value: React.ReactNode }>;
+
+  const historyItems = [
+    accessDetail?.begin_at
+      ? {
+          date: formatDetailDate(accessDetail.begin_at),
+          sentence:
+            accessType === "P"
+              ? (
+                  <>
+                    Se registró un pedido para{" "}
+                    <strong>{getEntityName(owner) || "el residente"}</strong> en{" "}
+                    <strong>{unitLabel}</strong>.
+                  </>
+                )
+              : accessType === "O"
+                ? (
+                    <>
+                      El residente{" "}
+                      <strong>{getEntityName(owner) || subjectName}</strong> inició
+                      un acceso con llave QR para <strong>{unitLabel}</strong>.
+                    </>
+                  )
+                : (
+                    <>
+                      Se registró la solicitud de acceso de{" "}
+                    <strong>{subjectName}</strong> para{" "}
+                    <strong>{unitLabel}</strong>.
+                  </>
+                ),
+          note: accessDetail?.obs_confirm || "",
+          tone: "warning" as Tone,
+        }
+      : null,
+    accessDetail?.confirm_at
+      ? {
+          date: formatDetailDate(accessDetail.confirm_at),
+          sentence: approvalInfo.actorName ? (
+            accessDetail?.confirm === "N" || accessDetail?.rejected_guard_id ? (
+              <>
+                {actorRolePrefix} <strong>{approvalInfo.actorName}</strong>{" "}
+                rechazó el acceso de <strong>{subjectName}</strong> para{" "}
+                <strong>{unitLabel}</strong>.
+              </>
+            ) : (
+              <>
+                {actorRolePrefix} <strong>{approvalInfo.actorName}</strong>{" "}
+                validó el acceso de <strong>{subjectName}</strong> para{" "}
+                <strong>{unitLabel}</strong>.
+              </>
+            )
+          ) : accessDetail?.confirm === "N" || accessDetail?.rejected_guard_id ? (
+            <>
+              Se rechazó el acceso de <strong>{subjectName}</strong> para{" "}
+              <strong>{unitLabel}</strong>.
+            </>
+          ) : (
+            <>
+              Se validó el acceso de <strong>{subjectName}</strong> para{" "}
+              <strong>{unitLabel}</strong>.
+            </>
+          ),
+          note: accessDetail?.obs_confirm || "",
+          tone:
+            accessDetail?.confirm === "N" || accessDetail?.rejected_guard_id
+              ? ("danger" as Tone)
+              : ("accent" as Tone),
+        }
+      : null,
+    accessDetail?.in_at
+      ? {
+          date: formatDetailDate(accessDetail.in_at),
+          sentence: guardInName ? (
+            <>
+              El guardia <strong>{guardInName}</strong> registró el ingreso de{" "}
+              <strong>{subjectName}</strong> en <strong>{unitLabel}</strong>.
+            </>
+          ) : (
+            <>
+              Se registró el ingreso de <strong>{subjectName}</strong> en{" "}
+              <strong>{unitLabel}</strong>.
+            </>
+          ),
+          note: accessDetail?.obs_in || "",
+          tone: "success" as Tone,
+        }
+      : null,
+    accessDetail?.out_at
+      ? {
+          date: formatDetailDate(accessDetail.out_at),
+          sentence: guardOutName ? (
+            <>
+              El guardia <strong>{guardOutName}</strong> registró la salida de{" "}
+              <strong>{subjectName}</strong>.
+            </>
+          ) : (
+            <>
+              Se registró la salida de <strong>{subjectName}</strong>.
+            </>
+          ),
+          note: accessDetail?.obs_out || "",
+          tone: "info" as Tone,
+        }
+      : null,
+  ].filter(Boolean) as Array<{
+    date: string;
+    sentence: React.ReactNode;
+    note?: string;
+    tone?: Tone;
+  }>;
+
+  const imageGroups = useMemo(() => {
+    const groups = [
+      {
+        key: "subject",
+        title: accessType === "O" ? "Fotos del residente" : "Fotos del visitante",
+        images:
+          accessType === "O" ? getEntityGallery(owner) : getEntityGallery(visit),
+      },
+      {
+        key: "host",
+        title: "Fotos del residente destino",
+        images: accessType === "O" ? [] : getEntityGallery(owner),
+      },
+      {
+        key: "access",
+        title: "Fotos del registro",
+        images: collectUniqueImages(
+          accessDetail?.url_image_p,
+          accessDetail?.url_image,
+        ),
+      },
+    ];
+
+    const used = new Set<string>();
+    return groups
+      .map((group) => ({
+        ...group,
+        images: group.images.filter((image) => {
+          if (used.has(image)) return false;
+          used.add(image);
+          return true;
+        }),
+      }))
+      .filter((group) => group.images.length > 0);
+  }, [accessDetail, accessType, owner, visit]);
+
+  const actionItems = technicalData.actions;
+  const deviceItems = technicalData.devices;
 
   return (
     <>
@@ -246,417 +544,253 @@ const RenderView: React.FC<AccessRenderViewProps> = ({
         }
         buttonText=""
         buttonCancel=""
-        maxWidth={840}
+        maxWidth={980}
       >
         <LoadingScreen
           onlyLoading={Object.keys(accessDetail).length === 0}
           type="CardSkeleton"
         >
           <div className={styles.container}>
-            <section className={styles.summaryCard}>
-              <div className={styles.summaryIcon}>
-                <IconCheck size={24} color="var(--cAccent)" />
+            <section className={styles.sectionCard}>
+              <div className={styles.sectionHeader}>
+                <p className={styles.sectionTitle}>Informacion del acceso</p>
               </div>
-              <div className={styles.summaryTextWrap}>
-                <p className={styles.summaryTitle}>
-                  <span className={styles.summaryStrong}>
-                    {displayName || "Sin nombre"}
-                  </span>{" "}
-                  <span className={styles.summarySoft}>
-                    {accessType === "P" ? "entregó a " : "visitó a "}
-                  </span>
-                  <span className={styles.summaryStrong}>
-                    {getFullName(owner) || "-/-"}
-                  </span>{" "}
-                  <span className={styles.summarySoft}>de la </span>
-                  <span className={styles.summaryStrong}>
-                    {owner?.dpto?.[0]?.nro
-                      ? `Casa ${owner?.dpto?.[0]?.nro}`
-                      : "Unidad -/-"}
-                  </span>
-                </p>
-                <p className={styles.summaryDate}>
-                  {formatDetailDate(in_at || begin_at)}
-                </p>
+              <div className={styles.infoTable}>
+                {infoRows.map((row) => (
+                  <AccessRow key={row.label} label={row.label} value={row.value} />
+                ))}
               </div>
             </section>
 
-            <section className={styles.sectionBlock}>
-              <p className={styles.sectionTitle}>Detalles del acceso</p>
-              <div className={styles.detailsGrid}>
-                <Row
-                  label="Estado"
-                  value={
-                    <span
-                      className={`${styles.statusBadge} ${statusClassName}`}
+            <section className={styles.sectionCard}>
+              <div className={styles.sectionHeader}>
+                <p className={styles.sectionTitle}>Historial de actividad</p>
+              </div>
+
+              {historyItems.length > 0 ? (
+                <div className={styles.historyList}>
+                  {historyItems.map((historyItem) => (
+                    <div
+                      className={styles.historyItem}
+                      key={`${historyItem.date}-${String(historyItem.tone)}`}
                     >
-                      {status}
-                    </span>
-                  }
-                />
-                <Row
-                  label="Tipo de acceso"
-                  value={getTypeAccess(accessType, accessDetail)}
-                />
-                {accessType == "G" && (
-                  <Row
-                    label="Evento"
-                    value={item?.invitation?.title || "-/-"}
-                  />
-                )}
-                {accessType == "G" && (
-                  <Row
-                    label="Cantidad de invitados"
-                    value={accessDetail?.invitation?.guests?.length || "-/-"}
-                  />
-                )}
-                <Row
-                  label={
-                    accessType == "C" && confirm == "N"
-                      ? "Hora y fecha de petición"
-                      : "Hora y fecha de ingreso"
-                  }
-                  value={
-                    accessType == "C" && confirm == "N"
-                      ? formatDetailDate(begin_at)
-                      : formatDetailDate(in_at)
-                  }
-                />
-                <Row
-                  label={
-                    accessType == "C" && confirm == "N"
-                      ? "Hora y fecha de rechazo"
-                      : "Hora y fecha de salida"
-                  }
-                  value={
-                    accessType == "C" && confirm == "N"
-                      ? formatDetailDate(confirm_at)
-                      : formatDetailDate(out_at)
-                  }
-                />
-                {accessType !== "O" && (
-                  <Row
-                    label={accessType != "P" ? "Visitó a" : "Entregó a"}
-                    value={
-                      <PersonValue
-                        person={item?.owner || owner}
-                        text={getFullName(item?.owner || owner)}
-                      />
-                    }
-                  />
-                )}
-                <Row label="Unidad" value={owner?.dpto?.[0]?.nro || "-/-"} />
-                <Row
-                  label="Guardia de ingreso"
-                  value={
-                    <PersonValue person={guardia} text={getFullName(guardia)} />
-                  }
-                />
-                <Row
-                  label="Guardia de salida"
-                  value={
-                    out_at ? (
-                      <PersonValue
-                        person={out_guard || guardia}
-                        text={getFullName(out_guard || guardia)}
-                      />
-                    ) : (
-                      "-/-"
-                    )
-                  }
-                />
-                <Row label="Observación de entrada" value={obs_in || "-/-"} />
-                <Row label="Observación de salida" value={obs_out || "-/-"} />
-                <Row
-                  label={approvalLabel}
-                  value={
-                    approvalName ? (
-                      <PersonValue
-                        person={approvedByGuard ? guardia : owner}
-                        text={approvalName}
-                        roleText={approvalRole}
-                      />
-                    ) : (
-                      "-/-"
-                    )
-                  }
-                />
-                <Row
-                  label={reasonLabel}
-                  value={accessDetail?.obs_confirm || "-/-"}
-                />
-              </div>
-            </section>
-
-            <div className={styles.separator} />
-
-            <section className={styles.sectionBlock}>
-              <p className={styles.sectionTitle}>Visitante</p>
-              <div className={styles.detailsGrid}>
-                <Row label="Nombre completo" value={displayName || "-/-"} />
-                <Row label="Nro de documento" value={displayCi || "-/-"} />
-                <Row
-                  label="Método de ingreso"
-                  value={
-                    plate || getTaxiData().length > 0 ? "Vehículo" : "Peatonal"
-                  }
-                />
-                <Row label="Placa" value={plate || "-/-"} />
-                <Row
-                  label="Tipo de usuario"
-                  value={accessType === "O" ? "Residente" : "Visitante"}
-                />
-              </div>
-            </section>
-
-            <div className={styles.separator} />
-
-            <section className={styles.sectionBlock}>
-              <p className={styles.sectionTitle}>Ingreso</p>
-              <div className={styles.detailsGrid}>
-                <Row label="Nombre completo" value={displayName || "-/-"} />
-                <Row
-                  label="Tipo de acceso"
-                  value={getTypeAccess(accessType, accessDetail)}
-                />
-                <Row
-                  label="Motivo"
-                  value={accessDetail?.obs_confirm || "-/-"}
-                />
-                <Row
-                  label="Tipo de usuario"
-                  value={accessType === "O" ? "Residente" : "Visitante"}
-                />
-              </div>
-            </section>
-
-            {accessDevices.length > 0 && (
-              <>
-                <div className={styles.separator} />
-                <section className={styles.sectionBlock}>
-                  <p className={styles.sectionTitle}>
-                    Dispositivos de registro
-                  </p>
-                  <div className={styles.devicesContainer}>
-                    {accessDevices.map((group: any, idx: number) => (
                       <div
-                        className={styles.deviceCard}
-                        key={(group?.guard_id || "guard") + idx}
-                      >
-                        <div className={styles.deviceHeader}>
-                          <span className={styles.deviceGuard}>
-                            {group?.guard_name || "Guardia"}
-                          </span>
-                        </div>
-                        {(group?.devices || []).map((dev: any, i: number) => (
-                          <div
-                            className={styles.deviceBlock}
-                            key={`${group?.guard_id || "g"}-d-${i}`}
-                          >
-                            <div className={styles.detailsGrid}>
-                              <div className={styles.rowLabel}>Dispositivo</div>
-                              <div className={styles.rowValue}>
-                                <div className={styles.deviceNameWrap}>
-                                  <span className={styles.deviceIcon}>
-                                    <IconPhone
-                                      size={14}
-                                      color="var(--cAccent)"
-                                    />
-                                  </span>
-                                  <span>
-                                    {dev?.device_name || "Dispositivo"}
-                                  </span>
-                                </div>
-                              </div>
-                              <div className={styles.rowLabel}>
-                                Marca / modelo
-                              </div>
-                              <div className={styles.rowValue}>
-                                {(dev?.brand || "-/-") +
-                                  " / " +
-                                  (dev?.model || "-/-")}
-                              </div>
-                              <div className={styles.rowLabel}>Sistema</div>
-                              <div className={styles.rowValue}>
-                                {(dev?.os || "-/-") +
-                                  " " +
-                                  (dev?.os_version || "")}
-                              </div>
-                              <div className={styles.rowLabel}>Red</div>
-                              <div className={styles.rowValue}>
-                                {"IP " +
-                                  (dev?.ip_address || "-/-") +
-                                  " · " +
-                                  (dev?.carrier && dev?.carrier !== "unknown"
-                                    ? dev?.carrier
-                                    : "")}
-                              </div>
-                              <div className={styles.rowLabel}>App</div>
-                              <div className={styles.rowValue}>
-                                {"v" +
-                                  (dev?.app_version || "-/-") +
-                                  " (" +
-                                  (dev?.build_number || "-/-") +
-                                  ")"}
-                              </div>
-                              <div className={styles.rowLabel}>Emulador</div>
-                              <div className={styles.rowValue}>
-                                {dev?.is_emulator ? "Sí" : "No"}
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                        <div className={styles.actionList}>
-                          {(group?.actions || []).map(
-                            (action: any, i: number) => (
-                              <div
-                                className={styles.actionRow}
-                                key={`${group?.guard_id || "g"}-a-${i}`}
-                              >
-                                <span className={styles.actionBadge}>
-                                  {getActionNameEs(action?.action_name)}
-                                </span>
-                                <span className={styles.actionText}>
-                                  {(action?.description || "Sin descripción") +
-                                    " · " +
-                                    formatDetailDate(action?.date_at)}
-                                </span>
-                              </div>
-                            ),
+                        className={`${styles.historyDot} ${
+                          toneClassMap[historyItem.tone || "info"]
+                        }`}
+                      ></div>
+                      <div className={styles.historyBody}>
+                        <p className={styles.historySentence}>
+                          {appendObservation(
+                            historyItem.sentence,
+                            historyItem.note,
                           )}
-                        </div>
+                        </p>
+                        <p className={styles.historyDate}>{historyItem.date}</p>
                       </div>
-                    ))}
-                  </div>
-                </section>
-              </>
-            )}
-
-            {images.length > 0 && (
-              <>
-                <div className={styles.separator} />
-                <section className={styles.sectionBlock}>
-                  <p className={styles.sectionTitle}>Imágenes</p>
-                  <div className={styles.imagesCarousel}>
-                    {showControls && (
-                      <button
-                        className={styles.carouselBtn}
-                        onClick={() =>
-                          rowRef.current?.scrollBy({
-                            left: -240,
-                            behavior: "smooth",
-                          })
-                        }
-                      >
-                        <IconArrowLeft color="var(--cWhite)" />
-                      </button>
-                    )}
-                    <div className={styles.imagesRow} ref={rowRef}>
-                      {images.map((src, i) => (
-                        <Image
-                          key={src + i}
-                          src={src}
-                          alt="img"
-                          h={90}
-                          w={120}
-                          expandable
-                          square
-                        />
-                      ))}
                     </div>
-                    {showControls && (
-                      <button
-                        className={styles.carouselBtn}
-                        onClick={() =>
-                          rowRef.current?.scrollBy({
-                            left: 240,
-                            behavior: "smooth",
-                          })
-                        }
-                      >
-                        <IconArrowRight color="var(--cWhite)" />
-                      </button>
-                    )}
-                  </div>
-                </section>
-              </>
-            )}
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.emptyCard}>
+                  Todavia no hay eventos registrados para este acceso.
+                </div>
+              )}
+            </section>
 
-            {getAcomData()?.length > 0 && (
-              <>
-                <Br />
-                <p className={styles.sectionTitle}>Acompañantes</p>
-                <div className={styles.listContainer}>
-                  {getAcomData()?.map((acc: any) => (
-                    <ItemList
-                      variant="V3"
-                      key={acc.id}
-                      title={getFullName(acc.visit || visit)}
-                      subtitle={"C.I: " + acc?.visit?.ci}
-                      left={<Avatar name={getFullName(acc.visit || visit)} />}
-                      right={
-                        <IconExpand
-                          color="var(--cWhiteV1)"
-                          onClick={() =>
-                            setOpenExpand({
-                              open: true,
-                              id: acc.id,
-                              type: "A",
-                              invitation: null,
-                            })
-                          }
-                        />
-                      }
+            {companions.length > 0 || taxis.length > 0 ? (
+              <section className={styles.sectionCard}>
+                <div className={styles.sectionHeader}>
+                  <p className={styles.sectionTitle}>Relacionados</p>
+                </div>
+                <div className={styles.relatedColumns}>
+                  {companions.length > 0 ? (
+                    <div className={styles.relatedColumn}>
+                      <div className={styles.relatedColumnHeader}>
+                        <p className={styles.relatedColumnTitle}>Acompanantes</p>
+                        <span className={styles.relatedColumnCount}>
+                          {companions.length}
+                        </span>
+                      </div>
+                      <div className={styles.relatedGrid}>
+                        {companions.map((entry: any) => (
+                          <RelatedAccessCard
+                            key={entry?.id}
+                            label="Acompanante"
+                            access={entry}
+                            onOpen={() =>
+                              setOpenExpand({
+                                open: true,
+                                id: entry?.id,
+                                type: "A",
+                              })
+                            }
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {taxis.length > 0 ? (
+                    <div className={styles.relatedColumn}>
+                      <div className={styles.relatedColumnHeader}>
+                        <p className={styles.relatedColumnTitle}>Taxi</p>
+                        <span className={styles.relatedColumnCount}>
+                          {taxis.length}
+                        </span>
+                      </div>
+                      <div className={styles.relatedGrid}>
+                        {taxis.map((entry: any) => (
+                          <RelatedAccessCard
+                            key={entry?.id}
+                            label="Taxi"
+                            access={entry}
+                            onOpen={() =>
+                              setOpenExpand({
+                                open: true,
+                                id: entry?.id,
+                                type: "T",
+                              })
+                            }
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </section>
+            ) : null}
+
+            <section className={styles.sectionCard}>
+              <div className={styles.sectionHeader}>
+                <p className={styles.sectionTitle}>Fotos</p>
+              </div>
+              {imageGroups.length > 0 ? (
+                <div className={styles.galleryStack}>
+                  {imageGroups.map((group) => (
+                    <GalleryGroup
+                      key={group.key}
+                      title={group.title}
+                      images={group.images}
                     />
                   ))}
                 </div>
-              </>
-            )}
+              ) : (
+                <div className={styles.emptyCard}>
+                  No se registraron imagenes para este acceso.
+                </div>
+              )}
+            </section>
 
-            {getTaxiData()?.length > 0 && (
-              <>
-                <Br />
-                <p className={styles.sectionTitle}>Taxista</p>
-                <div className={styles.listContainer}>
-                  {getTaxiData()?.map((acc: any) => (
-                    <ItemList
-                      variant="V3"
-                      key={acc.id}
-                      title={getFullName(acc.visit || visit)}
-                      subtitle={"C.I: " + acc?.visit?.ci}
-                      left={<Avatar name={getFullName(acc.visit || visit)} />}
-                      right={
-                        <IconExpand
-                          color="var(--cWhiteV1)"
-                          onClick={() =>
-                            setOpenExpand({
-                              open: true,
-                              id: acc.id,
-                              type: "T",
-                              invitation: null,
-                            })
-                          }
+            <section className={styles.sectionCard}>
+              <div className={styles.sectionHeader}>
+                <p className={styles.sectionTitle}>Registro tecnico</p>
+              </div>
+
+              {deviceItems.length > 0 ? (
+                <div className={styles.deviceGrid}>
+                  {deviceItems.map((device, index) => (
+                    <div
+                      className={styles.deviceCard}
+                      key={`${device?.device_name || "device"}-${index}`}
+                    >
+                      <div className={styles.deviceHead}>
+                        <div className={styles.deviceTitleWrap}>
+                          <span className={styles.deviceIcon}>
+                            <IconPhone size={14} color="var(--cAccent)" />
+                          </span>
+                          <div>
+                            <p className={styles.deviceTitle}>
+                              {device?.device_name || "Dispositivo"}
+                            </p>
+                            <p className={styles.deviceSubtitle}>
+                              {(device?.brand || "-/-") +
+                                " / " +
+                                (device?.model || "-/-")}
+                            </p>
+                          </div>
+                        </div>
+                        {device?.guardNames?.length > 0 ? (
+                          <span className={styles.deviceGuardList}>
+                            {device.guardNames.join(", ")}
+                          </span>
+                        ) : null}
+                      </div>
+
+                      <div className={styles.deviceFacts}>
+                        <InfoCard
+                          label="Sistema"
+                          value={`${device?.os || "-/-"} ${
+                            device?.os_version || ""
+                          }`.trim()}
                         />
-                      }
-                    />
+                        <InfoCard
+                          label="Red"
+                          value={`IP ${device?.ip_address || "-/-"}${
+                            device?.carrier && device?.carrier !== "unknown"
+                              ? ` · ${device.carrier}`
+                              : ""
+                          }`}
+                        />
+                        <InfoCard
+                          label="App"
+                          value={`v${device?.app_version || "-/-"} (${
+                            device?.build_number || "-/-"
+                          })`}
+                        />
+                        <InfoCard
+                          label="Emulador"
+                          value={device?.is_emulator ? "Si" : "No"}
+                        />
+                      </div>
+                    </div>
                   ))}
                 </div>
-              </>
-            )}
+              ) : (
+                <div className={styles.emptyCard}>
+                  No se registraron datos de dispositivo para este acceso.
+                </div>
+              )}
+
+              {actionItems.length > 0 ? (
+                <div className={styles.actionList}>
+                  {actionItems.map((action) => (
+                    <div className={styles.actionItem} key={action._key}>
+                      <DetailBadge
+                        label={action?.action_name === "Out" ? "Salida" : "Entrada"}
+                        tone={action?.action_name === "Out" ? "info" : "success"}
+                      />
+                      <div className={styles.actionBody}>
+                        <p className={styles.actionText}>
+                          {action?.description || "Sin descripcion"}
+                        </p>
+                        <p className={styles.actionMeta}>
+                          {[
+                            action?.guardName || "",
+                            action?.deviceName || "",
+                            formatDetailDate(action?.date_at),
+                          ]
+                            .filter(Boolean)
+                            .join(" · ")}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </section>
           </div>
         </LoadingScreen>
       </DetailModal>
 
-      {openExpand?.open && (
+      {openExpand.open ? (
         <ModalAccessExpand
-          open={openExpand?.open}
-          onClose={() =>
-            setOpenExpand({ open: false, id: null, type: "", invitation: null })
-          }
-          id={openExpand?.id}
-          type={openExpand?.type}
+          open={openExpand.open}
+          onClose={() => setOpenExpand({ open: false, id: null, type: "" })}
+          id={openExpand.id}
+          type={openExpand.type as "A" | "T"}
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/src/modulos/Activities/AccessTab/shared/accessDetailUtils.ts
+++ b/src/modulos/Activities/AccessTab/shared/accessDetailUtils.ts
@@ -1,0 +1,269 @@
+import { getFullName } from "@/mk/utils/string";
+
+type AnyRecord = Record<string, any>;
+
+const URL_KEYS = [
+  "secureUrl",
+  "secure_url",
+  "url",
+  "src",
+  "path",
+  "file",
+  "download_url",
+  "original_url",
+];
+
+export const cleanUrl = (value: any): string => {
+  if (value === null || value === undefined) return "";
+  const raw = String(value).trim();
+  if (!raw) return "";
+
+  const withoutQuotes = raw.replace(/[`'"]/g, "").trim();
+  if (!withoutQuotes || withoutQuotes.includes("undefined")) return "";
+  return withoutQuotes;
+};
+
+const parseMaybeJson = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) return value;
+  if (
+    (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
+    (trimmed.startsWith("{") && trimmed.endsWith("}"))
+  ) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+};
+
+export const extractImageUrls = (input: any): string[] => {
+  if (!input) return [];
+
+  if (Array.isArray(input)) {
+    return input.flatMap(extractImageUrls);
+  }
+
+  if (typeof input === "string") {
+    const parsed = parseMaybeJson(input);
+    if (parsed !== input) {
+      return extractImageUrls(parsed);
+    }
+    const cleaned = cleanUrl(parsed);
+    return cleaned ? [cleaned] : [];
+  }
+
+  if (typeof input === "object") {
+    const direct = URL_KEYS.flatMap((key) => extractImageUrls(input?.[key]));
+    if (direct.length > 0) return direct;
+  }
+
+  return [];
+};
+
+export const collectUniqueImages = (...sources: any[]): string[] => {
+  return Array.from(new Set(sources.flatMap(extractImageUrls)));
+};
+
+export const getEntityName = (entity: AnyRecord | null | undefined): string => {
+  if (!entity) return "";
+  return (
+    getFullName(entity) ||
+    entity?.full_name ||
+    entity?.name ||
+    entity?.title ||
+    ""
+  );
+};
+
+export const getEntityAvatar = (entity: AnyRecord | null | undefined) => {
+  return (
+    cleanUrl(entity?.url_avatar) ||
+    collectUniqueImages(
+      entity?.url_image_a,
+      entity?.url_image_r,
+      entity?.url_image,
+    )[0] ||
+    ""
+  );
+};
+
+export const getEntityGallery = (entity: AnyRecord | null | undefined) => {
+  return collectUniqueImages(
+    entity?.url_image_a,
+    entity?.url_image_r,
+    entity?.url_image,
+  );
+};
+
+export const getPrimaryUnit = (owner: AnyRecord | null | undefined) => {
+  if (!owner?.dpto) return null;
+  return Array.isArray(owner.dpto) ? owner.dpto[0] : owner.dpto;
+};
+
+export const getUnitLabel = (owner: AnyRecord | null | undefined) => {
+  const unit = getPrimaryUnit(owner);
+  if (!unit) return "-/-";
+
+  const prefix = unit?.type?.name || "Unidad";
+  const identifier = unit?.nro || unit?.description || "-/-";
+  return `${prefix} ${identifier}`.trim();
+};
+
+export const getAccessTypeLabel = (type: string, detail: AnyRecord) => {
+  const typeMap: Record<string, string> = {
+    C: "Sin QR",
+    I: "QR Individual",
+    G: "QR Grupal",
+    F: "QR Frecuente",
+    P: "Pedido",
+    O: "Llave QR",
+  };
+
+  if (type === "P") {
+    return `Pedido/${detail?.other?.other_type?.name || "-/-"}`;
+  }
+
+  return typeMap[type] || "-/-";
+};
+
+export const getAccessStatusInfo = (detail: AnyRecord) => {
+  if (detail?.out_at) {
+    return { label: "Completado", tone: "success" as const };
+  }
+
+  if (detail?.in_at) {
+    return { label: "Por salir", tone: "info" as const };
+  }
+
+  if (detail?.confirm === "N" || detail?.rejected_guard_id != null) {
+    return { label: "Rechazado", tone: "danger" as const };
+  }
+
+  if (!detail?.confirm_at) {
+    return { label: "Por confirmar", tone: "warning" as const };
+  }
+
+  return { label: "Por entrar", tone: "accent" as const };
+};
+
+export const getMovementMode = (detail: AnyRecord) => {
+  const related = Array.isArray(detail?.accesses) ? detail.accesses : [];
+  const hasTaxiRelation = related.some(
+    (entry: AnyRecord) => entry?.taxi === "C" || entry?.plate,
+  );
+  return detail?.plate || detail?.taxi === "C" || hasTaxiRelation
+    ? "Vehicular"
+    : "Peatonal";
+};
+
+export const getRequestActorInfo = (detail: AnyRecord) => {
+  const approvedByGuard =
+    detail?.confirm === "G" || detail?.rejected_guard_id != null;
+  const actor = approvedByGuard ? detail?.guardia : detail?.owner;
+  const actorName = getEntityName(actor);
+
+  if (!actorName) {
+    return {
+      label: detail?.confirm === "N" ? "Rechazado por" : "Aprobado por",
+      actor,
+      actorName: "",
+      roleText: "",
+    };
+  }
+
+  return {
+    label: detail?.confirm === "N" ? "Rechazado por" : "Aprobado por",
+    actor,
+    actorName,
+    roleText: approvedByGuard ? "Guardia" : "Residente",
+  };
+};
+
+export const getAccessHeadline = (detail: AnyRecord) => {
+  const subject = detail?.type === "O" ? detail?.owner : detail?.visit;
+  const subjectName = getEntityName(subject) || "Sin nombre";
+  const ownerName = getEntityName(detail?.owner) || "Residente";
+  const unit = getUnitLabel(detail?.owner);
+
+  if (detail?.type === "O") {
+    return `${subjectName} registro su acceso a ${unit}`;
+  }
+
+  if (detail?.type === "P") {
+    return `${subjectName} entrego a ${ownerName}`;
+  }
+
+  return `${subjectName} visito a ${ownerName}`;
+};
+
+export const splitRelatedAccesses = (detail: AnyRecord) => {
+  const related = Array.isArray(detail?.accesses) ? detail.accesses : [];
+  return {
+    companions: related.filter((entry: AnyRecord) => entry?.taxi !== "C"),
+    taxis: related.filter((entry: AnyRecord) => entry?.taxi === "C"),
+  };
+};
+
+export const flattenAccessDevices = (groups: AnyRecord[] = []) => {
+  const devicesMap = new Map<string, AnyRecord>();
+  const actions: AnyRecord[] = [];
+
+  groups.forEach((group, groupIndex) => {
+    const deviceList = Array.isArray(group?.devices) ? group.devices : [];
+
+    deviceList.forEach((device: AnyRecord, deviceIndex: number) => {
+      const key =
+        device?.device_id ||
+        device?.installation_id ||
+        device?.uuid ||
+        [
+          group?.guard_id || groupIndex,
+          device?.device_name || "device",
+          device?.brand || "brand",
+          device?.model || deviceIndex,
+        ].join("|");
+
+      const previous = devicesMap.get(key);
+      if (previous) {
+        const guardNames = new Set([
+          ...(previous.guardNames || []),
+          ...(group?.guard_name ? [group.guard_name] : []),
+        ]);
+        devicesMap.set(key, {
+          ...previous,
+          ...device,
+          guardNames: Array.from(guardNames),
+        });
+        return;
+      }
+
+      devicesMap.set(key, {
+        ...device,
+        guardNames: group?.guard_name ? [group.guard_name] : [],
+      });
+    });
+
+    (Array.isArray(group?.actions) ? group.actions : []).forEach(
+      (action: AnyRecord, actionIndex: number) => {
+        actions.push({
+          ...action,
+          _sortKey: action?.date_at || "",
+          _key: `${group?.guard_id || groupIndex}-${actionIndex}`,
+          guardName: group?.guard_name || "",
+          deviceName:
+            deviceList.length === 1 ? deviceList[0]?.device_name || "" : "",
+        });
+      },
+    );
+  });
+
+  actions.sort((a, b) => String(b._sortKey).localeCompare(String(a._sortKey)));
+
+  return {
+    devices: Array.from(devicesMap.values()),
+    actions,
+  };
+};

--- a/src/modulos/Alerts/RenderView/RenderView.module.css
+++ b/src/modulos/Alerts/RenderView/RenderView.module.css
@@ -4,10 +4,10 @@
   gap: var(--spM);
   align-self: stretch;
   /* background-color: var(--figma-main-bg, #333536); */
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   padding: var(--spL, 16px);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cBorder);
 }
 
 .hlTopSection,

--- a/src/modulos/Assemblies/components/AssemblyActaManager/AssemblyActaManager.module.css
+++ b/src/modulos/Assemblies/components/AssemblyActaManager/AssemblyActaManager.module.css
@@ -6,7 +6,7 @@
 
 .noActa {
   padding: 10px 0;
-  color: #666;
+  color: var(--cWhiteV1);
   font-size: 13px;
 }
 
@@ -15,16 +15,18 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
   border-radius: 8px;
   text-decoration: none;
   color: inherit;
-  transition: all 0.2s;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .actaItem:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--cBackground-foreground);
   border-color: var(--cAccent);
 }
 
@@ -48,15 +50,16 @@
   text-overflow: ellipsis;
   max-width: 180px;
   font-weight: 500;
+  color: var(--cWhite);
 }
 
 .actaDate {
   font-size: 11px;
-  color: #888;
+  color: var(--cWhiteV1);
 }
 
 .actaDownload {
-  color: #888;
+  color: var(--cWhiteV1);
   display: flex;
   align-items: center;
 }

--- a/src/modulos/Assemblies/components/AssemblyAttendanceForm/AssemblyAttendanceForm.module.css
+++ b/src/modulos/Assemblies/components/AssemblyAttendanceForm/AssemblyAttendanceForm.module.css
@@ -14,7 +14,7 @@
 .label {
   font-size: 13px;
   font-weight: 600;
-  color: #888;
+  color: var(--cWhiteV4);
 }
 
 .searchBar {
@@ -34,10 +34,10 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  background: #000;
+  background: var(--cModalSection);
   padding: 10px;
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--cModalBorder);
   max-width: 320px;
   margin: 0 auto;
   width: 100%;
@@ -47,7 +47,7 @@
 .scannerHint {
   text-align: center;
   font-size: 12px;
-  color: #888;
+  color: var(--cWhiteV1);
   margin: 0;
 }
 
@@ -58,15 +58,15 @@
 .resultsList {
   max-height: 250px;
   overflow-y: auto;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--cModalBorder);
   border-radius: 8px;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--cModalSurfaceRaised);
 }
 
 .message {
   padding: 30px;
   text-align: center;
-  color: #666;
+  color: var(--cWhiteV1);
   font-size: 14px;
 }
 
@@ -77,15 +77,15 @@
   padding: 12px 16px;
   cursor: pointer;
   transition: all 0.2s;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--cModalDivider);
 }
 
 .residentItem:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--cBackground-foreground);
 }
 
 .residentItem.selected {
-  background: rgba(var(--cAccentRGB), 0.1);
+  background: var(--cHoverCompl10);
   border-left: 3px solid var(--cAccent);
 }
 
@@ -97,22 +97,23 @@
   font-size: 14px;
   font-weight: 600;
   margin: 0;
+  color: var(--cWhite);
 }
 
 .resDetail {
   font-size: 12px;
-  color: #888;
+  color: var(--cWhiteV1);
   margin: 2px 0 0 0;
 }
 
 .registrationForm {
   padding: 16px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--cModalSection);
   border-radius: 12px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--cModalBorder);
 }
 
 .modalityOptions {
@@ -124,23 +125,24 @@
 
 .modalityCard {
   padding: 12px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
   border-radius: 8px;
   text-align: center;
   cursor: pointer;
   font-size: 14px;
+  color: var(--cWhite);
   transition: all 0.2s;
 }
 
 .modalityCard:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--cBackground-foreground);
 }
 
 .modalityCard.active {
   background: var(--cAccent);
   border-color: var(--cAccent);
-  color: #fff;
+  color: var(--cBlack);
 }
 
 .registerBtn {
@@ -163,20 +165,20 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .dptoCard:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--cBackground-foreground);
 }
 
 .dptoCard.active {
   border-color: var(--cAccent);
-  background: rgba(var(--cAccentRGB), 0.1);
+  background: var(--cHoverCompl10);
 }
 
 .dptoContent {
@@ -187,11 +189,12 @@
 .dptoNro {
   font-size: 14px;
   font-weight: 600;
+  color: var(--cWhite);
 }
 
 .dptoRole {
   font-size: 11px;
-  color: #888;
+  color: var(--cWhiteV1);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }

--- a/src/modulos/Assemblies/components/AssemblyAttendanceForm/AssemblyAttendanceForm.tsx
+++ b/src/modulos/Assemblies/components/AssemblyAttendanceForm/AssemblyAttendanceForm.tsx
@@ -228,9 +228,11 @@ const AssemblyAttendanceForm: React.FC<AssemblyAttendanceFormProps> = ({
               style={{
                 minWidth: "40px",
                 padding: "0 8px",
-                backgroundColor: isScannerOpen ? "var(--cPrimary)" : "transparent",
-                borderColor: "var(--cPrimary)",
-                color: isScannerOpen ? "#fff" : "var(--cPrimary)",
+                backgroundColor: isScannerOpen
+                  ? "var(--cAccent)"
+                  : "transparent",
+                borderColor: "var(--cAccent)",
+                color: isScannerOpen ? "var(--cBlack)" : "var(--cAccent)",
               }}
             >
               <IconGenericQr size={20} />

--- a/src/modulos/Assemblies/components/AssemblyAttendanceList/AssemblyAttendanceList.module.css
+++ b/src/modulos/Assemblies/components/AssemblyAttendanceList/AssemblyAttendanceList.module.css
@@ -7,35 +7,37 @@
 .loading {
   padding: 20px;
   text-align: center;
-  color: var(--cTextMuted);
+  color: var(--cWhiteV4);
 }
 
 .summary {
   display: flex;
   justify-content: space-between;
+  gap: 12px;
   padding: 12px 16px;
-  background: var(--cHoverCompl);
+  background: var(--cModalSection);
+  border: 1px solid var(--cModalBorder);
   border-radius: 8px;
   font-size: 14px;
 }
 
 .total {
-  color: var(--cText);
+  color: var(--cWhite);
 }
 
 .breakdown {
-  color: var(--cTextMuted);
+  color: var(--cWhiteV4);
 }
 
 .total strong,
 .breakdown strong {
-  color: var(--cText);
+  color: var(--cWhite);
 }
 
 .empty {
   padding: 40px;
   text-align: center;
-  color: var(--cTextMuted);
+  color: var(--cWhiteV4);
   font-size: 14px;
 }
 
@@ -53,17 +55,17 @@
 .table td {
   padding: 12px;
   text-align: left;
-  border-bottom: 1px solid var(--cBorder);
+  border-bottom: 1px solid var(--cModalBorder);
 }
 
 .table th {
   font-weight: 600;
-  color: var(--cTextMuted);
-  background: var(--cHoverCompl);
+  color: var(--cWhiteV4);
+  background: var(--cModalSurfaceRaised);
 }
 
 .table td {
-  color: var(--cText);
+  color: var(--cWhite);
 }
 
 .modalityBadge {
@@ -80,8 +82,8 @@
 }
 
 .virtual {
-  background: var(--cHoverCompl);
-  color: var(--cPrimary);
+  background: var(--cHoverCompl3);
+  color: var(--cInfo);
 }
 
 .deleteBtn {
@@ -102,7 +104,6 @@
   transform: scale(1.1);
 }
 
-/* Mobile Card Styles */
 .cardsContainer {
   display: flex;
   flex-direction: column;
@@ -111,8 +112,8 @@
 }
 
 .attendanceCard {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--cBorder);
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
   border-radius: 12px;
   padding: 12px;
   display: flex;
@@ -122,7 +123,7 @@
 }
 
 .attendanceCard:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--cBackground-foreground);
 }
 
 .cardHeader {
@@ -142,7 +143,7 @@
 .cardName {
   font-size: 14px;
   font-weight: 600;
-  color: var(--cText);
+  color: var(--cWhite);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -150,7 +151,7 @@
 
 .cardSub {
   font-size: 12px;
-  color: var(--cTextMuted);
+  color: var(--cWhiteV4);
 }
 
 .cardFooter {
@@ -158,7 +159,7 @@
   justify-content: space-between;
   align-items: center;
   padding-top: 8px;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid var(--cModalDivider);
 }
 
 .cardBadgeContainer {
@@ -177,6 +178,6 @@
 
 .cardTime {
   font-size: 12px;
-  color: var(--cTextMuted);
+  color: var(--cWhiteV1);
   font-variant-numeric: tabular-nums;
 }

--- a/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.module.css
+++ b/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.module.css
@@ -4,10 +4,10 @@
   flex-direction: column;
   gap: 20px;
   padding: 24px;
-  background-color: #0d0d0d;
+  background-color: var(--cBackground-muted);
   min-height: 100vh;
-  color: #fff;
-  font-family: "Inter", sans-serif;
+  color: var(--cWhite);
+  font-family: var(--fPrimary);
 }
 
 .breadcrumb {
@@ -15,7 +15,7 @@
   align-items: center;
   gap: 8px;
   font-size: 14px;
-  color: #888;
+  color: var(--cWhiteV1);
   margin-bottom: 8px;
 }
 
@@ -24,11 +24,12 @@
 }
 
 .breadcrumb span:first-child:hover {
+  color: var(--cWhite);
   text-decoration: underline;
 }
 
 .breadcrumb .active {
-  color: #fff;
+  color: var(--cWhite);
   font-weight: 600;
 }
 
@@ -51,9 +52,8 @@
 }
 
 .card {
-  background: rgba(255, 255, 255, 0.03);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--cBackground-foreground);
+  border: 1px solid var(--cModalBorder);
   border-radius: 12px;
   padding: 20px;
   position: relative;
@@ -69,7 +69,7 @@
 .cardTitle {
   font-size: 11px;
   font-weight: 700;
-  color: #888;
+  color: var(--cNeutral-100);
   letter-spacing: 1px;
   text-transform: uppercase;
   margin: 0;
@@ -78,9 +78,9 @@
 }
 
 .editButton {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #fff;
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
+  color: var(--cWhite);
   padding: 4px 12px;
   border-radius: 6px;
   font-size: 12px;
@@ -88,30 +88,35 @@
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  transition: all 0.2s;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .editButton:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--cBackground-foreground);
+  border-color: var(--cDivider);
 }
 
 .mainSubject {
   margin: 0 0 4px 0;
   font-size: 16px;
   font-weight: 500;
+  color: var(--cWhite);
 }
 
 .typeLabel {
   display: block;
   font-size: 13px;
-  color: #666;
+  color: var(--cWhiteV1);
   margin-bottom: 20px;
 }
 
 .statusBadge {
-  background: rgba(16, 185, 129, 0.1);
-  color: #10b981;
-  border: 1px solid rgba(16, 185, 129, 0.2);
+  background: var(--cHoverSuccess);
+  color: var(--cSuccess);
+  border: 1px solid var(--cSuccess);
   padding: 2px 12px;
   border-radius: 8px;
   font-size: 11px;
@@ -122,7 +127,7 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 24px;
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  border-top: 1px solid var(--cModalDivider);
   padding-top: 20px;
 }
 
@@ -134,16 +139,17 @@
 
 .metricLabel {
   font-size: 12px;
-  color: #666;
+  color: var(--cWhiteV1);
 }
 
 .metricValue {
   font-size: 14px;
   font-weight: 300;
+  color: var(--cWhite);
 }
 
 .descriptionText {
-  color: #ccc;
+  color: var(--cWhiteV1);
   font-size: 14px;
   line-height: 1.6;
   margin: 0;
@@ -160,12 +166,13 @@
   font-size: 14px;
   font-weight: 600;
   margin: 0;
+  color: var(--cWhite);
 }
 
 .addQuestionBtn {
-  background: none;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: #eee;
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
+  color: var(--cWhite);
   padding: 6px 14px;
   border-radius: 6px;
   font-size: 12px;
@@ -175,19 +182,21 @@
   cursor: pointer;
 }
 
-/* Votaciones card details */
 .votacionCard {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
   border-radius: 12px;
   padding: 20px;
   margin-bottom: 24px;
-  transition: all 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease,
+    transform 0.3s ease;
 }
 
 .votacionCard:hover {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.1);
+  background: var(--cBackground-foreground);
+  border-color: var(--cDivider);
 }
 
 .votacionTitle {
@@ -195,6 +204,7 @@
   font-weight: 600;
   margin: 0 0 8px 0;
   word-break: break-word;
+  color: var(--cWhite);
 }
 
 .votacionMeta {
@@ -206,11 +216,11 @@
 
 .votacionCount {
   font-size: 13px;
-  color: #666;
+  color: var(--cWhiteV1);
 }
 
 .votacionStatus {
-  color: #10b981;
+  color: var(--cSuccess);
   font-size: 12px;
   font-weight: 600;
 }
@@ -222,35 +232,36 @@
 .optionHeader {
   display: flex;
   justify-content: space-between;
+  gap: 12px;
   font-size: 14px;
   margin-bottom: 8px;
+  color: var(--cWhite);
 }
 
 .progressContainer {
   height: 8px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--cBackground-foreground);
   border-radius: 4px;
   overflow: hidden;
 }
 
 .progressBar {
   height: 100%;
-  background: linear-gradient(90deg, #8b5cf6, #3b82f6);
+  background: linear-gradient(90deg, var(--cAccent), var(--cInfo));
   border-radius: 4px;
 }
 
-/* Footer informativo de abstenciones (modo count_as_option=false) */
 .abstentionFooter {
   display: flex;
   align-items: center;
   gap: 10px;
   margin-top: 12px;
   padding: 8px 12px;
-  background: rgba(249, 115, 22, 0.06);
-  border: 1px solid rgba(249, 115, 22, 0.2);
+  background: var(--cHoverAlert);
+  border: 1px solid var(--cAlert);
   border-radius: 8px;
   font-size: 12px;
-  color: #aaa;
+  color: var(--cWhiteV1);
 }
 
 .abstentionFooterItem {
@@ -260,17 +271,15 @@
 }
 
 .abstentionFooterItem strong {
-  color: #fff;
+  color: var(--cWhite);
   font-weight: 600;
 }
 
 .abstentionSeparator {
-  color: rgba(255, 255, 255, 0.2);
+  color: var(--cModalDivider);
   font-size: 14px;
 }
 
-
-/* Accordion sections on the right */
 .section {
   display: flex;
   flex-direction: column;
@@ -287,30 +296,32 @@
 .sectionTitle {
   font-size: 12px;
   font-weight: 700;
-  color: #888;
+  color: var(--cNeutral-100);
   letter-spacing: 1px;
 }
 
 .detailRow {
   display: flex;
   justify-content: space-between;
+  gap: 16px;
   margin-bottom: 12px;
   font-size: 13px;
 }
 
 .detailLabel {
-  color: #666;
+  color: var(--cWhiteV1);
 }
 
 .detailValue {
   text-align: right;
   max-width: 180px;
+  color: var(--cWhite);
 }
 
 .actionBtn {
-  background: none;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #fff;
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
+  color: var(--cWhite);
   padding: 4px 10px;
   border-radius: 6px;
   font-size: 12px;
@@ -318,24 +329,33 @@
   align-items: center;
   gap: 6px;
   cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.actionBtn:hover {
+  background: var(--cBackground-foreground);
+  border-color: var(--cDivider);
 }
 
 .verVotantesBtn {
-  background: rgba(139, 92, 246, 0.15);
-  border: 1px solid rgba(139, 92, 246, 0.3);
-  color: #a78bfa;
+  background: var(--cHoverCompl3);
+  border: 1px solid var(--cInfo);
+  color: var(--cWhite);
   padding: 2px 8px;
   border-radius: 4px;
   font-size: 11px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .verVotantesBtn:hover {
-  background: rgba(139, 92, 246, 0.25);
-  border-color: rgba(139, 92, 246, 0.5);
-  color: #c4b5fd;
+  background: rgba(66, 133, 250, 0.28);
+  border-color: var(--cInfo);
 }
 
 .modalContent {
@@ -350,6 +370,7 @@
 }
 
 .link:hover {
+  color: var(--accentv1);
   text-decoration: underline;
 }
 
@@ -364,16 +385,19 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
   border-radius: 8px;
   text-decoration: none;
   color: inherit;
-  transition: all 0.2s;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .docItem:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--cBackground-foreground);
   border-color: var(--cAccent);
 }
 
@@ -390,13 +414,33 @@
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 180px;
+  color: var(--cWhite);
 }
 
 .docDownload {
-  color: #888;
+  color: var(--cWhiteV1);
   display: flex;
   align-items: center;
 }
+
+.emptyState {
+  padding: 10px 0;
+  color: var(--cWhiteV1);
+  font-size: 13px;
+}
+
+.helperText {
+  font-size: 14px;
+  color: var(--cWhiteV4);
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+
+.accentText {
+  color: var(--cAlert);
+  font-weight: 600;
+}
+
 @media (max-width: 900px) {
   .layout {
     grid-template-columns: 1fr;

--- a/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.tsx
+++ b/src/modulos/Assemblies/components/AssemblyDetail/AssemblyDetail.tsx
@@ -390,8 +390,8 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
   }
 
   const statusStyle = STATUS_STYLE[assembly.status] || {
-    color: "#fff",
-    backgroundColor: "#333",
+    color: "var(--cWhite)",
+    backgroundColor: "var(--cModalSurfaceRaised)",
   };
 
   return (
@@ -601,7 +601,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                                   alignItems: "center",
                                   gap: "8px",
                                   marginLeft: "8px",
-                                  borderLeft: "1px solid #e2e8f0",
+                                  borderLeft: "1px solid var(--cModalDivider)",
                                   paddingLeft: "16px",
                                 }}
                               >
@@ -642,7 +642,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                           <>
                             <IconEdit
                               size={18}
-                              color="#888"
+                              color="var(--cWhiteV3)"
                               style={{ cursor: "pointer" }}
                               onClick={() => handleEditSurvey(survey)}
                               title="Editar"
@@ -711,10 +711,10 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                             ?.toLowerCase()
                             .includes("nulo");
                           const barColor = isNo
-                            ? "#EF4444"
+                            ? "linear-gradient(90deg, var(--cError), var(--cAlert))"
                             : isNulo
-                              ? "#444"
-                              : "linear-gradient(90deg, #8b5cf6, #3b82f6)";
+                              ? "linear-gradient(90deg, var(--cNeutral-500), var(--cNeutral-700))"
+                              : "linear-gradient(90deg, var(--cAccent), var(--cInfo))";
 
                           return (
                             <div key={opt.id} className={styles.optionItem}>
@@ -766,7 +766,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                           <div className={styles.optionItem}>
                             <div className={styles.optionHeader}>
                               <span
-                                style={{ color: "#f97316", fontWeight: 600 }}
+                                className={styles.accentText}
                               >
                                 Abstenciones
                               </span>
@@ -777,7 +777,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                                   gap: 8,
                                 }}
                               >
-                                <span style={{ color: "#f97316" }}>
+                                <span className={styles.accentText}>
                                   {abstention.abstention_rate}% (
                                   {abstention.abstentions}{" "}
                                   {abstention.abstentions === 1
@@ -809,7 +809,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                                 style={{
                                   width: `${abstention.abstention_rate}%`,
                                   background:
-                                    "linear-gradient(90deg, #f97316, #ef4444)",
+                                    "linear-gradient(90deg, var(--cAlert), var(--cWarning))",
                                 }}
                               />
                             </div>
@@ -831,7 +831,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                               </span>
                               <span
                                 className={styles.abstentionFooterItem}
-                                style={{ color: "#f97316" }}
+                                style={{ color: "var(--cAlert)" }}
                               >
                                 Abstenciones:{" "}
                                 <strong>{abstention.abstentions}</strong> (
@@ -845,9 +845,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                 </div>
               ))
             ) : (
-              <div
-                style={{ padding: "20px", textAlign: "center", color: "#666" }}
-              >
+              <div className={styles.emptyState}>
                 No hay votaciones registradas.
               </div>
             )}
@@ -1007,7 +1005,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
                   </a>
                 ))
               ) : (
-                <div style={{ padding: "10px 0", color: "#666", fontSize: 13 }}>
+                <div className={styles.emptyState}>
                   No hay documentos subidos.
                 </div>
               )}
@@ -1115,12 +1113,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
         {isEditingDocs && (
           <div style={{ padding: "10px 0" }}>
             <p
-              style={{
-                fontSize: 14,
-                color: "#888",
-                marginBottom: 20,
-                lineHeight: 1.5,
-              }}
+              className={styles.helperText}
             >
               Sube o elimina documentos adjuntos para esta asamblea. Los cambios
               se aplicarán inmediatamente al guardar.
@@ -1148,12 +1141,7 @@ const AssemblyDetail: React.FC<AssemblyDetailProps> = ({ id }) => {
         {isEditingActa && (
           <div style={{ padding: "10px 0" }}>
             <p
-              style={{
-                fontSize: 14,
-                color: "#888",
-                marginBottom: 20,
-                lineHeight: 1.5,
-              }}
+              className={styles.helperText}
             >
               Sube el archivo final del acta de la asamblea. Este archivo estará
               disponible para consulta por los residentes.

--- a/src/modulos/Assemblies/components/AssemblyManualVoteForm/AssemblyManualVoteForm.module.css
+++ b/src/modulos/Assemblies/components/AssemblyManualVoteForm/AssemblyManualVoteForm.module.css
@@ -3,19 +3,19 @@
   flex-direction: column;
   gap: 20px;
   padding: 8px 0;
-  color: #f1f5f9;
+  color: var(--cWhite);
 }
 
 .surveyContext {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--cModalSection);
   padding: 16px;
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--cModalBorder);
 }
 
 .surveyLabel {
   font-size: 11px;
-  color: #94a3b8;
+  color: var(--cWhiteV1);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   margin-bottom: 6px;
@@ -25,7 +25,7 @@
 .surveyTitle {
   font-size: 18px;
   font-weight: 700;
-  color: #ffffff;
+  color: var(--cWhite);
   margin: 0;
 }
 
@@ -38,7 +38,7 @@
 .sectionLabel {
   font-size: 14px;
   font-weight: 600;
-  color: #94a3b8;
+  color: var(--cWhiteV4);
 }
 
 .searchBar {
@@ -48,9 +48,9 @@
 .attendeesList {
   max-height: 220px;
   overflow-y: auto;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--cModalBorder);
   border-radius: 12px;
-  background: rgba(15, 23, 42, 0.3);
+  background: var(--cModalSurfaceRaised);
 }
 
 .attendeeItem {
@@ -60,7 +60,7 @@
   padding: 12px;
   cursor: pointer;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--cModalDivider);
 }
 
 .attendeeItem:last-child {
@@ -68,12 +68,12 @@
 }
 
 .attendeeItem:hover {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: var(--cBackground-foreground);
 }
 
 .attendeeItem.selected {
-  background-color: rgba(30, 64, 175, 0.2);
-  border-left: 3px solid var(--cPrimary);
+  background-color: var(--cHoverCompl10);
+  border-left: 3px solid var(--cAccent);
 }
 
 .attendeeInfo {
@@ -83,20 +83,20 @@
 .attName {
   font-size: 14px;
   font-weight: 500;
-  color: #f8fafc;
+  color: var(--cWhite);
   margin: 0;
 }
 
 .attDetail {
   font-size: 12px;
-  color: #94a3b8;
+  color: var(--cWhiteV1);
   margin: 0;
 }
 
 .message {
   padding: 20px;
   text-align: center;
-  color: #94a3b8;
+  color: var(--cWhiteV1);
   font-size: 13px;
 }
 
@@ -111,25 +111,25 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px;
-  border: 2px solid rgba(255, 255, 255, 0.1);
+  border: 2px solid var(--cModalBorder);
   border-radius: 12px;
   cursor: pointer;
   transition: all 0.2s ease;
-  background: rgba(15, 23, 42, 0.2);
+  background: var(--cModalSurfaceRaised);
 }
 
 .optionCard:hover {
-  border-color: rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--cDivider);
+  background: var(--cBackground-foreground);
 }
 
 .optionActive {
-  border-color: var(--cSuccess);
-  background-color: rgba(34, 197, 94, 0.1);
+  border-color: var(--cAccent);
+  background-color: var(--cHoverCompl10);
 }
 
 .optionText {
   font-size: 15px;
   font-weight: 600;
-  color: #ffffff;
+  color: var(--cWhite);
 }

--- a/src/modulos/Assemblies/components/AssemblyManualVoteForm/AssemblyManualVoteForm.tsx
+++ b/src/modulos/Assemblies/components/AssemblyManualVoteForm/AssemblyManualVoteForm.tsx
@@ -229,8 +229,9 @@ const AssemblyManualVoteForm: React.FC<AssemblyManualVoteFormProps> = ({
                 style={{
                   width: "100%",
                   height: 48,
-                  backgroundColor: "var(--cSuccess)",
-                  borderColor: "var(--cSuccess)",
+                  backgroundColor: "var(--cAccent)",
+                  borderColor: "var(--cAccent)",
+                  color: "var(--cBlack)",
                   fontSize: "16px",
                   fontWeight: "bold",
                 }}

--- a/src/modulos/Assemblies/components/AssemblyStatusActions/AssemblyStatusActions.module.css
+++ b/src/modulos/Assemblies/components/AssemblyStatusActions/AssemblyStatusActions.module.css
@@ -8,7 +8,7 @@
 .currentStatus {
   font-size: 14px;
   font-weight: 600;
-  color: var(--cText);
+  color: var(--cWhiteV1);
 }
 
 .actions {

--- a/src/modulos/Balance/TableFinance/TableFinance.module.css
+++ b/src/modulos/Balance/TableFinance/TableFinance.module.css
@@ -1,33 +1,40 @@
-/* TableFinance Component Styles - Figma Inspired */
+/* TableFinance Component Styles */
+
+.tableShell {
+  width: 100%;
+  margin-top: 1rem;
+}
 
 .tableContainer {
-  margin-top: 1rem;
-  border-top-left-radius: 1rem;
-  border-top-right-radius: 1rem;
-  border-bottom-right-radius: 0;
-  background-color: #d7fff005;
-  border: 1px solid #d7fff014;
-  overflow: hidden;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  width: 100%;
+  margin-top: 0;
+  width: max-content;
+  min-width: 100%;
+  background-color: var(--cTableSurface);
+}
+
+.tableFinance {
+  min-width: var(--table-finance-min-width, 920px);
 }
 
 .tableHeaderRow {
   display: flex;
-  background-color: rgba(18, 21, 25, 0.8);
-  height: 55px;
+  width: max-content;
+  min-width: 100%;
+  min-height: 55px;
+  background-color: var(--cTableHeader);
   color: var(--cWhite);
-  font-weight: 600;
-  font-size: 16px;
-  width: 100%;
+  font-size: 15px;
+  font-weight: var(--bSemibold);
+  border-bottom: 1px solid var(--cTableBorder);
 }
 
 .headerCell {
   display: flex;
   align-items: center;
+  min-height: 55px;
   padding: 0 1rem;
-
   flex: 1;
+  color: var(--cWhiteV4);
 }
 
 .headerCell:last-child {
@@ -36,59 +43,50 @@
 
 .titleHeaderCell {
   flex: 2;
-  min-width: 200px;
-  border-left: none;
+  min-width: 240px;
 }
 
 .monthHeaderCell {
   flex: 1;
   flex-basis: 0;
-  min-width: 40px;
+  min-width: 88px;
   flex-shrink: 0;
   justify-content: flex-end;
-  align-items: center;
   padding: 0 1rem;
-  border-right: none;
 }
 
 .totalHeaderCell {
   flex: 1;
-  min-width: 150px;
+  min-width: 180px;
   flex-shrink: 0;
   justify-content: flex-end !important;
 }
 
 .dataRow {
   display: flex;
-  height: 56px;
-  border-top: 0.3px solid rgba(215, 255, 240, 0.12);
+  width: max-content;
+  min-width: 100%;
+  min-height: 56px;
+  border-top: 1px solid var(--cTableBorder);
   font-size: 14px;
   transition: background-color 0.2s ease;
-  width: 100%;
-}
-
-.dataRow:nth-child(odd) {
-  background-color: #121519;
-}
-
-.dataRow:nth-child(even) {
-  background-color: rgba(18, 21, 25, 0.76);
+  background-color: var(--cTableSurface);
 }
 
 .dataRow:hover {
-  background-color: rgba(0, 227, 140, 0.08);
+  background-color: var(--cTableHover);
 }
 
 .dataRowActive {
-  background-color: rgba(0, 227, 140, 0.12);
+  background-color: var(--cTableHover);
 }
 
 .dataCell {
   display: flex;
   align-items: center;
   padding: 0 1rem;
-
   flex: 1;
+  line-height: 1.35;
 }
 
 .dataCell:last-child {
@@ -97,29 +95,28 @@
 
 .categoryNameCell {
   flex: 2;
-  min-width: 200px;
+  min-width: 240px;
   flex-shrink: 0;
   cursor: pointer;
   gap: 0.5rem;
   font-weight: 500;
-  color: var(--cWhite, #fbfbfb);
+  color: var(--cWhite);
 }
 
 .expandIcon {
-  color: var(--cWhiteV1, #a7a7a7);
+  color: var(--cWhiteV1);
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .monthDataCell {
   flex: 1;
   flex-basis: 0;
-  min-width: 40px;
+  min-width: 88px;
   flex-shrink: 0;
   justify-content: flex-end;
-  align-items: center;
   padding: 0 1rem;
-  border-right: none;
 }
 
 .monthDataCell.no-value {
@@ -128,19 +125,18 @@
 
 .totalDataCell {
   flex: 1;
-  min-width: 150px;
+  min-width: 180px;
   flex-shrink: 0;
   justify-content: flex-end !important;
   font-weight: 500;
-  color: var(--cWhite, #fbfbfb);
+  color: var(--cWhite);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-/* Sub-Items */
 .subItemRow {
-  background-color: rgba(18, 21, 25, 0.65);
+  background-color: var(--cTableSurface);
   font-size: 13px;
   color: var(--cWhiteV1);
   animation: fadeIn 0.3s ease-out;
@@ -148,7 +144,7 @@
 
 .subCategoryNameCell {
   flex: 2;
-  min-width: 200px;
+  min-width: 240px;
   flex-shrink: 0;
   padding-left: 2rem;
   position: relative;
@@ -158,69 +154,54 @@
   content: "•";
   position: absolute;
   left: 1rem;
-  color: var(--cWhiteV2, #8e8e93);
+  color: var(--cWhiteV2);
 }
 
 .tableTotalRowContainer {
   display: flex;
-  justify-content: flex-end;
-  height: 56px;
   width: 100%;
-  color: transparent;
+  min-width: 100%;
+  border-top: 1px solid var(--cTableBorder);
 }
 
 .tableTotalRow {
   display: flex;
-  justify-content: flex-end;
-  height: 56px;
+  width: 100%;
+  min-width: 100%;
+  min-height: 56px;
   font-size: 14px;
   font-weight: 500;
-  min-width: 300px;
-}
-
-@media (max-width: 768px) {
-  .tableTotalRow {
-    min-width: 600px;
-    width: 100%;
-  }
 }
 
 .totalRowOutside {
-  margin-top: 0px;
-  border-bottom-left-radius: 1rem;
-  border-bottom-right-radius: 1rem;
+  margin-top: 0;
 }
 
 .totalLabelCell {
-  background-color: #121519;
+  background-color: var(--cTableSurfaceAlt);
   flex: 2;
-  min-width: 200px;
+  min-width: 240px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
+  gap: 0.75rem;
   padding: 0 1rem;
-
-  order: 1;
-  border-bottom-left-radius: 1rem;
 }
 
 .totalEmptyMonthCells {
   flex: 1;
-  order: 0;
   flex-grow: 1;
   flex-basis: 0;
 }
 
 .totalAmountCell {
   flex: 1;
-  min-width: 150px;
+  min-width: 180px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   padding: 0 1rem;
-  order: 2;
-  border-bottom-right-radius: 1rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -236,7 +217,6 @@
 
 .tooltipIcon {
   color: var(--cWhite);
-
   transition: all 0.2s ease;
 }
 
@@ -249,20 +229,21 @@
   visibility: hidden;
   opacity: 0;
   position: absolute;
-  background-color: var(--cWhite);
-  color: var(--darkv1);
+  background-color: var(--cTableHeader);
+  color: var(--cWhiteV4);
   text-align: center;
-  font-size: 1rem;
+  font-size: 14px;
   padding: 0.5rem 0.75rem;
   border-radius: 0.375rem;
   left: 50%;
   transform: translateX(-50%) translateY(10px);
   bottom: calc(100% + 5px);
   width: max-content;
-  max-width: 200px;
+  max-width: 220px;
   z-index: 10;
   transition: all 0.2s ease;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
+  border: 1px solid var(--cTableBorder);
 }
 
 .tooltip::before {
@@ -273,7 +254,7 @@
   margin-left: -6px;
   border-width: 6px;
   border-style: solid;
-  border-color: var(--cWhiteV1) transparent transparent transparent;
+  border-color: var(--cTableHeader) transparent transparent transparent;
 }
 
 .tooltipContainer:hover .tooltip {
@@ -282,27 +263,25 @@
   transform: translateX(-50%) translateY(0);
 }
 
-/* Animación */
 @keyframes fadeIn {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
 }
 
-/* Estilos para variantes */
 .totalRow-income {
   background-color: rgba(0, 227, 140, 0.05);
-  border-left: 0.3px solid var(--cPrimary);
-  border-right: 0.3px solid var(--cPrimary);
-  border-bottom: 0.3px solid var(--cPrimary);
-  border-style: solid;
+  border-left: 1px solid var(--cPrimary);
+  border-right: 1px solid var(--cPrimary);
+  border-bottom: 1px solid var(--cPrimary);
 }
 
 .text-income {
-  color: white;
+  color: var(--cWhite);
 }
 
 .totalLabelCell-income {
@@ -315,10 +294,9 @@
 
 .totalRow-expense {
   background-color: rgba(245, 101, 101, 0.05);
-  border-left: 0.3px solid var(--cError);
-  border-right: 0.3px solid var(--cError);
-  border-bottom: 0.3px solid var(--cError);
-  border-style: solid;
+  border-left: 1px solid var(--cError);
+  border-right: 1px solid var(--cError);
+  border-bottom: 1px solid var(--cError);
 }
 
 .text-expense {
@@ -335,10 +313,9 @@
 
 .totalRow-summary {
   background-color: rgba(66, 153, 225, 0.05);
-  border-left: 0.3px solid #4299e1;
-  border-right: 0.3px solid #4299e1;
-  border-bottom: 0.3px solid #4299e1;
-  border-style: solid;
+  border-left: 1px solid #4299e1;
+  border-right: 1px solid #4299e1;
+  border-bottom: 1px solid #4299e1;
 }
 
 .text-summary {
@@ -354,68 +331,121 @@
 }
 
 .activeBorder-income {
-  border: 1px solid var(--cSuccess, #00e38c);
+  border: 1px solid var(--cSuccess);
 }
+
 .activeBorder-expense {
-  border: 1px solid var(--cError, #ff5b4d);
+  border: 1px solid var(--cError);
 }
+
 .activeBorder-summary {
-  border: 1px solid var(--cInfo, #4c98df);
+  border: 1px solid var(--cInfo);
 }
 
 .groupBorder-income-top {
-  border-top: 1px solid var(--cSuccess, #00e38c);
-  border-left: 1px solid var(--cSuccess, #00e38c);
-  border-right: 1px solid var(--cSuccess, #00e38c);
+  border-top: 1px solid var(--cSuccess);
+  border-left: 1px solid var(--cSuccess);
+  border-right: 1px solid var(--cSuccess);
 }
+
 .groupBorder-expense-top {
-  border-top: 1px solid var(--cError, #ff5b4d);
-  border-left: 1px solid var(--cError, #ff5b4d);
-  border-right: 1px solid var(--cError, #ff5b4d);
+  border-top: 1px solid var(--cError);
+  border-left: 1px solid var(--cError);
+  border-right: 1px solid var(--cError);
 }
+
 .groupBorder-summary-top {
-  border-top: 1px solid var(--cInfo, #4c98df);
-  border-left: 1px solid var(--cInfo, #4c98df);
-  border-right: 1px solid var(--cInfo, #4c98df);
+  border-top: 1px solid var(--cInfo);
+  border-left: 1px solid var(--cInfo);
+  border-right: 1px solid var(--cInfo);
 }
 
 .groupBorder-income-mid {
-  border-left: 1px solid var(--cSuccess, #00e38c);
-  border-right: 1px solid var(--cSuccess, #00e38c);
+  border-left: 1px solid var(--cSuccess);
+  border-right: 1px solid var(--cSuccess);
 }
+
 .groupBorder-expense-mid {
-  border-left: 1px solid var(--cError, #ff5b4d);
-  border-right: 1px solid var(--cError, #ff5b4d);
+  border-left: 1px solid var(--cError);
+  border-right: 1px solid var(--cError);
 }
+
 .groupBorder-summary-mid {
-  border-left: 1px solid var(--cInfo, #4c98df);
-  border-right: 1px solid var(--cInfo, #4c98df);
+  border-left: 1px solid var(--cInfo);
+  border-right: 1px solid var(--cInfo);
 }
 
 .groupBorder-income-bot {
-  border-left: 1px solid var(--cSuccess, #00e38c);
-  border-right: 1px solid var(--cSuccess, #00e38c);
-  border-bottom: 1px solid var(--cSuccess, #00e38c);
-}
-.groupBorder-expense-bot {
-  border-left: 1px solid var(--cError, #ff5b4d);
-  border-right: 1px solid var(--cError, #ff5b4d);
-  border-bottom: 1px solid var(--cError, #ff5b4d);
-}
-.groupBorder-summary-bot {
-  border-left: 1px solid var(--cInfo, #4c98df);
-  border-right: 1px solid var(--cInfo, #4c98df);
-  border-bottom: 1px solid var(--cInfo, #4c98df);
+  border-left: 1px solid var(--cSuccess);
+  border-right: 1px solid var(--cSuccess);
+  border-bottom: 1px solid var(--cSuccess);
 }
 
-/* Responsive */
+.groupBorder-expense-bot {
+  border-left: 1px solid var(--cError);
+  border-right: 1px solid var(--cError);
+  border-bottom: 1px solid var(--cError);
+}
+
+.groupBorder-summary-bot {
+  border-left: 1px solid var(--cInfo);
+  border-right: 1px solid var(--cInfo);
+  border-bottom: 1px solid var(--cInfo);
+}
+
+.alignCellContentRight {
+  justify-content: flex-end !important;
+}
+
+.tableResponsiveWrapper {
+  width: 100%;
+  overflow-x: auto !important;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  position: relative;
+  scrollbar-width: thin;
+  scrollbar-color: var(--cWhiteV2) transparent;
+  border: 1px solid var(--cTableBorder);
+  border-radius: 16px;
+  background-color: var(--cTableSurface);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
+}
+
+.tableResponsiveWrapper::-webkit-scrollbar {
+  height: 10px;
+  background: transparent;
+}
+
+.tableResponsiveWrapper::-webkit-scrollbar-thumb {
+  background: var(--cWhiteV2);
+  border-radius: 8px;
+  border: 2px solid rgba(44, 47, 51, 0.7);
+}
+
+.tableResponsiveWrapper::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollHint {
+  display: none;
+}
+
+@media (max-width: 1200px) {
+  .scrollHint {
+    display: block;
+    color: var(--cWhiteV3);
+    font-size: 13px;
+    text-align: right;
+    margin-bottom: 4px;
+    margin-right: 8px;
+  }
+}
+
 @media (max-width: 768px) {
   .tableHeaderRow,
   .dataRow,
   .tableTotalRow {
-    height: auto;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    min-height: 52px;
   }
 
   .headerCell,
@@ -427,14 +457,13 @@
   .categoryNameCell,
   .subCategoryNameCell,
   .totalLabelCell {
-    width: 120px;
-    min-width: 100px;
+    min-width: 180px;
     font-size: 13px;
   }
 
   .monthHeaderCell,
   .monthDataCell {
-    min-width: 32px;
+    min-width: 72px;
     font-size: 11px;
     padding: 0 0.5rem;
   }
@@ -442,58 +471,7 @@
   .totalHeaderCell,
   .totalDataCell,
   .totalAmountCell {
-    min-width: 150px;
+    min-width: 160px;
     font-size: 13px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
-}
-
-.alignCellContentRight {
-  justify-content: flex-end !important;
-}
-
-.tableResponsiveWrapper {
-  width: 100%;
-  overflow-x: auto !important;
-  -webkit-overflow-scrolling: touch;
-  position: relative;
-  scrollbar-width: thin;
-  scrollbar-color: var(--cWhiteV2, #444) transparent;
-
-  box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
-  border-radius: 0 0 1rem 1rem;
-}
-
-.tableResponsiveWrapper::-webkit-scrollbar {
-  height: 10px;
-  background: transparent;
-}
-.tableResponsiveWrapper::-webkit-scrollbar-thumb {
-  background: var(--cWhiteV2, #444);
-  border-radius: 8px;
-  border: 2px solid rgba(44, 47, 51, 0.7);
-}
-.tableResponsiveWrapper::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.tableFinance {
-  min-width: 1200px; /* Aumenta el ancho mínimo para vistas anuales */
-}
-
-@media (max-width: 1200px) {
-  .scrollHint {
-    display: block;
-    color: var(--cWhiteV1);
-    font-size: 13px;
-    text-align: right;
-    margin-bottom: 4px;
-    margin-right: 8px;
-  }
-}
-
-.scrollHint {
-  display: none;
 }

--- a/src/modulos/Balance/TableFinance/TableFinance.tsx
+++ b/src/modulos/Balance/TableFinance/TableFinance.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { CSSProperties, useEffect, useMemo, useState } from "react";
 import { formatNumber } from "@/mk/utils/numbers";
 
 import styles from "./TableFinance.module.css";
@@ -36,7 +36,6 @@ const TableFinance = ({
   title,
   title2,
   total,
-  color = "text-white",
   titleTotal,
   meses = [],
   tooltip,
@@ -44,20 +43,10 @@ const TableFinance = ({
 }: PropsType) => {
   const [dropStates, setDropStates] = useState<Array<{ drop: boolean }>>([]);
   const isTwoColumnLayout = meses.length === 0;
-  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     setDropStates(data.map(() => ({ drop: false })));
   }, [data]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth <= 1536);
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
 
   const handleItemClick = (index: number) => {
     setDropStates(
@@ -72,16 +61,7 @@ const TableFinance = ({
   };
 
   const getContainerClass = () => {
-    switch (variant) {
-      case "income":
-        return `${styles.tableContainer} ${styles["tableContainer-income"]}`;
-      case "expense":
-        return `${styles.tableContainer} ${styles["tableContainer-expense"]}`;
-      case "summary":
-        return `${styles.tableContainer} ${styles["tableContainer-summary"]}`;
-      default:
-        return styles.tableContainer;
-    }
+    return styles.tableContainer;
   };
 
   const getTotalRowVariantClass = () => {
@@ -154,196 +134,183 @@ const TableFinance = ({
     return styles["groupBorder-summary-bot"];
   };
 
+  const tableMinWidth = useMemo(() => {
+    if (isTwoColumnLayout) {
+      return 560;
+    }
+
+    return Math.max(760, 260 + meses.length * 92 + 180);
+  }, [isTwoColumnLayout, meses.length]);
+
   return (
-    <div className={styles.tableResponsiveWrapper}>
+    <div className={styles.tableShell}>
       <div className={styles.scrollHint}>
         Desliza horizontalmente para ver todos los meses →
       </div>
-      <div className={getContainerClass() + " " + styles.tableFinance}>
-        <div className={styles.tableHeaderRow}>
-          <div className={`${styles.headerCell} ${styles.titleHeaderCell}`}>
-            <span>{title}</span>
-          </div>
-          {meses.map((mes, index) => (
-            <div
-              key={"meses" + index}
-              className={`${styles.headerCell} ${styles.monthHeaderCell}`}
-            >
-              <span>{mes.toUpperCase()}</span>
+      <div className={styles.tableResponsiveWrapper}>
+        <div
+          className={getContainerClass() + " " + styles.tableFinance}
+          style={
+            {
+              "--table-finance-min-width": `${tableMinWidth}px`,
+            } as CSSProperties
+          }
+        >
+          <div className={styles.tableHeaderRow}>
+            <div className={`${styles.headerCell} ${styles.titleHeaderCell}`}>
+              <span>{title}</span>
             </div>
-          ))}
-
-          <div
-            className={`${styles.headerCell} ${styles.totalHeaderCell} ${
-              isTwoColumnLayout ? styles.alignCellContentRight : ""
-            }`}
-          >
-            <span>{title2}</span>
-          </div>
-        </div>
-
-        {data.map((item, index) => {
-          const isOpen = dropStates[index]?.drop;
-          const subLength = item.sub?.length || 0;
-          return (
-            <React.Fragment key={"item" + index}>
+            {meses.map((mes, index) => (
               <div
-                className={
-                  `${styles.dataRow} ${isOpen ? styles.dataRowActive : ""} ` +
-                  (isOpen ? getGroupTopClass() : "")
-                }
+                key={"meses" + index}
+                className={`${styles.headerCell} ${styles.monthHeaderCell}`}
+              >
+                <span>{mes.toUpperCase()}</span>
+              </div>
+            ))}
+
+            <div
+              className={`${styles.headerCell} ${styles.totalHeaderCell} ${
+                isTwoColumnLayout ? styles.alignCellContentRight : ""
+              }`}
+            >
+              <span>{title2}</span>
+            </div>
+          </div>
+
+          {data.map((item, index) => {
+            const isOpen = dropStates[index]?.drop;
+            const subLength = item.sub?.length || 0;
+            return (
+              <React.Fragment key={"item" + index}>
+                <div
+                  className={
+                    `${styles.dataRow} ${isOpen ? styles.dataRowActive : ""} ` +
+                    (isOpen ? getGroupTopClass() : "")
+                  }
+                >
+                  <div
+                    className={`${styles.dataCell} ${styles.categoryNameCell}`}
+                    onClick={() => item.sub?.length > 0 && handleItemClick(index)}
+                  >
+                    {item.sub?.length > 0 && (
+                      <span className={styles.expandIcon}>
+                        {isOpen ? (
+                          <IconArrowUp size={24} />
+                        ) : (
+                          <IconArrowDown size={24} />
+                        )}
+                      </span>
+                    )}
+                    <span>{item.name}</span>
+                  </div>
+                  {Array.from({ length: meses.length }).map((_, mesIdx) => {
+                    const valor = item.totalMeses?.[mesIdx];
+                    return (
+                      <div
+                        key={`item-${index}-mes-${mesIdx}`}
+                        className={`${styles.dataCell} ${styles.monthDataCell} ${
+                          !valor || valor === "-" ? styles["no-value"] : ""
+                        }`}
+                      >
+                        <span>
+                          {valor && valor !== 0 ? formatNumber(valor) : "-"}
+                        </span>
+                      </div>
+                    );
+                  })}
+                  <div
+                    className={`${styles.dataCell} ${styles.totalDataCell} ${
+                      isTwoColumnLayout ? styles.alignCellContentRight : ""
+                    }`}
+                  >
+                    <span>Bs {formatNumber(item.amount)}</span>
+                  </div>
+                </div>
+                {isOpen &&
+                  item.sub?.map((subItem, subIndex) => {
+                    const isLast = subIndex === subLength - 1;
+                    return (
+                      <div
+                        className={
+                          `${styles.dataRow} ${styles.subItemRow} ` +
+                          (isLast ? getGroupBotClass() : getGroupMidClass())
+                        }
+                        key={`subitem-${index}-${subIndex}`}
+                      >
+                        <div
+                          className={`${styles.dataCell} ${styles.subCategoryNameCell}`}
+                        >
+                          <span>{subItem.name}</span>
+                        </div>
+                        {Array.from({ length: meses.length }).map((_, mesIdx) => {
+                          const valor = subItem.totalMeses?.[mesIdx];
+                          return (
+                            <div
+                              key={`subitem-${index}-${subIndex}-mes-${mesIdx}`}
+                              className={`${styles.dataCell} ${
+                                styles.monthDataCell
+                              } ${
+                                !valor || valor === "-" ? styles["no-value"] : ""
+                              }`}
+                            >
+                              <span>
+                                {valor && valor !== 0
+                                  ? formatNumber(valor)
+                                  : "-"}
+                              </span>
+                            </div>
+                          );
+                        })}
+                        <div
+                          className={`${styles.dataCell} ${
+                            styles.totalDataCell
+                          } ${
+                            isTwoColumnLayout ? styles.alignCellContentRight : ""
+                          }`}
+                        >
+                          <span>Bs {formatNumber(subItem.amount)}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+              </React.Fragment>
+            );
+          })}
+          {typeof total !== "undefined" && (
+            <div className={styles.tableTotalRowContainer}>
+              <div
+                className={`${styles.tableTotalRow} ${getTotalRowVariantClass()} ${
+                  styles.totalRowOutside
+                }`}
               >
                 <div
-                  className={`${styles.dataCell} ${styles.categoryNameCell}`}
-                  onClick={() => item.sub?.length > 0 && handleItemClick(index)}
+                  className={`${
+                    styles.totalLabelCell
+                  } ${getTotalLabelCellVariantClass()} ${getTotalTextColorClass()}`}
                 >
-                  {item.sub?.length > 0 && (
-                    <span className={styles.expandIcon}>
-                      {isOpen ? (
-                        <IconArrowUp size={24} />
-                      ) : (
-                        <IconArrowDown size={24} />
-                      )}
-                    </span>
-                  )}
-                  <span>{item.name}</span>
-                </div>
-                {Array.from({ length: meses.length }).map((_, mesIdx) => {
-                  const valor = item.totalMeses?.[mesIdx];
-                  return (
-                    <div
-                      key={`item-${index}-mes-${mesIdx}`}
-                      className={`${styles.dataCell} ${styles.monthDataCell} ${
-                        !valor || valor === "-" ? styles["no-value"] : ""
-                      }`}
-                    >
-                      <span>
-                        {valor && valor !== 0 ? formatNumber(valor) : "-"}
-                      </span>
+                  {tooltip && (
+                    <div className={styles.tooltipContainer}>
+                      <IconTableHelp className={styles.tooltipIcon} />
+                      <span className={styles.tooltip}>{tooltip}</span>
                     </div>
-                  );
-                })}
+                  )}
+                  <span>{titleTotal ?? "Total de " + title}</span>
+                </div>
                 <div
-                  className={`${styles.dataCell} ${styles.totalDataCell} ${
+                  className={`${
+                    styles.totalAmountCell
+                  } ${getTotalAmountCellVariantClass()} ${getTotalTextColorClass()} ${
                     isTwoColumnLayout ? styles.alignCellContentRight : ""
                   }`}
                 >
-                  <span>Bs {formatNumber(item.amount)}</span>
+                  <span>Bs {formatNumber(total)}</span>
                 </div>
               </div>
-              {isOpen &&
-                item.sub?.map((subItem, subIndex) => {
-                  const isLast = subIndex === subLength - 1;
-                  return (
-                    <div
-                      className={
-                        `${styles.dataRow} ${styles.subItemRow} ` +
-                        (isLast ? getGroupBotClass() : getGroupMidClass())
-                      }
-                      key={`subitem-${index}-${subIndex}`}
-                    >
-                      <div
-                        className={`${styles.dataCell} ${styles.subCategoryNameCell}`}
-                      >
-                        <span>{subItem.name}</span>
-                      </div>
-                      {Array.from({ length: meses.length }).map((_, mesIdx) => {
-                        const valor = subItem.totalMeses?.[mesIdx];
-                        return (
-                          <div
-                            key={`subitem-${index}-${subIndex}-mes-${mesIdx}`}
-                            className={`${styles.dataCell} ${
-                              styles.monthDataCell
-                            } ${
-                              !valor || valor === "-" ? styles["no-value"] : ""
-                            }`}
-                          >
-                            <span>
-                              {valor && valor !== 0 ? formatNumber(valor) : "-"}
-                            </span>
-                          </div>
-                        );
-                      })}
-                      <div
-                        className={`${styles.dataCell} ${
-                          styles.totalDataCell
-                        } ${
-                          isTwoColumnLayout ? styles.alignCellContentRight : ""
-                        }`}
-                      >
-                        <span>Bs {formatNumber(subItem.amount)}</span>
-                      </div>
-                    </div>
-                  );
-                })}
-            </React.Fragment>
-          );
-        })}
-        {/* Fila de Total General SOLO en móvil */}
-        {isMobile && typeof total !== "undefined" && (
-          <div
-            className={`${styles.tableTotalRow} ${getTotalRowVariantClass()} ${
-              styles.totalRowOutside
-            }`}
-          >
-            <div
-              className={`${
-                styles.totalLabelCell
-              } ${getTotalLabelCellVariantClass()} ${getTotalTextColorClass()}`}
-            >
-              {tooltip && (
-                <div className={styles.tooltipContainer}>
-                  <IconTableHelp className={styles.tooltipIcon} />
-                  <span className={styles.tooltip}>{tooltip}</span>
-                </div>
-              )}
-              <span>{titleTotal ?? "Total de " + title}</span>
             </div>
-            <div
-              className={`${
-                styles.totalAmountCell
-              } ${getTotalAmountCellVariantClass()} ${getTotalTextColorClass()} ${
-                isTwoColumnLayout ? styles.alignCellContentRight : ""
-              }`}
-            >
-              <span>Bs {formatNumber(total)}</span>
-            </div>
-          </div>
-        )}
-      </div>
-      {/* Fila de Total General SOLO en desktop */}
-      {!isMobile && typeof total !== "undefined" && (
-        <div className={styles.tableTotalRowContainer}>
-          <div
-            className={`${styles.tableTotalRow} ${getTotalRowVariantClass()} ${
-              styles.totalRowOutside
-            }`}
-          >
-            <div
-              className={`${
-                styles.totalLabelCell
-              } ${getTotalLabelCellVariantClass()} ${getTotalTextColorClass()}`}
-            >
-              {tooltip && (
-                <div className={styles.tooltipContainer}>
-                  <IconTableHelp className={styles.tooltipIcon} />
-                  <span className={styles.tooltip}>{tooltip}</span>
-                </div>
-              )}
-              <span>{titleTotal ?? "Total de " + title}</span>
-            </div>
-            <div
-              className={`${
-                styles.totalAmountCell
-              } ${getTotalAmountCellVariantClass()} ${getTotalTextColorClass()} ${
-                isTwoColumnLayout ? styles.alignCellContentRight : ""
-              }`}
-            >
-              <span>Bs {formatNumber(total)}</span>
-            </div>
-          </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/modulos/Binnacle/RenderView/RenderView.module.css
+++ b/src/modulos/Binnacle/RenderView/RenderView.module.css
@@ -2,9 +2,9 @@
   display: flex;
   gap: 20px;
   padding: 16px;
-  background-color: #d7fff005;
+  background-color: var(--cModalSection);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   width: 100%;
 }
 
@@ -19,7 +19,7 @@
 .imageWrapper {
   width: 380px;
   height: 300px;
-  background-color: #d7fff005;
+  background-color: var(--cModalSurfaceRaised);
   border-radius: var(--bRadiusS);
   overflow: hidden;
   display: flex;
@@ -38,9 +38,9 @@
 }
 
 .button {
-  background-color: #d7fff005;
+  background-color: var(--cModalSurfaceRaised);
   padding: 6px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   border-radius: 100%;
   display: flex;
   justify-content: center;
@@ -67,7 +67,7 @@
   flex-direction: column;
   gap: 6px;
   padding-bottom: 12px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid var(--cModalDivider);
 }
 
 .label {

--- a/src/modulos/Budget/Budget/RenderView/RenderView.module.css
+++ b/src/modulos/Budget/Budget/RenderView/RenderView.module.css
@@ -1,5 +1,5 @@
 .container {
-  background-color: #d7fff005;
+  background-color: var(--cBackground);
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   color: var(--cWhite);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cBorder);
   min-width: 600px;
 }
 
@@ -39,7 +39,7 @@
   width: 100%;
   border: none;
   height: 0;
-  border-top: 0.5px solid var(--cWhiteV1);
+  border-top: 1px solid var(--cBorder);
 }
 
 .detailsSection {

--- a/src/modulos/Contents/RenderView/RenderView.module.css
+++ b/src/modulos/Contents/RenderView/RenderView.module.css
@@ -4,9 +4,9 @@
   gap: 12px;
   padding: 16px;
   min-height: 400px;
-  background-color: #d7fff005;
+  background-color: var(--cModalSection);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
 }
 
 .header {
@@ -62,7 +62,7 @@
 
 .imageWrapper {
   height: 400px;
-  background-color: #d7fff005;
+  background-color: var(--cModalSurfaceRaised);
   border-radius: var(--bRadiusS);
   overflow: hidden;
   display: flex;
@@ -93,9 +93,9 @@
 }
 
 .button {
-  background-color: #d7fff005;
+  background-color: var(--cModalSurfaceRaised);
   padding: 6px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   border-radius: 100%;
   display: flex;
   justify-content: center;
@@ -124,7 +124,7 @@
   align-items: center;
   gap: 12px;
   padding-bottom: 12px;
-  border-bottom: 0.3px solid rgba(215, 255, 240, 0.12);
+  border-bottom: 1px solid var(--cModalDivider);
 }
 
 .userInfo {
@@ -221,8 +221,8 @@
 /* Agregar estos estilos al archivo existente */
 
 .button {
-  background-color: #d7fff005;
-  border: 1px solid #d7fff014;
+  background-color: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
   border-radius: var(--bRadiusS);
   padding: 8px;
   cursor: pointer;
@@ -233,7 +233,7 @@
 }
 
 .button:hover {
-  background-color: rgba(0, 227, 140, 0.12);
+  background-color: rgba(0, 227, 140, 0.08);
 }
 
 .button:active {
@@ -285,7 +285,7 @@
         overflow: hidden;
         height: 300px;
         border-radius: 12px;
-        background-color: #d7fff005;
+        background-color: var(--cModalSurfaceRaised);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -301,9 +301,9 @@
         margin-top: 16px;
 
         .button {
-          background-color: #d7fff005;
+          background-color: var(--cModalSurfaceRaised);
           padding: 6px;
-          border: 1px solid #d7fff014;
+          border: 1px solid var(--cModalBorder);
           border-radius: 100%;
           display: flex;
           justify-content: center;
@@ -312,7 +312,7 @@
           transition: background-color 0.2s ease;
 
           &:hover {
-            background-color: rgba(0, 227, 140, 0.12);
+            background-color: rgba(0, 227, 140, 0.08);
           }
         }
       }

--- a/src/modulos/DashDptos/AccessTable/AccessTable.tsx
+++ b/src/modulos/DashDptos/AccessTable/AccessTable.tsx
@@ -140,24 +140,28 @@ const AccessTable = ({ access }: AccessTableProps) => {
       key: "visit",
       label: "Visita",
       responsive: "desktop",
+      width: "260px",
       onRender: visitCell,
     },
     {
       key: "visited_to",
       label: "Visitó a",
       responsive: "desktop",
+      width: "240px",
       onRender: visitedToCell,
     },
     {
       key: "type",
       label: "Tipo de Acceso",
       responsive: "desktop",
+      width: "170px",
       onRender: typeCell,
     },
     {
       key: "entry_exit",
       label: "Ingreso/Salida",
       responsive: "desktop",
+      width: "180px",
       onRender: entryExitCell,
     },
   ];

--- a/src/modulos/DashDptos/PaymentsTable/PaymentsTable.tsx
+++ b/src/modulos/DashDptos/PaymentsTable/PaymentsTable.tsx
@@ -46,6 +46,7 @@ const PaymentsTable = ({ payments }: PaymentsTableProps) => {
       key: 'paid_at',
       label: 'Fecha de pago',
       responsive: 'desktop',
+      width: '160px',
       onRender: ({ item }: any) => {
         return getDateStrMes(item?.paid_at) || '-/-';
       },
@@ -54,11 +55,13 @@ const PaymentsTable = ({ payments }: PaymentsTableProps) => {
       key: 'payment_method',
       label: 'Método de pago',
       responsive: 'desktop',
+      width: '180px',
       onRender: paymentMethodCell,
     },
     {
       key: 'amount',
       label: 'Monto',
+      width: '150px',
       style: { textAlign: 'right', justifyContent: 'flex-end' },
       responsive: 'desktop',
       onRender: amountCell,
@@ -66,6 +69,7 @@ const PaymentsTable = ({ payments }: PaymentsTableProps) => {
     {
       key: 'status',
       label: 'Estado',
+      width: '210px',
       style: { textAlign: 'center', justifyContent: 'center' },
       responsive: 'desktop',
       onRender: statusCell,

--- a/src/modulos/DashDptos/ReservationsTable/ReservationsTable.tsx
+++ b/src/modulos/DashDptos/ReservationsTable/ReservationsTable.tsx
@@ -120,6 +120,7 @@ const ReservationsTable = ({ reservations }: ReservationsTableProps) => {
       key: "area",
       label: "Área social",
       responsive: "desktop",
+      width: "280px",
       onRender: areaInfoCell,
     },
 
@@ -127,12 +128,14 @@ const ReservationsTable = ({ reservations }: ReservationsTableProps) => {
       key: "reservation_date",
       label: "Fecha de reserva",
       responsive: "desktop",
+      width: "170px",
       onRender: dateReserveCell,
     },
     {
       key: "status",
       label: "Estado",
       responsive: "desktop",
+      width: "210px",
       style: { textAlign: "center", justifyContent: "center" },
       onRender: statusCell,
     },

--- a/src/modulos/DebtsManager/RenderView/RenderView.module.css
+++ b/src/modulos/DebtsManager/RenderView/RenderView.module.css
@@ -1,5 +1,5 @@
 .container {
-  background-color: #d7fff005;
+  background-color: var(--cModalSection);
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   color: var(--cWhite);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   min-width: 600px;
 }
 
@@ -37,7 +37,7 @@
   justify-content: flex-end;
   gap: var(--spM);
   padding-bottom: var(--spL);
-  border-bottom: 1px solid var(--cWhiteV1);
+  border-bottom: 1px solid var(--cModalDivider);
 }
 
 .iconButton {
@@ -110,7 +110,7 @@
   width: 100%;
   border: none;
   height: 0;
-  border-top: 0.5px solid var(--cWhiteV1);
+  border-top: 1px solid var(--cModalDivider);
 }
 
 .detailsSection {
@@ -187,9 +187,9 @@
   gap: var(--spL);
   width: 100%;
   padding: var(--spL);
-  background-color: rgba(18, 21, 25, 0.65);
+  background-color: var(--cModalSurfaceRaised);
   border-radius: var(--bRadiusS);
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
 }
 
 .advancedItem {
@@ -197,14 +197,14 @@
   flex-direction: column;
   gap: var(--spXs);
   padding: var(--spM);
-  background-color: #d7fff005;
+  background-color: var(--cModalSection);
   border-radius: var(--bRadiusS);
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   transition: all 0.2s ease;
 }
 
 .advancedItem:hover {
-  border-color: #d7fff014;
+  border-color: var(--cModalBorder);
   background-color: rgba(0, 227, 140, 0.08);
 }
 
@@ -248,7 +248,7 @@
 
 .canceledReason {
   font-style: italic;
-  background-color: rgba(220, 53, 69, 0.1);
+  background-color: rgba(228, 96, 85, 0.12);
   padding: 8px 12px;
   border-radius: 4px;
   border-left: 3px solid var(--cError);

--- a/src/modulos/Events/RenderView/EventsRenderView.module.css
+++ b/src/modulos/Events/RenderView/EventsRenderView.module.css
@@ -3,8 +3,8 @@
 
 }
 .cardEvent {
-  background-color: #d7fff005;
-  border: 1px solid #d7fff014;
+  background-color: var(--cBackground);
+  border: 1px solid var(--cBorder);
   border-radius: 12px;
   padding:var(--spS);
   width: 100%;
@@ -85,9 +85,9 @@
     & > div {
       flex: 1;
 
-      background-color: #d7fff005;
+      background-color: var(--cBackground);
       border-radius: 8px;
-      border: 1px solid #d7fff014;
+      border: 1px solid var(--cBorder);
       padding: 8px 0px;
       & > p:nth-child(1) {
         text-align: center;

--- a/src/modulos/NewReserva/NewReserva.module.css
+++ b/src/modulos/NewReserva/NewReserva.module.css
@@ -1,0 +1,463 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: calc(100vh - 150px);
+}
+
+.header {
+  align-items: flex-end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.heading {
+  max-width: 760px;
+}
+
+.eyebrow {
+  color: var(--cWhiteV3);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.title {
+  color: var(--cWhite);
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.05;
+  margin-top: 6px;
+}
+
+.subtitle {
+  color: var(--cWhiteV1);
+  font-size: 14px;
+  line-height: 1.55;
+  margin-top: 8px;
+}
+
+.primaryAction {
+  align-items: center;
+  background: var(--cPrimary);
+  border: 0;
+  border-radius: 8px;
+  color: var(--cNeutral-900);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 700;
+  gap: 8px;
+  height: 40px;
+  padding: 0 14px;
+  transition:
+    filter 0.18s ease,
+    transform 0.18s ease;
+}
+
+.primaryAction:hover {
+  filter: brightness(0.97);
+}
+
+.calendarShell {
+  position: relative;
+  --df-calendar-height: clamp(720px, calc(100vh - 220px), 980px);
+  --df-color-background: var(--cBackground);
+  --df-color-card: var(--cBlackV1);
+  --df-color-card-foreground: var(--cWhite);
+  --df-color-foreground: var(--cWhite);
+  --df-color-hover: color-mix(in srgb, var(--cPrimary) 12%, var(--cBlackV1));
+  --df-color-border: color-mix(in srgb, var(--cDivider) 70%, transparent);
+  --df-color-muted: var(--cBlack);
+  --df-color-muted-foreground: var(--cWhiteV1);
+  --df-color-primary: var(--cPrimary);
+  --df-color-primary-foreground: var(--cBlack);
+  --df-color-secondary: var(--cBlackV2);
+  --df-color-secondary-foreground: var(--cWhite);
+  --df-color-destructive: var(--cError);
+  --df-color-destructive-foreground: var(--cWhite);
+  --df-heat-1: color-mix(in srgb, var(--cPrimary) 16%, var(--cBlackV1));
+  --df-heat-2: color-mix(in srgb, var(--cPrimary) 28%, var(--cBlackV1));
+  --df-heat-3: color-mix(in srgb, var(--cPrimary) 42%, var(--cBlackV1));
+  --df-heat-4: color-mix(in srgb, var(--cPrimary) 58%, var(--cBlackV1));
+  --df-heat-5: color-mix(in srgb, var(--cPrimary) 76%, var(--cBlackV1));
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.calendarShell :global(.df-calendar-container) {
+  border: 1px solid var(--df-color-border);
+  border-radius: 8px;
+  box-shadow: none;
+  background: var(--df-color-background);
+  color: var(--df-color-foreground);
+}
+
+.calendarShell :global(.df-header) {
+  border-bottom: 1px solid var(--df-color-border);
+  background: var(--cBlackV1);
+}
+
+.calendarShell :global(.df-sidebar) {
+  width: 280px;
+  background: var(--cBlack);
+  border-right: 1px solid var(--df-color-border);
+}
+
+.calendarShell :global(.df-event-detail-panel),
+.calendarShell :global(.df-search-popover),
+.calendarShell :global(.df-popover-content),
+.calendarShell :global(.df-mini-calendar),
+.calendarShell :global(.df-button-group),
+.calendarShell :global(.df-day-view),
+.calendarShell :global(.df-week-view),
+.calendarShell :global(.df-month-view),
+.calendarShell :global(.df-year-view) {
+  background: transparent;
+}
+
+.calendarShell :global(.df-time-grid),
+.calendarShell :global(.df-month-grid),
+.calendarShell :global(.df-year-grid),
+.calendarShell :global(.df-event-detail-panel),
+.calendarShell :global(.df-mini-calendar) {
+  border-color: var(--df-color-border);
+}
+
+.calendarShell :global(.df-month-week-event-layer),
+.calendarShell :global(.df-month-week-event-layer-row) {
+  z-index: 2;
+}
+
+.calendarShell :global(.df-month-day-cell-overlay-mask) {
+  display: none;
+}
+
+.calendarShell :global(.df-event[data-view="month"]) {
+  min-height: 18px;
+}
+
+.calendarShell :global(.df-month-segment-event),
+.calendarShell :global(.df-event-month-regular),
+.calendarShell :global(.df-event-month-all-day) {
+  align-items: center;
+  border-radius: 6px;
+  min-height: 18px;
+}
+
+.calendarShell :global(.df-button),
+.calendarShell :global(.df-icon-button),
+.calendarShell :global(.df-segmented-control-button),
+.calendarShell :global(.df-calendar-nav-button),
+.calendarShell :global(.df-calendar-today-button),
+.calendarShell :global(.df-calendar-picker-trigger),
+.calendarShell :global(.df-view-switcher-btn) {
+  color: var(--cWhite);
+}
+
+.calendarShell :global(.df-button:hover),
+.calendarShell :global(.df-icon-button:hover),
+.calendarShell :global(.df-segmented-control-button:hover),
+.calendarShell :global(.df-calendar-nav-button:hover),
+.calendarShell :global(.df-calendar-today-button:hover),
+.calendarShell :global(.df-calendar-picker-trigger:hover),
+.calendarShell :global(.df-view-switcher-btn:hover) {
+  background: var(--df-color-hover);
+}
+
+.calendarShell :global(.df-segmented-control-button[data-state="active"]),
+.calendarShell :global(.df-button[data-variant="primary"]),
+.calendarShell :global(.df-view-switcher-btn[data-active="true"]) {
+  background: var(--cPrimary);
+  color: var(--cBlack);
+  box-shadow: none;
+}
+
+.calendarShell :global(.df-time-label),
+.calendarShell :global(.df-weekday-label),
+.calendarShell :global(.df-month-day-label),
+.calendarShell :global(.df-mini-calendar-weekday),
+.calendarShell :global(.df-muted),
+.calendarShell :global(.df-mini-calendar-header),
+.calendarShell :global(.df-view-header-subtitle),
+.calendarShell :global(.df-year-grid-day-number),
+.calendarShell :global(.df-calendar-picker-label) {
+  color: var(--cWhiteV1);
+}
+
+.calendarShell :global(.df-grid-line),
+.calendarShell :global(.df-divider) {
+  border-color: var(--df-color-border);
+}
+
+.calendarShell :global(.df-view-header-title),
+.calendarShell :global(.df-mini-calendar-month-label),
+.calendarShell :global(.df-mini-calendar-day),
+.calendarShell :global(.df-mini-calendar-day-number) {
+  color: var(--cWhite);
+}
+
+.calendarShell :global(.df-view-switcher) {
+  align-items: center;
+  background: var(--cBlack);
+  border: 1px solid var(--df-color-border);
+  border-radius: 10px;
+  display: inline-flex;
+  gap: 4px;
+  min-height: 48px;
+  padding: 4px;
+}
+
+.calendarShell :global(.df-view-switcher-btn) {
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  min-height: 40px;
+  padding-inline: 16px;
+}
+
+.calendarShell :global(.df-navigation),
+.calendarShell :global(.df-view-header-nav) {
+  gap: 8px;
+}
+
+.calendarShell :global(.df-calendar-nav-button) {
+  background: var(--cBlack);
+  border-color: var(--df-color-border);
+  border-radius: 10px;
+  height: 48px;
+  width: 48px;
+}
+
+.calendarShell :global(.df-calendar-today-button),
+.calendarShell :global(.df-calendar-picker-trigger),
+.calendarShell :global(.df-search-group-input) {
+  background: var(--cBlack);
+  border: 1px solid var(--df-color-border);
+  border-radius: 10px;
+  color: var(--cWhite);
+  height: 48px;
+}
+
+.calendarShell :global(.df-calendar-today-button) {
+  font-size: 14px;
+  font-weight: 600;
+  padding: 0 16px;
+}
+
+.calendarShell :global(.df-calendar-picker-trigger) {
+  box-shadow: none;
+  padding: 0 14px;
+}
+
+.calendarShell :global(.df-search-group-input) {
+  box-shadow: none;
+  padding-left: 42px;
+  padding-right: 38px;
+}
+
+.calendarShell :global(.df-search-group-input::placeholder) {
+  color: var(--cWhiteV1);
+}
+
+.calendarShell :global(.df-search-group-input:focus) {
+  border-color: var(--cPrimary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--cPrimary) 22%, transparent);
+}
+
+.calendarShell :global(.df-search-group-icon),
+.calendarShell :global(.df-search-group-clear),
+.calendarShell :global(.df-calendar-picker-trigger svg),
+.calendarShell :global(.df-calendar-nav-button svg),
+.calendarShell :global(.df-mini-calendar-nav-btn),
+.calendarShell :global(.df-mini-calendar-nav-btn svg) {
+  color: var(--cWhiteV1);
+}
+
+.calendarShell :global(.df-mini-calendar-nav-btn:hover) {
+  background: color-mix(in srgb, var(--cPrimary) 12%, transparent);
+}
+
+.calendarShell :global(.df-search-results-date-header) {
+  background: var(--cBlackV1);
+}
+
+.calendarShell :global(.df-search-results-event:hover) {
+  background: color-mix(in srgb, var(--cPrimary) 10%, transparent);
+}
+
+.loadingBadge {
+  background: color-mix(in srgb, var(--cBlackV1) 92%, transparent);
+  border: 1px solid var(--cDivider);
+  border-radius: 999px;
+  color: var(--cWhite);
+  font-size: 12px;
+  font-weight: 700;
+  padding: 6px 10px;
+  position: absolute;
+  right: 16px;
+  top: 16px;
+  z-index: 4;
+}
+
+.eventBody {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.eventTitle {
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.eventMeta {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+  opacity: 0.8;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detailContent {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.detailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detailHeaderRow {
+  align-items: flex-start;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.detailTitle {
+  color: var(--cWhite);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.detailDate {
+  color: var(--cWhiteV1);
+  font-size: 13px;
+  line-height: 1.4;
+  margin-top: 4px;
+}
+
+.statusPill {
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 8px 10px;
+  white-space: nowrap;
+}
+
+.detailGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.detailItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.detailItemWide {
+  grid-column: 1 / -1;
+}
+
+.detailLabel {
+  color: var(--cWhiteV1);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.detailValue {
+  color: var(--cWhite);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.detailValueMuted {
+  color: var(--cWhiteV1);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.detailActions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.detailButton {
+  align-items: center;
+  background: var(--cPrimary);
+  border: 0;
+  border-radius: 8px;
+  color: var(--cNeutral-900);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 700;
+  height: 38px;
+  padding: 0 14px;
+}
+
+.detailButton:hover {
+  filter: brightness(0.97);
+}
+
+.emptyDetail {
+  color: var(--cWhiteV1);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+@media (max-width: 1024px) {
+  .calendarShell {
+    --df-calendar-height: calc(100vh - 250px);
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    gap: 12px;
+  }
+
+  .title {
+    font-size: 28px;
+  }
+
+  .calendarShell {
+    --df-calendar-height: calc(100vh - 220px);
+  }
+
+  .detailGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/modulos/NewReserva/NewReserva.tsx
+++ b/src/modulos/NewReserva/NewReserva.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  createDayView,
+  createMonthView,
+  createWeekView,
+  createYearView,
+  DayFlowCalendar,
+  useCalendarApp,
+  ViewType,
+  type CalendarSearchEvent,
+  type Event as DayFlowEvent,
+  type EventContentSlotArgs,
+} from "@dayflow/react";
+import { useRouter } from "next/navigation";
+import NotAccess from "@/components/auth/NotAccess/NotAccess";
+import ReservationDetailModal from "@/modulos/Reservas/RenderView/RenderView";
+import { IconNewReserve } from "@/components/layout/icons/IconsBiblioteca";
+import styles from "./NewReserva.module.css";
+import { useNewReserva } from "./useNewReserva";
+import {
+  RESERVATION_CALENDARS,
+  getReservationFromCalendarEvent,
+  getReservationMetaFromCalendarEvent,
+  getVisibleRangeForView,
+  normalizeSearchText,
+} from "./helpers";
+
+const NewReserva = () => {
+  const router = useRouter();
+  const controller = useNewReserva();
+  const calendarLocale = useMemo(
+    () => ({
+      code: "es",
+      messages: {
+        allDay: "Todo el día",
+        today: "Hoy",
+        tomorrow: "Mañana",
+        day: "Día",
+        week: "Semana",
+        month: "Mes",
+        year: "Año",
+        search: "Buscar",
+        noResults: "Sin resultados",
+        calendar: "Calendario",
+        starts: "Inicio",
+        ends: "Fin",
+        notes: "Notas",
+        viewEvent: "Ver evento",
+        done: "Cerrar",
+      },
+    }),
+    [],
+  );
+
+  const renderEventContent = useCallback(({ event }: EventContentSlotArgs) => {
+    const meta = getReservationMetaFromCalendarEvent(event);
+    const eventMeta = [meta?.unitLabel, meta?.residentName]
+      .filter(Boolean)
+      .join(" · ");
+
+    return (
+      <div className={styles.eventBody}>
+        <span className={styles.eventTitle}>{meta?.areaName || event.title}</span>
+        {eventMeta ? <span className={styles.eventMeta}>{eventMeta}</span> : null}
+      </div>
+    );
+  }, []);
+
+  const searchConfig = useMemo(
+    () => ({
+      emptyText: "Sin resultados",
+      customSearch: ({
+        keyword,
+        events,
+      }: {
+        keyword: string;
+        events: CalendarSearchEvent[];
+      }) => {
+        const normalizedKeyword = normalizeSearchText(keyword);
+        if (!normalizedKeyword) return events;
+
+        return events.filter((event) => {
+          const meta = getReservationMetaFromCalendarEvent(event);
+          const haystack = [
+            event.title,
+            event.description,
+            meta?.searchText,
+          ]
+            .filter(Boolean)
+            .join(" ");
+
+          return normalizeSearchText(haystack).includes(normalizedKeyword);
+        });
+      },
+      onResultClick: ({
+        event,
+        defaultAction,
+      }: {
+        event: CalendarSearchEvent;
+        defaultAction: () => void;
+      }) => {
+        const reservation = getReservationFromCalendarEvent(event);
+        if (reservation) {
+          defaultAction();
+          controller.openReservationDetail(reservation);
+          return;
+        }
+        defaultAction();
+      },
+    }),
+    [controller.openReservationDetail],
+  );
+
+  const initialDateRef = useRef(new Date());
+  const lastCalendarStateRef = useRef<{
+    view: ViewType;
+    date: Date;
+  }>({
+    view: ViewType.MONTH,
+    date: initialDateRef.current,
+  });
+
+  const dayflowConfig = useMemo(
+    () => ({
+      views: [
+        createDayView({
+          showAllDay: true,
+        }),
+        createWeekView({
+          startOfWeek: 1,
+          showAllDay: true,
+        }),
+        createMonthView({
+          startOfWeek: 1,
+          scroll: { disabled: true, transition: "fade" },
+        }),
+        createYearView(),
+      ],
+      events: controller.calendarEvents,
+      calendars: RESERVATION_CALENDARS,
+      defaultView: lastCalendarStateRef.current.view,
+      initialDate: lastCalendarStateRef.current.date,
+      switcherMode: "buttons" as const,
+      useCalendarHeader: true,
+      useEventDetailDialog: false,
+      useEventDetailPanel: false,
+      locale: calendarLocale,
+      readOnly: true,
+      theme: { mode: "dark" as const },
+      callbacks: {
+        onEventClick: (event: DayFlowEvent) => {
+          const reservation = getReservationFromCalendarEvent(event);
+          if (reservation) {
+            controller.openReservationDetail(reservation);
+          }
+        },
+      },
+    }),
+    [calendarLocale, controller.calendarEvents, controller.openReservationDetail],
+  );
+
+  const calendarVersion = useMemo(
+    () =>
+      controller.calendarEvents
+        .map((event) => `${event.id}:${String(event.start)}:${String(event.end)}`)
+        .join("|"),
+    [controller.calendarEvents],
+  );
+
+  const calendar = useCalendarApp(dayflowConfig, calendarVersion);
+
+  useEffect(() => {
+    lastCalendarStateRef.current = {
+      view: calendar.currentView as ViewType,
+      date: new Date(calendar.currentDate),
+    };
+  }, [calendar.currentDate, calendar.currentView]);
+
+  useEffect(() => {
+    const range = getVisibleRangeForView(
+      calendar.currentDate,
+      calendar.currentView,
+    );
+
+    controller.handleVisibleRangeChange(range.start, range.end);
+  }, [calendar.currentDate, calendar.currentView, controller.handleVisibleRangeChange]);
+
+  useEffect(() => {
+    calendar.highlightEvent(controller.selectedReservationId);
+  }, [calendar, controller.selectedReservationId]);
+
+  if (!controller.canView) return <NotAccess />;
+
+  return (
+    <section className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.heading}>
+          <p className={styles.eyebrow}>Reservas</p>
+          <h1 className={styles.title}>Calendario</h1>
+          <p className={styles.subtitle}>
+            Esta vista usa DayFlow como superficie principal y deja intacto el
+            flujo multistep existente para crear reservas.
+          </p>
+        </div>
+
+        {controller.canCreate ? (
+          <button
+            type="button"
+            className={styles.primaryAction}
+            onClick={() => router.push("/create-reservas")}
+          >
+            <IconNewReserve size={18} />
+            Nueva reserva
+          </button>
+        ) : null}
+      </header>
+
+      <div className={styles.calendarShell}>
+        {controller.loading ? (
+          <div className={styles.loadingBadge}>Actualizando reservas...</div>
+        ) : null}
+
+        <DayFlowCalendar
+          calendar={calendar}
+          search={searchConfig}
+          eventContentDay={renderEventContent}
+          eventContentWeek={renderEventContent}
+          eventContentYear={renderEventContent}
+          eventContentAllDayDay={renderEventContent}
+          eventContentAllDayWeek={renderEventContent}
+          eventContentAllDayYear={renderEventContent}
+        />
+      </div>
+
+      {controller.detailItem ? (
+        <ReservationDetailModal
+          open
+          item={controller.detailItem}
+          onClose={() => controller.setDetailItem(null)}
+          reLoad={controller.reloadCurrentRange}
+        />
+      ) : null}
+    </section>
+  );
+};
+
+export default NewReserva;

--- a/src/modulos/NewReserva/helpers.ts
+++ b/src/modulos/NewReserva/helpers.ts
@@ -1,0 +1,397 @@
+import {
+  createAllDayEvent,
+  createTimedEvent,
+  type CalendarType,
+  type Event as DayFlowEvent,
+} from "@dayflow/core";
+import {
+  addHours,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  format,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+} from "date-fns";
+import { formatBs } from "@/mk/utils/numbers";
+import { getFullName } from "@/mk/utils/string";
+import {
+  RESERVATION_STATUS_CONFIG,
+  getUpdatedReservationStatus,
+  type ReservationStatus,
+} from "@/modulos/Reservas/constants/reservationConstants";
+import type {
+  NewReservaResident,
+  NewReservaUnit,
+  ReservationCalendarKey,
+  ReservationCalendarMeta,
+  ReservationListItem,
+  ReservationVisibleRange,
+} from "./types";
+
+export const RESERVATION_CALENDARS: CalendarType[] = [
+  {
+    id: "pending",
+    name: "Pendientes",
+    icon: "P",
+    colors: {
+      eventColor: "#E9B01E2B",
+      eventSelectedColor: "#E9B01E45",
+      lineColor: "#E9B01E",
+      textColor: "#FFD977",
+    },
+    isVisible: true,
+  },
+  {
+    id: "confirmed",
+    name: "Reservadas",
+    icon: "R",
+    colors: {
+      eventColor: "#00E38C26",
+      eventSelectedColor: "#00E38C40",
+      lineColor: "#00E38C",
+      textColor: "#8AF5C9",
+    },
+    isVisible: true,
+  },
+  {
+    id: "cancelled",
+    name: "Canceladas",
+    icon: "C",
+    colors: {
+      eventColor: "#E4605528",
+      eventSelectedColor: "#E4605542",
+      lineColor: "#E46055",
+      textColor: "#FFBAB3",
+    },
+    isVisible: true,
+  },
+  {
+    id: "maintenance",
+    name: "Mantenimiento",
+    icon: "M",
+    colors: {
+      eventColor: "#4285FA24",
+      eventSelectedColor: "#4285FA3F",
+      lineColor: "#4285FA",
+      textColor: "#A7C6FF",
+    },
+    isVisible: true,
+  },
+];
+
+export const normalizeSearchText = (value?: string | null) =>
+  (value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+
+export const formatDateKey = (date: Date) => format(date, "yyyy-MM-dd");
+
+export const getResidentFromUnit = (unit?: NewReservaUnit | null) => {
+  return unit?.tenant || unit?.homeowner || unit?.titular?.owner || null;
+};
+
+export const getResidentName = (resident?: NewReservaResident | null) => {
+  const fullName = getFullName({
+    name: resident?.name || undefined,
+    middle_name: resident?.middle_name || undefined,
+    last_name: resident?.last_name || undefined,
+    mother_last_name: resident?.mother_last_name || undefined,
+  });
+
+  return fullName || "Residente no disponible";
+};
+
+export const getUnitLabel = (unit?: NewReservaUnit | null) => {
+  if (!unit?.nro) return "Unidad sin asignar";
+  return `Unidad ${unit.nro}`;
+};
+
+export const getAreaName = (reservation?: ReservationListItem | null) => {
+  return reservation?.area?.title?.trim() || "Área social";
+};
+
+export const getReservationStatusMeta = (reservation?: ReservationListItem | null) => {
+  const nextStatus = getUpdatedReservationStatus(
+    reservation?.status as ReservationStatus | undefined,
+    reservation?.date_end || undefined,
+    reservation?.end_time || undefined,
+  );
+
+  if (!nextStatus) return null;
+  return RESERVATION_STATUS_CONFIG[nextStatus];
+};
+
+export const getReservationCalendarKey = (
+  status?: ReservationStatus | "X" | string | null,
+): ReservationCalendarKey => {
+  if (!status) return "pending";
+  if (status === "M") return "maintenance";
+  if (["R", "C", "T", "X"].includes(status)) return "cancelled";
+  if (["N", "L", "F"].includes(status)) return "confirmed";
+  return "pending";
+};
+
+const sortPeriods = (
+  periods?: ReservationListItem["periods"],
+): Array<{ time_from?: string | null; time_to?: string | null }> => {
+  if (!Array.isArray(periods)) return [];
+  return [...periods].sort((left, right) =>
+    String(left?.time_from || "").localeCompare(String(right?.time_from || "")),
+  );
+};
+
+const getTimeBounds = (reservation: ReservationListItem) => {
+  const sortedPeriods = sortPeriods(reservation.periods);
+  const firstPeriod = sortedPeriods[0];
+  const lastPeriod = sortedPeriods[sortedPeriods.length - 1];
+
+  return {
+    startTime:
+      reservation.start_time || firstPeriod?.time_from || null,
+    endTime:
+      reservation.end_time || lastPeriod?.time_to || null,
+  };
+};
+
+const buildDateTime = (dateAt: string, timeAt: string) => {
+  const safeTime = timeAt.length === 5 ? `${timeAt}:00` : timeAt;
+  return new Date(`${dateAt}T${safeTime}`);
+};
+
+const hasSyntheticFullDayTimes = (
+  startTime?: string | null,
+  endTime?: string | null,
+) => {
+  const normalizedStart = (startTime || "").slice(0, 5);
+  const normalizedEnd = (endTime || "").slice(0, 5);
+
+  if (normalizedStart === "23:59" && normalizedEnd === "23:59") {
+    return true;
+  }
+
+  return (
+    (normalizedStart === "00:00" || normalizedStart === "00:01") &&
+    (normalizedEnd === "23:59" || normalizedEnd === "23:58")
+  );
+};
+
+const getReservationDateBounds = (reservation: ReservationListItem) => {
+  if (!reservation.date_at) return null;
+
+  const { startTime, endTime } = getTimeBounds(reservation);
+  if (!startTime && !endTime) {
+    return {
+      allDay: true,
+      start: new Date(`${reservation.date_at}T00:00:00`),
+      end: new Date(`${reservation.date_at}T23:59:59`),
+    };
+  }
+
+  if (hasSyntheticFullDayTimes(startTime, endTime)) {
+    return {
+      allDay: true,
+      start: new Date(`${reservation.date_at}T00:00:00`),
+      end: new Date(`${reservation.date_at}T23:59:59`),
+    };
+  }
+
+  const start = buildDateTime(reservation.date_at, startTime || "08:00:00");
+  let end = buildDateTime(
+    reservation.date_at,
+    endTime || startTime || "09:00:00",
+  );
+
+  if (end <= start) {
+    end = addHours(start, 1);
+  }
+
+  return {
+    allDay: false,
+    start,
+    end,
+  };
+};
+
+export const formatReservationTimeRange = (
+  reservation?: ReservationListItem | null,
+) => {
+  if (!reservation) return "Horario no definido";
+
+  const { startTime, endTime } = getTimeBounds(reservation);
+  if (!startTime && !endTime) return "Todo el día";
+
+  const safeStart = (startTime || "00:00:00").slice(0, 5);
+  const safeEnd = (endTime || startTime || "00:00:00").slice(0, 5);
+  return `${safeStart} - ${safeEnd}`;
+};
+
+export const formatReservationDateLabel = (
+  reservation?: ReservationListItem | null,
+) => {
+  if (!reservation?.date_at) return "Fecha pendiente";
+  return format(new Date(`${reservation.date_at}T00:00:00`), "dd/MM/yyyy");
+};
+
+export const formatReservationAmount = (
+  reservation?: ReservationListItem | null,
+) => {
+  const amount = Number(reservation?.amount ?? reservation?.area?.price ?? 0);
+  if (!Number.isFinite(amount) || amount <= 0) return "Gratis";
+  return formatBs(amount);
+};
+
+export const getReservationMetaFromCalendarEvent = (
+  event?: DayFlowEvent | null,
+) => {
+  return (event?.meta || null) as ReservationCalendarMeta | null;
+};
+
+export const getReservationFromCalendarEvent = (
+  event?: DayFlowEvent | null,
+) => {
+  return getReservationMetaFromCalendarEvent(event)?.reservation || null;
+};
+
+export const mapReservationsToCalendarEvents = (
+  reservations: ReservationListItem[],
+) => {
+  return reservations.reduce<DayFlowEvent[]>((events, reservation) => {
+    const bounds = getReservationDateBounds(reservation);
+    if (!bounds) return events;
+
+    const statusMeta = getReservationStatusMeta(reservation);
+    const statusKey = getReservationCalendarKey(reservation.status);
+    const areaName = getAreaName(reservation);
+    const residentName = getResidentName(
+      reservation.owner || getResidentFromUnit(reservation.dpto),
+    );
+    const unitLabel = getUnitLabel(reservation.dpto);
+    const dateKey = reservation.date_at || "";
+    const statusLabel = statusMeta?.label || "Sin estado";
+    const meta: ReservationCalendarMeta = {
+      reservation,
+      areaName,
+      residentName,
+      unitLabel,
+      statusKey,
+      statusLabel,
+      dateKey,
+      searchText: [
+        areaName,
+        residentName,
+        unitLabel,
+        reservation.obs,
+        statusLabel,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    };
+
+    if (bounds.allDay) {
+      events.push({
+        ...createAllDayEvent(
+          String(reservation.id),
+          areaName,
+          bounds.start,
+          {
+            calendarId: statusKey,
+            meta,
+          },
+        ),
+        description: `${unitLabel} · ${residentName}`,
+      });
+      return events;
+    }
+
+    events.push({
+      ...createTimedEvent(
+        String(reservation.id),
+        areaName,
+        bounds.start,
+        bounds.end,
+        {
+          calendarId: statusKey,
+          meta,
+        },
+      ),
+      description: `${unitLabel} · ${residentName}`,
+    });
+
+    return events;
+  }, []);
+};
+
+export const buildVisibleRangeSegments = (
+  start: Date,
+  end: Date,
+): ReservationVisibleRange[] => {
+  const segments: ReservationVisibleRange[] = [];
+  let currentYear = start.getFullYear();
+
+  while (currentYear <= end.getFullYear()) {
+    const startBoundary =
+      currentYear === start.getFullYear()
+        ? start
+        : startOfYear(new Date(currentYear, 0, 1));
+    const endBoundary =
+      currentYear === end.getFullYear()
+        ? end
+        : endOfYear(new Date(currentYear, 0, 1));
+
+    segments.push({
+      start: startBoundary,
+      end: endBoundary,
+    });
+
+    currentYear += 1;
+  }
+
+  return segments;
+};
+
+export const getVisibleRangeForView = (
+  date: Date,
+  viewType: string,
+): ReservationVisibleRange => {
+  if (viewType === "day") {
+    return {
+      start: startOfDay(date),
+      end: endOfDay(date),
+    };
+  }
+
+  if (viewType === "week") {
+    return {
+      start: startOfWeek(date, { weekStartsOn: 1 }),
+      end: endOfWeek(date, { weekStartsOn: 1 }),
+    };
+  }
+
+  if (viewType === "year") {
+    return {
+      start: startOfYear(date),
+      end: endOfYear(date),
+    };
+  }
+
+  return {
+    start: startOfWeek(startOfMonth(date), { weekStartsOn: 1 }),
+    end: endOfWeek(endOfMonth(date), { weekStartsOn: 1 }),
+  };
+};
+
+export const dedupeReservationsById = (
+  reservations: ReservationListItem[],
+) => {
+  return Array.from(
+    new Map(
+      reservations.map((reservation) => [String(reservation.id), reservation]),
+    ).values(),
+  );
+};

--- a/src/modulos/NewReserva/types.ts
+++ b/src/modulos/NewReserva/types.ts
@@ -1,0 +1,92 @@
+import type { ReservationStatus } from "@/modulos/Reservas/constants/reservationConstants";
+
+export type ReservationListItem = {
+  id: number | string;
+  status?: ReservationStatus | "X" | string;
+  amount?: string | number | null;
+  obs?: string | null;
+  created_at?: string | null;
+  date_at?: string | null;
+  date_end?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  people_count?: number | null;
+  periods?:
+    | Array<{
+        time_from?: string | null;
+        time_to?: string | null;
+      }>
+    | null;
+  area?: NewReservaArea | null;
+  owner?: NewReservaResident | null;
+  dpto?: NewReservaUnit | null;
+};
+
+export type NewReservaResident = {
+  id?: number | string;
+  name?: string | null;
+  middle_name?: string | null;
+  last_name?: string | null;
+  mother_last_name?: string | null;
+  url_avatar?: string | null;
+  email?: string | null;
+};
+
+export type NewReservaUnit = {
+  id: number | string;
+  nro?: string | null;
+  defaulter?: string | null;
+  homeowner?: NewReservaResident | null;
+  tenant?: NewReservaResident | null;
+  titular?: {
+    id?: number | string;
+    owner_id?: number | string;
+    owner?: NewReservaResident | null;
+  } | null;
+};
+
+export type NewReservaArea = {
+  id: number | string;
+  title?: string | null;
+  description?: string | null;
+  max_capacity?: number | null;
+  available_days?: string[] | null;
+  price?: string | number | null;
+  is_free?: string | null;
+  booking_mode?: string | null;
+  max_booking_duration?: number | null;
+  usage_rules?: string | null;
+  special_restrictions?: string | null;
+  cancellation_policy?: string | null;
+  penalty_or_debt_restriction?: string | null;
+  requires_approval?: string | null;
+  show_real_time_availability?: string | null;
+  images?: string[] | null;
+};
+
+export type NewReservaExtraData = {
+  areas?: NewReservaArea[];
+  dptos?: NewReservaUnit[];
+};
+
+export type ReservationCalendarKey =
+  | "pending"
+  | "confirmed"
+  | "cancelled"
+  | "maintenance";
+
+export type ReservationVisibleRange = {
+  start: Date;
+  end: Date;
+};
+
+export type ReservationCalendarMeta = {
+  reservation: ReservationListItem;
+  areaName: string;
+  residentName: string;
+  unitLabel: string;
+  statusKey: ReservationCalendarKey;
+  statusLabel: string;
+  dateKey: string;
+  searchText: string;
+};

--- a/src/modulos/NewReserva/useNewReserva.ts
+++ b/src/modulos/NewReserva/useNewReserva.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { type Event as DayFlowEvent } from "@dayflow/core";
+import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
+import { useAuth } from "@/mk/contexts/AuthProvider";
+import type { ReservationListItem, ReservationVisibleRange } from "./types";
+import {
+  buildVisibleRangeSegments,
+  dedupeReservationsById,
+  formatDateKey,
+  mapReservationsToCalendarEvents,
+} from "./helpers";
+
+export const useNewReserva = () => {
+  const { contextInstance } = useContext(AxiosContext);
+  const { showToast, userCan } = useAuth();
+
+  const [visibleRange, setVisibleRange] = useState<ReservationVisibleRange | null>(
+    null,
+  );
+  const [reservations, setReservations] = useState<ReservationListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedReservationId, setSelectedReservationId] = useState<string | null>(
+    null,
+  );
+  const [detailItem, setDetailItem] = useState<ReservationListItem | null>(null);
+
+  const requestRangeRef = useRef("");
+
+  const loadReservations = useCallback(
+    async (range: ReservationVisibleRange) => {
+      if (!contextInstance) return;
+
+      const rangeKey = `${formatDateKey(range.start)}:${formatDateKey(range.end)}`;
+      requestRangeRef.current = rangeKey;
+      setLoading(true);
+
+      try {
+        const responses = await Promise.all(
+          buildVisibleRangeSegments(range.start, range.end).map((segment) =>
+            contextInstance.request({
+              method: "GET",
+              url: "/reservations",
+              params: {
+                fullType: "L",
+                page: 1,
+                perPage: 1000,
+                filterBy: `date_at:${formatDateKey(segment.start)},${formatDateKey(
+                  segment.end,
+                )}`,
+              },
+            }),
+          ),
+        );
+
+        if (requestRangeRef.current !== rangeKey) return;
+
+        const merged = dedupeReservationsById(
+          responses.flatMap((response) =>
+            Array.isArray(response?.data?.data) ? response.data.data : [],
+          ),
+        );
+
+        setReservations(merged);
+        setSelectedReservationId((previous) =>
+          previous && merged.some((item) => String(item.id) === previous)
+            ? previous
+            : null,
+        );
+      } catch (_error) {
+        if (requestRangeRef.current !== rangeKey) return;
+        setReservations([]);
+        setSelectedReservationId(null);
+        showToast("No pudimos cargar las reservas del calendario", "error");
+      } finally {
+        if (requestRangeRef.current === rangeKey) {
+          setLoading(false);
+        }
+      }
+    },
+    [contextInstance, showToast],
+  );
+
+  useEffect(() => {
+    if (!visibleRange) return;
+    void loadReservations(visibleRange);
+  }, [loadReservations, visibleRange]);
+
+  const handleVisibleRangeChange = useCallback((start: Date, end: Date) => {
+    setVisibleRange((previous) => {
+      const nextKey = `${formatDateKey(start)}:${formatDateKey(end)}`;
+      if (!previous) {
+        return { start, end };
+      }
+
+      const previousKey = `${formatDateKey(previous.start)}:${formatDateKey(
+        previous.end,
+      )}`;
+
+      return previousKey === nextKey ? previous : { start, end };
+    });
+  }, []);
+
+  const calendarEvents = useMemo<DayFlowEvent[]>(
+    () => mapReservationsToCalendarEvents(reservations),
+    [reservations],
+  );
+
+  const selectedReservation = useMemo(
+    () =>
+      reservations.find(
+        (reservation) => String(reservation.id) === selectedReservationId,
+      ) || null,
+    [reservations, selectedReservationId],
+  );
+
+  const selectReservationById = useCallback((reservationId?: string | number | null) => {
+    setSelectedReservationId(reservationId ? String(reservationId) : null);
+  }, []);
+
+  const selectReservation = useCallback(
+    (reservation: ReservationListItem) => {
+      selectReservationById(reservation.id);
+    },
+    [selectReservationById],
+  );
+
+  const openReservationDetail = useCallback(
+    (reservation: ReservationListItem) => {
+      selectReservation(reservation);
+      setDetailItem(reservation);
+    },
+    [selectReservation],
+  );
+
+  const reloadCurrentRange = useCallback(() => {
+    if (!visibleRange) return;
+    void loadReservations(visibleRange);
+  }, [loadReservations, visibleRange]);
+
+  return {
+    canView: userCan("reservations", "R"),
+    canCreate: userCan("reservations", "C"),
+    loading,
+    calendarEvents,
+    selectedReservation,
+    selectedReservationId,
+    detailItem,
+    setDetailItem,
+    handleVisibleRangeChange,
+    selectReservation,
+    selectReservationById,
+    openReservationDetail,
+    reloadCurrentRange,
+  };
+};

--- a/src/modulos/Outlays/RenderView/RenderView.module.css
+++ b/src/modulos/Outlays/RenderView/RenderView.module.css
@@ -1,5 +1,5 @@
 .container {
-  background-color: #d7fff005;
+  background-color: var(--cModalSection);
   display: flex;
   flex-direction: column;
   padding: var(--spL);
@@ -8,7 +8,7 @@
   box-sizing: border-box;
   color: var(--cWhite);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   margin-bottom: var(--spM);
   &:last-of-type {
     margin-bottom: 0;
@@ -45,7 +45,7 @@
   width: 100%;
   border: none;
   height: 0;
-  border-top: 0.5px solid var(--cWhiteV5);
+  border-top: 1px solid var(--cModalDivider);
 }
 .detailsSection {
   display: flex;
@@ -98,7 +98,7 @@
 .canceledReason {
   color: var(--cError) !important;
   font-style: italic;
-  background-color: rgba(220, 53, 69, 0.1);
+  background-color: rgba(228, 96, 85, 0.12);
   padding: 8px 12px;
   border-radius: 4px;
   border-left: 3px solid var(--cError);
@@ -110,9 +110,9 @@
   padding-bottom: var(--spS);
 }
 .voucherButton {
-  background-color: #d7fff005;
+  background-color: var(--cModalSurfaceRaised);
   color: var(--cWhite);
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   font-size: var(--sM);
   padding: var(--spM) var(--spXl);
   border-radius: var(--bRadiusS);
@@ -122,8 +122,8 @@
   cursor: pointer;
 }
 .voucherButton:hover {
-  background-color: rgba(0, 227, 140, 0.12);
-  border-color: #d7fff014;
+  background-color: rgba(0, 227, 140, 0.08);
+  border-color: var(--cModalBorder);
 }
 
 .messageContainer {
@@ -195,7 +195,7 @@
     gap: 12px;
   }
   .voucherButton {
-    background-color: #d7fff005;
+    background-color: var(--cModalSurfaceRaised);
     padding: var(--spS) var(--spM);
     font-size: var(--sS);
     width: 100%;

--- a/src/modulos/PartialPayments/RenderView/RenderView.module.css
+++ b/src/modulos/PartialPayments/RenderView/RenderView.module.css
@@ -1,0 +1,172 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.actionsRow {
+  display: flex;
+  gap: 16px;
+  width: 100%;
+}
+
+.growButton {
+  flex: 1;
+}
+
+.card {
+  background-color: var(--cModalSection);
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--cModalBorder);
+}
+
+.summaryCard {
+  text-align: center;
+}
+
+.summaryAmount {
+  color: var(--cWhite);
+  margin-top: 8px;
+  font-size: 36px;
+  font-weight: 600;
+}
+
+.summarySubtitle {
+  color: var(--cWhiteV1);
+  font-size: 16px;
+}
+
+.infoGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.labelValue {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.labelText {
+  color: var(--cWhiteV1);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.valueText {
+  color: var(--cWhite);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.statusValue {
+  font-weight: 600;
+}
+
+.receiptCell {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.receiptIcon {
+  background-color: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
+  padding: 8px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.receiptCode {
+  color: var(--cWhite);
+}
+
+.receiptLink {
+  color: var(--cAccent);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.receiptLink:hover {
+  text-decoration: underline;
+}
+
+.emptyValue {
+  color: var(--cWhite);
+}
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.tableWrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.tableFooter {
+  padding: 16px;
+  border-bottom-left-radius: 12px;
+  border-bottom-right-radius: 12px;
+  border: 1px solid var(--cModalBorder);
+  border-top: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 80px;
+  background-color: var(--cModalSection);
+}
+
+.tableFooterLabels {
+  text-align: right;
+  color: var(--cWhiteV1);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tableFooterValues {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.footerValue {
+  color: var(--cWhite);
+}
+
+@media (max-width: 900px) {
+  .actionsRow {
+    flex-direction: column;
+  }
+
+  .infoGrid,
+  .metaGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .tableFooter {
+    gap: 20px;
+  }
+}
+
+@media (max-width: 640px) {
+  .summaryAmount {
+    font-size: 30px;
+  }
+
+  .tableFooter {
+    justify-content: space-between;
+    gap: 12px;
+  }
+}

--- a/src/modulos/PartialPayments/RenderView/RenderView.tsx
+++ b/src/modulos/PartialPayments/RenderView/RenderView.tsx
@@ -16,6 +16,7 @@ import Loading from "@/mk/components/ui/LoadingScreen/Loading/Loading";
 import { MONTHS, MONTHS_S } from "@/mk/utils/date1";
 import RenderDel from "@/modulos/Payments/RenderDel/RenderDel";
 import { shouldIgnoreValueTranslationContext } from "@/i18n/translationGuards";
+import styles from "./RenderView.module.css";
 
 const LabelValue = ({
   label,
@@ -33,18 +34,15 @@ const LabelValue = ({
   const ignoreValueTranslation = shouldIgnoreValueTranslationContext({ label });
 
   return (
-    <div style={{ ...style, flex: 1 }}>
-      <p style={{ color: "var(--cWhiteV1)", ...styleLabel }}>{label}</p>
+    <div className={styles.labelValue} style={style}>
+      <p className={styles.labelText} style={styleLabel}>
+        {label}
+      </p>
       {typeof value == "string" ? (
         <p
           data-i18n-ignore={ignoreValueTranslation ? "true" : undefined}
-          style={{
-            color: "var(--cWhite)",
-            marginTop: 8,
-            fontWeight: "500",
-            fontSize: 16,
-            ...styleValue,
-          }}
+          className={styles.valueText}
+          style={styleValue}
         >
           {value}
         </p>
@@ -104,24 +102,14 @@ const RenderView = ({
       responsive: "onlyDesktop",
       onRender: ({ item }: any) =>
         item?.files?.length > 0 ? (
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <div
-              style={{
-                backgroundColor: "rgba(18, 21, 25, 0.72)",
-                border: "1px solid #d7fff014",
-                padding: 8,
-                borderRadius: "100%",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
+          <div className={styles.receiptCell}>
+            <div className={styles.receiptIcon}>
               <IconGallery color="var(--cWhite)" />
             </div>
             <div>
-              <p style={{ color: "var(--cWhite)" }}>{item?.code}</p>
+              <p className={styles.receiptCode}>{item?.code}</p>
               <div
-                style={{ color: "var(--cAccent)", fontSize: 12 }}
+                className={styles.receiptLink}
                 onClick={(e: any) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -133,7 +121,7 @@ const RenderView = ({
             </div>
           </div>
         ) : (
-          <p style={{ color: "var(--cWhite)" }}>-/-</p>
+          <p className={styles.emptyValue}>-/-</p>
         ),
     },
     {
@@ -265,19 +253,19 @@ const RenderView = ({
         buttonText=""
         buttonCancel=""
         buttonExtra={
-          <div style={{ display: "flex", gap: 16, width: "100%" }}>
+          <div className={styles.actionsRow}>
             <Button
               disabled={loadingExport}
               onClick={() => getExport()}
               variant="secondary"
-              style={{ flex: 1 }}
+              className={styles.growButton}
             >
               Ver recibo
             </Button>
             {item?.status === "I" && (
               <Button
                 onClick={() => setOpenFormAccount(true)}
-                style={{ flex: 1 }}
+                className={styles.growButton}
               >
                 Registrar pago a cuenta
               </Button>
@@ -289,33 +277,12 @@ const RenderView = ({
         {loading ? (
           <Loading />
         ) : (
-          <div style={{ display: "flex", gap: 12, flexDirection: "column" }}>
-            <div
-              style={{
-                backgroundColor: "#d7fff005",
-                padding: 16,
-                borderRadius: 16,
-                border: "1px solid #d7fff014",
-              }}
-            >
-              <p
-                style={{
-                  color: "var(--cWhite)",
-                  marginTop: 8,
-                  fontSize: 36,
-                  fontWeight: 600,
-                  textAlign: "center",
-                }}
-              >
+          <div className={styles.root}>
+            <div className={`${styles.card} ${styles.summaryCard}`}>
+              <p className={styles.summaryAmount}>
                 {formatBs(totalAmount)}
               </p>
-              <p
-                style={{
-                  color: "var(--cWhiteV1)",
-                  fontSize: 16,
-                  textAlign: "center",
-                }}
-              >
+              <p className={styles.summarySubtitle}>
                 {item.type === 1 &&
                   "Pago de expensa - " +
                     MONTHS[item.debt.month] +
@@ -326,16 +293,7 @@ const RenderView = ({
                 {item.type === 0 && item.subcategory?.name}
               </p>
             </div>
-            <div
-              style={{
-                backgroundColor: "#d7fff005",
-                padding: 16,
-                borderRadius: 16,
-                border: "1px solid #d7fff014",
-                display: "flex",
-                gap: 16,
-              }}
-            >
+            <div className={`${styles.card} ${styles.infoGrid}`}>
               <LabelValue label="Deuda" value={formatBs(item?.amount)} />
               <LabelValue
                 label="Multa"
@@ -349,20 +307,15 @@ const RenderView = ({
               )}
             </div>
 
-            <div
-              style={{
-                backgroundColor: "#d7fff005",
-                padding: 16,
-                borderRadius: 16,
-                border: "1px solid #d7fff014",
-                gap: 16,
-              }}
-            >
-              <div style={{ display: "flex", gap: 16, marginBottom: 20 }}>
+            <div className={styles.card}>
+              <div className={styles.metaGrid}>
                 <LabelValue
                   label="Estado"
                   value={statusText[item?.status]}
-                  styleValue={{ color: statusColor[item?.status] }}
+                  styleValue={{
+                    color: statusColor[item?.status],
+                    fontWeight: 600,
+                  }}
                 />
                 <LabelValue
                   label="Autorizado por:"
@@ -377,7 +330,7 @@ const RenderView = ({
                   value={getFullName(item?.dpto?.homeowner) || "-/-"}
                 />
               </div>
-              <div style={{ display: "flex", gap: 16 }}>
+              <div className={styles.metaGrid}>
                 <LabelValue
                   label="Unidad"
                   value={item?.dpto?.type?.name + " " + item?.dpto?.nro}
@@ -390,7 +343,7 @@ const RenderView = ({
                 <LabelValue label="" value={""} />
               </div>
             </div>
-            <div>
+            <div className={styles.tableWrapper}>
               <Table
                 style={{
                   borderBottomLeftRadius: 0,
@@ -406,28 +359,14 @@ const RenderView = ({
                 data={item?.history}
                 header={header}
               />
-              <div
-                style={{
-                  padding: 16,
-                  borderBottomLeftRadius: 12,
-                  borderBottomRightRadius: 12,
-                  border: "1px solid #d7fff014",
-                  borderTop: "none",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "flex-end",
-                  gap: 80,
-                }}
-              >
-                <div style={{ textAlign: "right" }}>
+              <div className={styles.tableFooter}>
+                <div className={styles.tableFooterLabels}>
                   <p>Total pagado</p>
                   <p>Saldo restante</p>
                 </div>
-                <div>
-                  <p style={{ color: "var(--cWhite)" }}>
-                    {formatBs(totalPagado)}
-                  </p>
-                  <p style={{ color: "var(--cWhite)" }}>
+                <div className={styles.tableFooterValues}>
+                  <p className={styles.footerValue}>{formatBs(totalPagado)}</p>
+                  <p className={styles.footerValue}>
                     {formatBs(saldoRestante)}
                   </p>
                 </div>

--- a/src/modulos/Payments/Payments.tsx
+++ b/src/modulos/Payments/Payments.tsx
@@ -151,7 +151,6 @@ const Payments = () => {
 
     renderView: (props: any) => <RenderView {...props} />,
     renderDel: (props: any) => <RenderDel {...props} />,
-    loadView: { fullType: 'DET' },
     hideActions: {
       view: false,
       add: false,

--- a/src/modulos/Payments/RenderView/RenderView.module.css
+++ b/src/modulos/Payments/RenderView/RenderView.module.css
@@ -1,5 +1,5 @@
 .container {
-  background-color: #d7fff005;
+  background-color: var(--cModalSection);
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   color: var(--cWhite);
   border-radius: 12px;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   min-width: 600px;
   margin-bottom: var(--spM);
   &:last-of-type {
@@ -61,7 +61,7 @@
   width: 100%;
   border: none;
   height: 0;
-  border-top: 0.5px solid var(--cWhiteV5);
+  border-top: 1px solid var(--cModalDivider);
 }
 
 .detailsSection {
@@ -147,7 +147,7 @@
 
 .canceledReason {
   font-style: italic;
-  background-color: rgba(220, 53, 69, 0.1);
+  background-color: rgba(228, 96, 85, 0.12);
   padding: 8px 12px;
   border-radius: 4px;
   border-left: 3px solid var(--cError);
@@ -155,7 +155,7 @@
 
 .rechazedReason {
   font-style: italic;
-  background-color: rgba(243, 127, 61, 0.15);
+  background-color: rgba(243, 127, 61, 0.12);
   padding: 8px 12px;
   border-radius: 4px;
   border-left: 3px solid var(--cRandom16);
@@ -171,9 +171,9 @@
 }
 
 .voucherButton {
-  background-color: #d7fff005;
+  background-color: var(--cModalSurfaceRaised);
   color: var(--cWhite);
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   font-size: var(--sL);
   padding: var(--spM) var(--spXl);
   border-radius: var(--bRadiusS);
@@ -190,8 +190,8 @@
 }
 
 .voucherButton:hover {
-  background-color: rgba(0, 227, 140, 0.12);
-  border-color: #d7fff014;
+  background-color: rgba(0, 227, 140, 0.08);
+  border-color: var(--cModalBorder);
 }
 
 .periodsDetailsSection {
@@ -218,7 +218,7 @@
 
 .periodsTableWrapper {
   width: 100%;
-  border: 1px solid #d7fff014;
+  border: 1px solid var(--cModalBorder);
   border-radius: var(--bRadiusM);
   overflow: hidden;
 }
@@ -247,7 +247,7 @@
 
 .periodsTableHeader,
 .periodsTableHeaderReservations {
-  background-color: rgba(18, 21, 25, 0.8);
+  background-color: var(--cModalSurfaceRaised);
   color: var(--cWhite);
   font-family: Roboto, sans-serif;
   font-weight: 600;
@@ -280,7 +280,7 @@
   font-family: Roboto, sans-serif;
   font-size: 16px;
   font-weight: 500;
-  background-color: rgba(18, 21, 25, 0.8);
+  background-color: var(--cModalSurfaceRaised);
   height: 48px;
 }
 
@@ -293,7 +293,7 @@
 .periodsTableBody
   .periodsTableRowReservations:nth-child(odd)
   .periodsTableCell {
-  background-color: rgba(18, 21, 25, 0.76);
+  background-color: var(--cModalSection);
   color: var(--cWhiteV1);
 }
 
@@ -490,8 +490,8 @@
     grid-template-columns: 1fr;
     gap: 0;
     padding: var(--spM);
-    border-bottom: 1px solid rgba(215, 255, 240, 0.12);
-    background-color: rgba(18, 21, 25, 0.76);
+    border-bottom: 1px solid var(--cModalDivider);
+    background-color: var(--cModalSection);
   }
 
   .periodsTableBody .periodsTableRow:last-child {
@@ -504,7 +504,7 @@
     text-align: left !important;
     padding: var(--spS) 0;
     border-right: none;
-    border-bottom: 1px dashed rgba(215, 255, 240, 0.12);
+    border-bottom: 1px dashed var(--cModalDivider);
     font-size: var(--sS);
     background-color: transparent;
     min-height: auto;

--- a/src/modulos/Reservas/RenderView/RenderView.tsx
+++ b/src/modulos/Reservas/RenderView/RenderView.tsx
@@ -74,18 +74,19 @@ interface ReservationDetailModalProps {
 const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
   ({ open, onClose, item, reservationId, reLoad }) => {
     const { showToast } = useAuth();
+    const detailId = reservationId || item?.id;
+    const shouldFetchDetail = open && Boolean(detailId);
 
-    // Usar useAxios como hook directo, similar al componente de DebtsManager
     const { data } = useAxios(
-      "/reservations",
+      shouldFetchDetail ? "/reservations" : null,
       "GET",
       {
         fullType: "DET",
-        searchBy: reservationId || item?.id,
+        searchBy: detailId,
         page: 1,
         perPage: 1,
       },
-      open && (!!reservationId || !!item?.id), // Solo ejecutar si el modal está abierto y tenemos un ID
+      false,
     );
 
     // Usar los datos de la consulta DET si están disponibles, sino usar el item original
@@ -226,7 +227,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
           "PUT",
           payload,
           false,
-          false,
+          true,
         );
         if (reLoad) reLoad();
         onClose();
@@ -268,7 +269,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
           "PUT",
           payload,
           false,
-          false,
+          true,
         );
 
         setIsRejectModalOpen(false);
@@ -313,6 +314,8 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
           status: "C",
           reason: formState?.reason,
         },
+        false,
+        true,
       );
       if (data?.success) {
         setOpenModalCancel(false);
@@ -334,7 +337,8 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
           title="Detalle de la reserva"
           buttonText=""
           buttonCancel=""
-          style={{ width: "739px", maxWidth: "80%" }}
+          minWidth={739}
+          maxWidth={920}
           variant={"mini"}
         >
           <LoadingScreen
@@ -370,12 +374,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
                     canCancel && (
                       <p
                         onClick={() => setOpenModalCancel(true)}
-                        style={{
-                          color: "var(--cError)",
-                          textAlign: "right",
-                          textDecorationLine: "underline",
-                          cursor: "pointer",
-                        }}
+                        className={styles.cancelLink}
                       >
                         Cancelar reserva
                       </p>
@@ -423,13 +422,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
                   <div className={styles.mainDetailsContainer}>
                     <div className={styles.detailsColumn}>
                       <div className={styles.specificDetails}>
-                        <div
-                          style={{
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "center",
-                          }}
-                        >
+                        <div className={styles.inlineMetaHeader}>
                           <span className={styles.detailsHeader}>
                             Área social: {reservationDetail?.area?.title}
                           </span>
@@ -496,17 +489,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
                 </div>
 
                 {actionError && (
-                  <div
-                    className={styles.errorText}
-                    style={{
-                      color: "red",
-                      marginTop: "10px",
-                      textAlign: "center",
-                      padding: "5px",
-                      border: "1px solid red",
-                      borderRadius: "4px",
-                    }}
-                  >
+                  <div className={styles.errorBox}>
                     Error: {actionError}
                   </div>
                 )}
@@ -568,10 +551,11 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
             buttonText="Cancelar reserva"
             buttonCancel="Salir"
             onClose={() => setOpenModalCancel(false)}
-            style={{ width: "686px" }}
+            minWidth={686}
+            maxWidth={760}
             onSave={onSaveCancel}
           >
-            <p style={{ marginBottom: 16 }}>
+            <p className={styles.modalParagraph}>
               Por favor, indica el motivo por el cual quieres cancelar esta
               reserva.
             </p>
@@ -596,7 +580,8 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
             title="Rechazar solicitud"
             buttonText=""
             buttonCancel=""
-            style={{ width: "486px", maxWidth: "80%" }}
+            minWidth={486}
+            maxWidth={560}
           >
             <div className={styles.divider}></div>
             <div className={styles.modalContentContainer}>
@@ -624,11 +609,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
               {rejectErrors.reason && (
                 <span
                   id="rejection-error-message"
-                  style={{
-                    color: "var(--cError, #e46055)",
-                    fontSize: "12px",
-                    marginTop: "4px",
-                  }}
+                  className={styles.rejectErrorMessage}
                 >
                   {rejectErrors.reason}
                 </span>
@@ -636,8 +617,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
             </div>
 
             <div
-              className={styles.actionButtonsContainer}
-              style={{ marginTop: "var(--spL, 16px)" }}
+              className={`${styles.actionButtonsContainer} ${styles.rejectActions}`}
             >
               <Button
                 className={styles.secondaryActionButton}

--- a/src/modulos/Reservas/RenderView/ReservationDetailModal.module.css
+++ b/src/modulos/Reservas/RenderView/ReservationDetailModal.module.css
@@ -6,6 +6,31 @@
   gap: var(--spM, 12px); /* Usa variable o valor */
 }
 
+.container {
+  background-color: var(--cModalSection);
+  border: 1px solid var(--cModalBorder);
+  border-radius: var(--bRadiusM);
+  padding: var(--spL);
+}
+
+.notFoundContainer {
+  padding: var(--spXl) var(--spL);
+  text-align: center;
+  color: var(--cWhiteV1);
+}
+
+.notFoundText {
+  color: var(--cWhite);
+  font-size: var(--sL);
+  font-weight: var(--bMedium);
+  margin-bottom: var(--spS);
+}
+
+.notFoundSuggestion {
+  color: var(--cWhiteV1);
+  font-size: var(--sM);
+}
+
 .modalHeader {
   display: flex;
   justify-content: space-between;
@@ -32,17 +57,17 @@
   border-radius: 50%;
 }
 .closeButton:hover {
-  background-color: var(--cHover, #ffffff0d);
+  background-color: var(--cBackground-foreground);
 }
 
 .reservationBlock {
   display: flex;
   flex-direction: column;
   gap: var(--spM, 12px);
-  background-color: #d7fff005; /* Variable */
+  background-color: var(--cModalSection);
   padding: var(--spM, 12px);
   border-radius: var(--bRadius, 12px);
-  border: 1px solid #d7fff014; /* Variable */
+  border: 1px solid var(--cModalBorder);
 }
 
 .requesterSection {
@@ -86,6 +111,10 @@
   display: flex;
   align-items: flex-start;
   gap: var(--spM, 12px);
+  background-color: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
+  border-radius: var(--bRadius, 12px);
+  padding: var(--spM);
 }
 
 .imageWrapper {
@@ -94,6 +123,8 @@
   flex-shrink: 0;
   border-radius: var(--bRadiusS, 8px); /* Variable */
   overflow: hidden;
+  background-color: var(--cModalSection);
+  border: 1px solid var(--cModalBorder);
 }
 
 .areaImage {
@@ -104,7 +135,7 @@
 }
 
 .imagePlaceholder {
-  background-color: rgba(18, 21, 25, 0.72); /* Fondo placeholder */
+  background-color: var(--cBackground-foreground);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -150,6 +181,15 @@
   display: flex;
   flex-direction: column;
   gap: var(--spS, 8px);
+  width: 100%;
+}
+
+.inlineMetaHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spM);
+  flex-wrap: wrap;
 }
 
 .detailsHeader {
@@ -162,6 +202,7 @@
   display: flex;
   /* flex-direction: column; */
   gap: var(--spS, 8px);
+  flex-wrap: wrap;
 }
 
 .detailItem {
@@ -169,6 +210,11 @@
   align-items: center;
   flex: 1;
   gap: var(--spXs, 4px);
+  min-width: 220px;
+  background-color: var(--cModalSection);
+  border: 1px solid var(--cModalBorder);
+  border-radius: var(--bRadiusS);
+  padding: 10px 12px;
 }
 
 .detailIcon {
@@ -203,6 +249,7 @@
   gap: var(--spS, 8px); /* Mantiene el espacio entre botones */
   margin-top: var(--spM, 12px);
   width: 100%; /* Asegura que el contenedor ocupe todo el ancho disponible */
+  align-items: stretch;
 }
 
 .rejectButtonProportional {
@@ -249,6 +296,58 @@
   align-items: center;
   min-height: 200px; /* Altura mínima mientras carga */
 }
+
+.cancelLink {
+  color: var(--cError);
+  text-align: right;
+  text-decoration-line: underline;
+  cursor: pointer;
+}
+
+.cancelLink:hover {
+  color: #f07b71;
+}
+
+.timeLimitAlert {
+  background-color: rgba(233, 176, 30, 0.1);
+  border: 1px solid rgba(233, 176, 30, 0.28);
+  color: var(--cWhite);
+  border-radius: var(--bRadiusS);
+  padding: 12px 14px;
+  line-height: 1.45;
+}
+
+.errorBox {
+  color: var(--cError);
+  margin-top: 10px;
+  text-align: center;
+  padding: 10px 12px;
+  border: 1px solid rgba(228, 96, 85, 0.3);
+  border-radius: var(--bRadiusS);
+  background-color: rgba(228, 96, 85, 0.08);
+}
+
+.divider {
+  height: 1px;
+  width: 100%;
+  background-color: var(--cModalDivider);
+}
+
+.modalParagraph {
+  margin-bottom: 16px;
+  color: var(--cWhiteV1);
+  line-height: 1.45;
+}
+
+.rejectErrorMessage {
+  color: var(--cError, #e46055);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.rejectActions {
+  margin-top: var(--spL, 16px);
+}
 /* En TuComponentePadre.module.css */
 
 .confirmCancelButton {
@@ -275,74 +374,104 @@
   line-height: 1.4;
 }
 .statusBadge {
-  padding: 8px;
+  padding: 8px 12px;
   text-align: center;
-  border-radius: 4px;
+  border-radius: 999px;
   font-size: 14px;
+  font-weight: var(--bSemibold);
+  border: 1px solid transparent;
 }
 
 /* W: Esperando confirmación (Amarillo) */
 .statusW {
-  background-color: #E9B01E33;
-  color: #E9B01E;
+  background-color: rgba(233, 176, 30, 0.14);
+  color: var(--cWarning);
+  border-color: rgba(233, 176, 30, 0.22);
 }
 
 /* A: Pago pendiente (Amarillo) */
 .statusA {
-  background-color: #E9B01E33;
-  color: #E9B01E;
+  background-color: rgba(233, 176, 30, 0.14);
+  color: var(--cWarning);
+  border-color: rgba(233, 176, 30, 0.22);
 }
 
 /* Q: Pago por confirmar (Amarillo) */
 .statusQ {
-  background-color: #E9B01E33;
-  color: #E9B01E;
+  background-color: rgba(233, 176, 30, 0.14);
+  color: var(--cWarning);
+  border-color: rgba(233, 176, 30, 0.22);
 }
 
 /* N: Reservado (sin pago) (Verde) */
 .statusN {
-  background-color: #00E38C33;
-  color: #00E38C;
+  background-color: rgba(0, 227, 140, 0.1);
+  color: var(--cPrimary);
+  border-color: rgba(0, 227, 140, 0.22);
 }
 
 /* L: Reservado (pagado) (Verde) */
 .statusL {
-  background-color: #00E38C33;
-  color: #00E38C;
+  background-color: rgba(0, 227, 140, 0.1);
+  color: var(--cPrimary);
+  border-color: rgba(0, 227, 140, 0.22);
 }
 
 /* R: Reserva rechazada (Rojo) */
 .statusR {
-  background-color: #E4605533;
-  color: #E46055;
+  background-color: rgba(228, 96, 85, 0.1);
+  color: var(--cError);
+  border-color: rgba(228, 96, 85, 0.24);
 }
 
 /* C: Cancelada por usuario (Rojo) */
 .statusC {
-  background-color: #E4605533;
-  color: #E46055;
+  background-color: rgba(228, 96, 85, 0.1);
+  color: var(--cError);
+  border-color: rgba(228, 96, 85, 0.24);
 }
 
 /* T: Cancelada automática (Rojo) */
 .statusT {
-  background-color: #E4605533;
-  color: #E46055;
+  background-color: rgba(228, 96, 85, 0.1);
+  color: var(--cError);
+  border-color: rgba(228, 96, 85, 0.24);
 }
 
 /* F: Finalizada (Verde) */
 .statusF {
-  background-color: #00E38C33;
-  color: #00E38C;
+  background-color: rgba(0, 227, 140, 0.1);
+  color: var(--cPrimary);
+  border-color: rgba(0, 227, 140, 0.22);
 }
 
 .statusUnknown {
-  background-color: var(--cHoverLight, rgba(248, 249, 250, 0.5));
-  color: var(--cLightDark, rgb(108, 117, 125));
-  border: 1px solid var(--cLightDark, rgb(200, 200, 200));
+  background-color: var(--cModalSection);
+  color: var(--cWhiteV1);
+  border: 1px solid var(--cModalBorder);
 }
 
 .areaSeparator {
   /* Línea separadora */
   border: none;
-  border-top: 0.5px solid var(--cWhiteV1); /* Línea sutil */
+  border-top: 1px solid var(--cModalDivider); /* Línea sutil */
+}
+
+@media (max-width: 768px) {
+  .mainDetailsContainer {
+    flex-direction: column;
+  }
+
+  .imageWrapper {
+    width: 100%;
+    height: 220px;
+  }
+
+  .detailItem {
+    min-width: 100%;
+  }
+
+  .actionButtonsContainer {
+    flex-direction: column;
+  }
 }

--- a/src/modulos/Surveys/components/AssemblySurveyForm/AssemblySurveyForm.module.css
+++ b/src/modulos/Surveys/components/AssemblySurveyForm/AssemblySurveyForm.module.css
@@ -1,169 +1,171 @@
 .container {
-    color: #fff;
-    font-family: inherit;
+  color: var(--cWhite);
+  font-family: inherit;
 }
 
 .step {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .fieldGroup {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .label {
-    font-size: 1.1rem;
-    font-weight: 600;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--cWhite);
 }
 
 .subtext {
-    font-size: 0.85rem;
-    color: #888;
-    margin-bottom: 8px;
+  font-size: 0.85rem;
+  color: var(--cWhiteV1);
+  margin-bottom: 8px;
 }
 
 .radioGrid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 12px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
 }
 
 .radioCard {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
-    padding: 16px;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    cursor: pointer;
-    transition: all 0.2s;
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
 }
 
 .radioCard:hover {
-    background: rgba(255, 255, 255, 0.08);
+  background: var(--cBackground-foreground);
 }
 
 .radioCard.active {
-    background: rgba(0, 255, 128, 0.1);
-    border-color: #00ff80;
+  background: var(--cHoverCompl10);
+  border-color: var(--cAccent);
 }
 
 .radioCircle {
-    width: 20px;
-    height: 20px;
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    border-radius: 50%;
-    position: relative;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--cModalBorder);
+  border-radius: 50%;
+  position: relative;
+  flex-shrink: 0;
 }
 
 .active .radioCircle {
-    border-color: #00ff80;
+  border-color: var(--cAccent);
 }
 
 .active .radioCircle::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 10px;
-    height: 10px;
-    background: #00ff80;
-    border-radius: 50%;
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 10px;
+  height: 10px;
+  background: var(--cAccent);
+  border-radius: 50%;
 }
 
 .optionList {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .optionItem {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
-    padding: 14px 16px;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    cursor: pointer;
-    transition: all 0.2s;
+  background: var(--cModalSurfaceRaised);
+  border: 1px solid var(--cModalBorder);
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
 }
 
 .optionItem:hover {
-    background: rgba(255, 255, 255, 0.08);
+  background: var(--cBackground-foreground);
 }
 
 .optionItem.active {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: #00ff8033;
+  background: var(--cHoverCompl10);
+  border-color: var(--cAccent);
 }
 
 .footer {
-    display: flex;
-    gap: 12px;
-    margin-top: 12px;
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
 }
 
 .questionInput {
-    min-height: 80px;
+  min-height: 80px;
 }
 
 .optionInputs {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .optionRow {
-    display: flex;
-    gap: 8px;
-    align-items: center;
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
 
 .removeBtn {
-    background: rgba(255, 50, 50, 0.1);
-    border: none;
-    color: #ff5050;
-    width: 38px;
-    height: 38px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.2s;
+  background: var(--cHoverError);
+  border: none;
+  color: var(--cError);
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
 }
 
 .removeBtn:hover {
-    background: rgba(255, 50, 50, 0.2);
+  background: var(--cHoverError);
 }
 
 .addBtn {
-    background: transparent;
-    border: none;
-    color: #00ff80;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.95rem;
-    font-weight: 500;
-    padding: 8px 0;
-    cursor: pointer;
-    width: fit-content;
+  background: transparent;
+  border: none;
+  color: var(--cAccent);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 8px 0;
+  cursor: pointer;
+  width: fit-content;
 }
 
 .addBtn:hover {
-    opacity: 0.8;
+  opacity: 0.8;
 }
 
 .errorText {
-    color: #ff5050;
-    font-size: 0.8rem;
-    margin-top: 4px;
+  color: var(--cError);
+  font-size: 0.8rem;
+  margin-top: 4px;
 }

--- a/src/modulos/Surveys/components/VotersListModal/VotersListModal.module.css
+++ b/src/modulos/Surveys/components/VotersListModal/VotersListModal.module.css
@@ -4,7 +4,9 @@
 
 .header {
   padding: 16px;
-  border-bottom: 1px solid var(--cWhiteV2, rgba(255, 255, 255, 0.1));
+  border-bottom: 1px solid var(--cModalDivider);
+  background: var(--cModalSection);
+  border-radius: 12px;
 }
 
 .optionBadge {
@@ -16,16 +18,16 @@
 
 .optionLabel {
   font-size: 12px;
-  color: var(--cWhiteV2);
+  color: var(--cWhiteV1);
 }
 
 .optionText {
   font-size: 14px;
   font-weight: 600;
-  color: var(--cWhite);
-  background: var(--cPrimary);
+  color: var(--cBlack);
+  background: var(--cAccent);
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: 999px;
 }
 
 .totalCount {
@@ -43,7 +45,7 @@
 
 .loading p,
 .empty p {
-  color: var(--cWhiteV2);
+  color: var(--cWhiteV1);
   font-size: 14px;
 }
 
@@ -63,12 +65,12 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--cModalDivider);
   transition: background-color 0.15s ease;
 }
 
 .voterItem:hover {
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--cBackground-foreground);
 }
 
 .voterItem:last-child {
@@ -95,6 +97,6 @@
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  color: var(--cWhiteV2);
+  color: var(--cWhiteV1);
   margin: 0;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -46,29 +46,41 @@
   --success: #34a853;
   --info: #4285fa;
 
+  /* Paleta neutral base */
+  --cNeutral-50: #f4f7fa;
+  --cNeutral-100: #e4eaf0;
+  --cNeutral-200: #cfd8e1;
+  --cNeutral-300: #aab6c3;
+  --cNeutral-400: #8693a0;
+  --cNeutral-500: #667281;
+  --cNeutral-600: #46515d;
+  --cNeutral-700: #2b333d;
+  --cNeutral-800: #1b2229;
+  --cNeutral-900: #121519;
+
   /* sidebar */
-  --cSidebar: #246950;
-  --cSidebarV2: #00e38c1f;
-  --cFillSidebar: #1f2d27;
-  --cFillSidebarV2: #00e38c0a;
-  --cBorderSidebar: #00e38c66;
+  --cSidebar: var(--cNeutral-800);
+  --cSidebarV2: var(--cNeutral-700);
+  --cFillSidebar: var(--cNeutral-900);
+  --cFillSidebarV2: var(--cNeutral-800);
+  --cBorderSidebar: var(--cNeutral-600);
 
   /* Paleta de colores principales */
   --cPrimary: #00e38c;
   --cSecondary: #212121;
   --cTerciary: #393c3f;
   --cAccent: #00e38c;
-  --cWhite: #fafafa;
-  --cWhiteV1: #a7a7a7;
-  --cWhiteV2: #414141;
-  --cWhiteV3: #818181;
-  --cWhiteV4: #d9d9d9;
-  --cWhiteV5: #505050;
-  --cBlack: #212121;
-  --cBlackV1: #292929;
-  --cBlackV2: #333536;
-  --cBlackV3: #393c3f;
-  --cHover: #ffffff0d;
+  --cWhite: var(--cNeutral-50);
+  --cWhiteV1: var(--cNeutral-300);
+  --cWhiteV2: var(--cNeutral-700);
+  --cWhiteV3: var(--cNeutral-400);
+  --cWhiteV4: var(--cNeutral-200);
+  --cWhiteV5: var(--cNeutral-600);
+  --cBlack: var(--cNeutral-900);
+  --cBlackV1: var(--cNeutral-800);
+  --cBlackV2: var(--cNeutral-700);
+  --cBlackV3: var(--cNeutral-600);
+  --cHover: #20262d;
   --cHoverAccent: #f5822033;
   --cHoveTablePdf: #7979791a;
   --cHoverBigSidebar: #1f2d27;
@@ -122,7 +134,7 @@
   --cHoverBlack: #212121cc;
   --cHoverBlackv2: #33353633;
   --cHoverUnread: #18f6620f;
-  --cHoverModal: rgba(0, 0, 0, 0.75); /* 75% de opacidad para Modales */
+  --cHoverModal: rgba(8, 11, 15, 0.9);
   /* Paleta de colores Random */
   --cRandom1: #a2d2bf;
   --cRandom2: #a9cce3;
@@ -197,26 +209,23 @@
   --figma-warning-text-color: #e9b01e;
   --figma-success-text-color: #34a853;
 
-  /* Paleta de colores nueva neutral base */
-
-  --cNeutral-50: #fffff;
-  --cNeutral-100: #fffff;
-  --cNeutral-200: #fffff;
-  --cNeutral-300: #fffff;
-  --cNeutral-400: #fffff;
-  --cNeutral-500: #585858;
-  --cNeutral-600: #383838;
-  --cNeutral-700: #303030;
-  --cNeutral-800: #242424;
-  --cNeutral-900: #191919;
-
   /* Paleta de colores nueva semantic */
 
   --cBackground-muted: var(--cNeutral-900);
   --cBackground: var(--cNeutral-800);
-  --cBackground-foreground: var(--cNeutral-700);
-  --cBorder: var(--cNeutral-600);
-  --cDivider: var(--cNeutral-500);
+  --cBackground-foreground: #232b34;
+  --cBorder: #313b46;
+  --cDivider: var(--cNeutral-600);
+  --cTableSurface: #151a20;
+  --cTableSurfaceAlt: #1b222b;
+  --cTableHeader: #1d2530;
+  --cTableHover: #242d38;
+  --cTableBorder: #35414f;
+  --cModalSurface: #10161d;
+  --cModalSurfaceRaised: #18212b;
+  --cModalSection: #151c24;
+  --cModalBorder: #2b3642;
+  --cModalDivider: #25303b;
   --cBrand-primary: #00e38c;
 }
 
@@ -236,7 +245,7 @@ body {
   font-family: var(--fPrimary);
   font-weight: var(--bRegular);
   color: var(--cWhite);
-  background-color: var(--cBlack);
+  background-color: var(--cBackground-muted);
 }
 
 input,
@@ -251,12 +260,7 @@ button {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: linear-gradient(
-      148deg,
-      rgba(0, 227, 140, 0.08) 0%,
-      rgba(0, 227, 140, 0) 50%,
-      rgba(0, 227, 140, 0) 100%
-    ), linear-gradient(0deg, rgba(18, 21, 25, 1) 0%, rgba(18, 21, 25, 1) 100%);
+  background: var(--cBackground-muted);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -279,8 +283,7 @@ button {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  background-color: var(--cBackground-muted);
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
## What changed

This branch brings the latest `dev` changes into `prod35` and adds a follow-up visual pass for the assemblies detail flow.

It includes:
- sync with the latest changes currently on `dev`
- UI theme alignment for assembly detail cards and related modals
- updated neutral surfaces, clearer secondary text, and lighter card section titles using the current admin palette

## Why

Direct pushes to `dev` are blocked by repository rules, so this PR is the path to move the integrated work back into `dev`.

The assemblies detail area still had older dark surfaces and low-contrast text that no longer matched the rest of the admin theme.

## Impact

Users should see the assemblies detail flow visually aligned with the newer admin styling, while `dev` also receives the already-integrated work from `prod35`.

## Validation

- `pnpm build`
