### PR TITLE
Add reservation advance limit settings

### DIFF
--- a/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
@@ -210,6 +210,10 @@ const FourPart = ({ item }: { item: any }) => {
               title={"Reservación por semana"}
               value={item?.max_reservations_per_week}
             />
+            <KeyValue
+              title={"Anticipación mínima"}
+              value={`${item?.min_reservation_advance_hours ?? 0}h`}
+            />
             {item?.price > 0 && (
               <KeyValue
                 title={"Cancelación sin multa"}

--- a/src/modulos/Areas/RenderForm/Partes/ThirdPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/ThirdPart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "../RenderForm.module.css";
 import TextArea from "@/mk/components/forms/TextArea/TextArea";
 import Switch from "@/mk/components/forms/Switch/Switch";
+import Input from "@/mk/components/forms/Input/Input";
 import Br from "@/components/Detail/Br";
 interface PropsType {
   handleChange: any;
@@ -33,6 +34,22 @@ const ThirdPart = ({ handleChange, errors, formState }: PropsType) => {
           value={formState?.penalty_or_debt_restriction}
         />
       </div>
+      <Br />
+      <div className={styles.sectionBlock}>
+        <p className={styles.title}>Anticipación de reservas</p>
+        <p className={styles.subtitle}>
+          Define cuántas horas antes del turno puede reservar un residente.
+        </p>
+      </div>
+      <Input
+        type="number"
+        label="Horas mínimas de anticipación"
+        name="min_reservation_advance_hours"
+        value={formState?.min_reservation_advance_hours ?? 0}
+        onChange={handleChange}
+        error={errors}
+        min={0}
+      />
       <Br />
       <div className={styles.sectionBlock}>
         <p className={styles.title}>Políticas de uso</p>

--- a/src/modulos/Areas/RenderForm/RenderForm.tsx
+++ b/src/modulos/Areas/RenderForm/RenderForm.tsx
@@ -85,6 +85,8 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
     has_price: item?.price ? "S" : "N",
     requires_approval: item?.requires_approval || "X",
     penalty_or_debt_restriction: item?.penalty_or_debt_restriction || "X",
+    min_reservation_advance_hours:
+      item?.min_reservation_advance_hours ?? 0,
   });
   const { showToast } = useAuth();
   const [level, setLevel] = useState(1);
@@ -239,6 +241,21 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
   };
   const validateLevel3 = () => {
     let errors: any = {};
+    const advanceHoursValue = formState?.min_reservation_advance_hours;
+
+    if (
+      advanceHoursValue !== undefined &&
+      advanceHoursValue !== null &&
+      String(advanceHoursValue).trim() !== ""
+    ) {
+      const advanceHours = Number(advanceHoursValue);
+
+      if (!Number.isInteger(advanceHours) || advanceHours < 0) {
+        errors.min_reservation_advance_hours =
+          "Ingresa un número entero mayor o igual a 0";
+      }
+    }
+
     setErrors(errors);
     return errors;
   };
@@ -291,6 +308,10 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
         usage_rules: formState?.usage_rules,
         cancellation_policy: formState?.cancellation_policy,
         approval_response_hours: formState?.approval_response_hours,
+        min_reservation_advance_hours:
+          formState?.min_reservation_advance_hours === ""
+            ? 0
+            : Number(formState?.min_reservation_advance_hours || 0),
         penalty_or_debt_restriction: formState?.penalty_or_debt_restriction,
         booking_mode: formState?.booking_mode,
         max_reservations_per_day: formState?.max_reservations_per_day,

--- a/src/modulos/Config/DptoConfig/DptoConfig.tsx
+++ b/src/modulos/Config/DptoConfig/DptoConfig.tsx
@@ -105,6 +105,10 @@ const createFormState = (client_config: Record<string, any>) => ({
     Number(client_config?.has_soft_reservation) === 1 ||
     client_config?.has_soft_reservation === true ||
     client_config?.has_soft_reservation === "Y",
+  has_reservation_advance_limit:
+    Number(client_config?.has_reservation_advance_limit) === 1 ||
+    client_config?.has_reservation_advance_limit === true ||
+    client_config?.has_reservation_advance_limit === "Y",
   has_tasks_visible:
     Number(client_config?.has_tasks_visible) === 1 ||
     client_config?.has_tasks_visible === true ||
@@ -265,6 +269,13 @@ const DptoConfig = ({
       setFormState((prev: any) => ({
         ...prev,
         has_soft_reservation: isEnabled,
+      }));
+    } else if (name === "has_reservation_advance_limit") {
+      const isEnabled = value === "Y";
+
+      setFormState((prev: any) => ({
+        ...prev,
+        has_reservation_advance_limit: isEnabled,
       }));
     } else if (name === "has_tasks_visible") {
       const isEnabled = value === "Y";
@@ -990,6 +1001,27 @@ const DptoConfig = ({
                   disabled={!editMode}
                 />
               )}
+
+              <div className={styles.switchContainer}>
+                <div className={styles.switchContent}>
+                  <p className={styles.textTitle}>
+                    Respetar anticipación mínima por área
+                  </p>
+                  <p className={styles.textSubtitle}>
+                    Bloquea para residentes los turnos que no cumplan las horas
+                    de anticipación configuradas en cada área social.
+                  </p>
+                </div>
+                <Switch
+                  name="has_reservation_advance_limit"
+                  label=""
+                  value={formState.has_reservation_advance_limit ? "Y" : "N"}
+                  onChange={handleSwitchChange}
+                  optionValue={["Y", "N"]}
+                  checked={formState.has_reservation_advance_limit}
+                  disabled={!editMode}
+                />
+              </div>
 
               <div className={styles.switchContainer}>
                 <div className={styles.switchContent}>


### PR DESCRIPTION
## Summary
- Adds the global reservation advance limit switch in operational rules.
- Adds per-area minimum advance hours in the social area form and summary.

## Notes
- Direct push to test is blocked by repository rules, so this PR targets test.