### PR TITLE
fix(ui): allow time and datetime inputs to be clicked anywhere to open native picker

### DIFF
--- a/src/mk/components/forms/Input/Input.tsx
+++ b/src/mk/components/forms/Input/Input.tsx
@@ -274,6 +274,16 @@ const Input = (props: PropsType) => {
   const focusInput = () => {
     if (disabled || readOnly) return;
     inputRef.current?.focus();
+    if (
+      (type === "date" || type === "time" || type === "datetime-local") &&
+      typeof inputRef.current?.showPicker === "function"
+    ) {
+      try {
+        inputRef.current.showPicker();
+      } catch (err) {
+        console.error("Failed to show picker:", err);
+      }
+    }
   };
 
   const handleContainerClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -327,6 +337,18 @@ const Input = (props: PropsType) => {
         onChange={type === "currency" ? handleCurrencyChange : onChange}
         onFocus={onFocus}
         onBlur={type === "currency" ? handleCurrencyBlur : onBlur}
+        onClick={(e) => {
+          if (
+            (type === "date" || type === "time" || type === "datetime-local") &&
+            typeof inputRef.current?.showPicker === "function"
+          ) {
+            try {
+              inputRef.current.showPicker();
+            } catch (err) {
+              console.error("Failed to show picker:", err);
+            }
+          }
+        }}
         name={name}
         value={currentDisplayValue}
         onKeyDown={handleKeyDown}

--- a/src/mk/components/forms/Input/input.module.css
+++ b/src/mk/components/forms/Input/input.module.css
@@ -131,22 +131,15 @@
   color: var(--cWhite);
 }
 
-.hasTrailingIcon > div > input[type="date"]::-webkit-calendar-picker-indicator {
+.hasTrailingIcon > div > input[type="date"]::-webkit-calendar-picker-indicator,
+.hasTrailingIcon > div > input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+.hasTrailingIcon > div > input[type="time"]::-webkit-calendar-picker-indicator {
   position: absolute;
   inset: 0;
   width: auto;
   height: auto;
   color: transparent;
   background: transparent;
-  cursor: pointer;
-}
-
-.hasTrailingIcon
-  > div
-  > input[type="datetime-local"]::-webkit-calendar-picker-indicator,
-.hasTrailingIcon > div > input[type="time"]::-webkit-calendar-picker-indicator {
-  filter: invert(1);
-  opacity: 0;
   cursor: pointer;
 }
 


### PR DESCRIPTION
This PR extends the custom styling and Javascript behavior to all time/datetime-local inputs, enabling a click anywhere on the input container or clock icon to open the browser's native picker, exactly like date inputs.