### PR TITLE
[codex] stabilize reservations and dashboard counters

### DIFF
--- a/src/components/ChooseClient/ChooseClient.module.css
+++ b/src/components/ChooseClient/ChooseClient.module.css
@@ -111,6 +111,7 @@
 }
 
 .clientItem {
+  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -120,10 +121,19 @@
   border-radius: 12px;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  color: inherit;
+  font: inherit;
+  text-align: left;
 }
 
 .clientItem:hover {
   background-color: rgba(0, 227, 140, 0.08);
+}
+
+.clientItemDisabled {
+  cursor: wait;
+  opacity: 0.7;
+  pointer-events: none;
 }
 
 .clientInfo {

--- a/src/components/ChooseClient/ChooseClient.tsx
+++ b/src/components/ChooseClient/ChooseClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 import DataModal from "@/mk/components/ui/DataModal/DataModal";
 import { useAuth } from "@/mk/contexts/AuthProvider";
-import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import {
   IconArrowRight,
@@ -22,26 +21,49 @@ interface Props {
   onClose: () => void;
 }
 const ChooseClient = ({ open, onClose }: Props) => {
-  const { user, getUser, setStore, store } = useAuth();
+  const { user, getUser, showToast } = useAuth();
   const [searchTerm, setSearchTerm] = useState("");
-  const router = useRouter();
+  const [switchingClientId, setSwitchingClientId] = useState<
+    string | number | null
+  >(null);
   const { translate } = useScopedI18n("chooseClient");
 
   const onClick = async (id: any) => {
-    await getUser(id);
-    router.push("/");
-    setStore({
-      ...store,
-      reLoadDashboard: true,
-    });
+    if (switchingClientId !== null) return;
+
+    setSwitchingClientId(id);
+    const nextUser = await getUser(id);
+
+    if (!nextUser?.client_id || String(nextUser.client_id) !== String(id)) {
+      setSwitchingClientId(null);
+      showToast(
+        "No se pudo cambiar de condominio. Intenta nuevamente.",
+        "error",
+      );
+      return;
+    }
+
     onClose();
+    if (
+      window.location.pathname === "/" &&
+      !window.location.search &&
+      !window.location.hash
+    ) {
+      window.location.reload();
+      return;
+    }
+    window.location.assign("/");
   };
 
   const renderClient = (c: any) => {
     return (
-      <div
+      <button
+        type="button"
         key={c.id}
-        className={styles.clientItem}
+        className={`${styles.clientItem} ${
+          switchingClientId !== null ? styles.clientItemDisabled : ""
+        }`}
+        disabled={switchingClientId !== null}
         onClick={() => onClick(c.id)}
       >
         <div className={styles.clientInfo}>
@@ -84,7 +106,7 @@ const ChooseClient = ({ open, onClose }: Props) => {
             <IconArrowRight size={16} color="var(--cWhiteV1)" />
           </div>
         </div>
-      </div>
+      </button>
     );
   };
 

--- a/src/components/Index/Index.tsx
+++ b/src/components/Index/Index.tsx
@@ -33,6 +33,7 @@ import ContentRenderView from "@/modulos/Contents/RenderView/RenderView";
 import { useScopedI18n } from "@/i18n/useScopedI18n";
 import { useScreenSize } from "@/mk/hooks/useScreenSize";
 import { AssemblyDashboardCard } from "@/modulos/Assemblies/components/AssemblyDashboardCard/AssemblyDashboardCard";
+import { firstCountOrZero } from "@/mk/utils/dashboardCounts";
 
 const paramsInitial = {
   fullType: "L",
@@ -88,6 +89,23 @@ const HomePage = () => {
   } = useAxios("/dashboard", "GET", {
     ...paramsInitial,
   });
+  const dashboardData = dashboard?.data ?? {};
+  const administratorsCount = firstCountOrZero(
+    dashboardData.adminsCount,
+    dashboardData.administratorsCount,
+    dashboardData.admins,
+  );
+  const residentsCount = firstCountOrZero(
+    dashboardData.residentsCount,
+    dashboardData.tenantsCount,
+    dashboardData.residents,
+    dashboardData.tenants,
+    dashboardData.ownersCount,
+  );
+  const guardsCount = firstCountOrZero(
+    dashboardData.guardsCount,
+    dashboardData.guards,
+  );
 
   const today = new Date();
   const monthLabel = new Intl.DateTimeFormat(localeTag, {
@@ -368,9 +386,9 @@ const HomePage = () => {
             {!isMobile && (
               <WidgetBase variant={"V1"} title={translate("usersSummary")} subtitle={translate("usersSummarySubtitle")} className={styles.summaryWidgetEqualHeight} style={{ maxHeight: "max-content" }}>
                 <div className={styles.widgetsResumeContainer}>
-                  <WidgetDashCard title={translate("administrators")} data={formatNumber(dashboard?.data?.adminsCount, 0)} tooltip={true} tooltipTitle={translate("administratorsTooltip")} tooltipColor="var(--cWhiteV1)" tooltipPosition="left" tooltipWidth={500} />
-                  <WidgetDashCard title={translate("residents")} data={formatNumber(dashboard?.data?.ownersCount, 0)} tooltip={true} tooltipTitle={translate("residentsTooltip")} tooltipColor="var(--cWhiteV1)" tooltipPosition="left" tooltipWidth={500} />
-                  <WidgetDashCard title={translate("guards")} data={formatNumber(dashboard?.data?.guardsCount, 0)} tooltip={true} tooltipTitle={translate("guardsTooltip")} tooltipColor="var(--cWhiteV1)" tooltipPosition="left" tooltipWidth={500} />
+                  <WidgetDashCard title={translate("administrators")} data={formatNumber(administratorsCount, 0)} tooltip={true} tooltipTitle={translate("administratorsTooltip")} tooltipColor="var(--cWhiteV1)" tooltipPosition="left" tooltipWidth={500} />
+                  <WidgetDashCard title={translate("residents")} data={formatNumber(residentsCount, 0)} tooltip={true} tooltipTitle={translate("residentsTooltip")} tooltipColor="var(--cWhiteV1)" tooltipPosition="left" tooltipWidth={500} />
+                  <WidgetDashCard title={translate("guards")} data={formatNumber(guardsCount, 0)} tooltip={true} tooltipTitle={translate("guardsTooltip")} tooltipColor="var(--cWhiteV1)" tooltipPosition="left" tooltipWidth={500} />
                 </div>
               </WidgetBase>
             )}

--- a/src/mk/components/forms/Select/Select.tsx
+++ b/src/mk/components/forms/Select/Select.tsx
@@ -67,7 +67,8 @@ const Section = ({
       style={{
         top: `${position?.top || 0}px`,
         left: `${position?.left || 0}px`,
-        minWidth: `${position?.width || 0}px`,
+        width: `${position?.width || 0}px`,
+        maxWidth: "calc(100vw - 24px)",
       }}
     >
       <div className={filter ? styles.searchBox : styles.hidden}>
@@ -302,16 +303,36 @@ const Select = ({
     let parent: any = select.getBoundingClientRect();
     let childPosition: any = child?.getBoundingClientRect();
 
-    let up = 57;
-    if (childPosition) {
-      if (parent.top + 57 + childPosition.height > window.innerHeight) {
-        up = childPosition.height * -1;
-      }
-    }
+    const viewportMargin = 12;
+    const gap = 8;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const resolvedWidth = Math.min(
+      Math.max(parent.width, 220),
+      viewportWidth - viewportMargin * 2,
+    );
+    const dropdownHeight =
+      childPosition?.height ||
+      Math.min(360, viewportHeight - viewportMargin * 2);
+    const availableBelow = viewportHeight - parent.bottom - viewportMargin;
+    const availableAbove = parent.top - viewportMargin;
+    const shouldOpenAbove =
+      childPosition && availableBelow < dropdownHeight && availableAbove > availableBelow;
+    const top = shouldOpenAbove
+      ? Math.max(viewportMargin, parent.top - dropdownHeight - gap)
+      : Math.min(
+          parent.bottom + gap,
+          Math.max(viewportMargin, viewportHeight - dropdownHeight - viewportMargin),
+        );
+    const left = Math.min(
+      Math.max(viewportMargin, parent.left),
+      Math.max(viewportMargin, viewportWidth - resolvedWidth - viewportMargin),
+    );
+
     setPosition({
-      top: parent.top + up,
-      left: parent.left,
-      width: parent.width,
+      top,
+      left,
+      width: resolvedWidth,
     });
   };
 
@@ -319,6 +340,16 @@ const Select = ({
     if (openOptions) {
       calcPosition();
     }
+  }, [openOptions, search]);
+
+  useEffect(() => {
+    if (!openOptions) return;
+
+    window.addEventListener("resize", calcPosition);
+
+    return () => {
+      window.removeEventListener("resize", calcPosition);
+    };
   }, [openOptions]);
   //cambio for value in multiselect
   useEffect(() => {

--- a/src/mk/components/forms/Select/select.module.css
+++ b/src/mk/components/forms/Select/select.module.css
@@ -167,8 +167,8 @@
 .selectOptions {
   cursor: pointer;
   z-index: 1300;
-  width: max-content;
-  max-width: min(calc(100vw - 24px), 420px);
+  max-width: calc(100vw - 24px);
+  box-sizing: border-box;
   padding: 8px;
   background-color: rgba(18, 21, 25, 0.98);
   border: 1px solid var(--cModalBorder);

--- a/src/mk/components/ui/DataModal/DataModal.tsx
+++ b/src/mk/components/ui/DataModal/DataModal.tsx
@@ -108,7 +108,11 @@ const DataModal = ({
   if (fullScreen) {
     return (
       <div
-        style={{ visibility: open ? "visible" : "hidden", zIndex }}
+        style={{
+          visibility: open ? "visible" : "hidden",
+          pointerEvents: open ? "auto" : "none",
+          zIndex,
+        }}
         className={styles.dataModal}
         data-i18n-ignore={ignoreTranslation ? "true" : undefined}
       >

--- a/src/mk/components/ui/DataModal/dataModal.module.css
+++ b/src/mk/components/ui/DataModal/dataModal.module.css
@@ -14,6 +14,7 @@
     position: relative;
     display: flex;
     flex-direction: column;
+    min-height: 0;
     color: var(--cWhite);
     background-color: var(--cModalSurface);
     border-radius: var(--bRadiusL);
@@ -70,20 +71,29 @@
       flex-direction: column;
       gap: 12px;
       overflow-y: auto;
-      flex-grow: 1;
+      flex: 1 1 auto;
+      min-height: 0;
       color: var(--cWhiteV1);
       margin-top: var(--spS);
       margin-bottom: var(--spS);
     }
     & > footer {
       display: flex;
+      flex: 0 0 auto;
       /* flex-direction: column;  Mantenemos esto para el móvil inicialmente */
       gap: 8px; /* Espacio entre botones si están en columna o si hay más de dos */
+      padding-top: var(--spM);
+      border-top: 1px solid var(--cModalDivider);
 
       /* Para pantallas móviles (botones en columna, ocupan todo el ancho por defecto) */
       & > button {
         /* Estilo general para los botones en el footer si es necesario */
         width: 100%; /* Hacemos que ocupen todo el ancho en vista de columna */
+      }
+
+      & > :not(button) {
+        width: 100%;
+        min-width: 0;
       }
 
       @media (width > 768px) {

--- a/src/mk/components/ui/DataModalV2/DataModalV2.tsx
+++ b/src/mk/components/ui/DataModalV2/DataModalV2.tsx
@@ -93,7 +93,11 @@ const DataModalV2 = ({
   }
   return (
     <div
-      style={{ visibility: open ? "visible" : "hidden", zIndex }}
+      style={{
+        visibility: open ? "visible" : "hidden",
+        pointerEvents: open ? "auto" : "none",
+        zIndex,
+      }}
       className={styles.dataModal}
       onClick={(e) => e.stopPropagation()}
     >

--- a/src/mk/components/ui/DetailModal/DetailModal.tsx
+++ b/src/mk/components/ui/DetailModal/DetailModal.tsx
@@ -89,7 +89,11 @@ const DetailModal = ({
 
   return (
     <div
-      style={{ visibility: open ? "visible" : "hidden", zIndex }}
+      style={{
+        visibility: open ? "visible" : "hidden",
+        pointerEvents: open ? "auto" : "none",
+        zIndex,
+      }}
       className={`${styles.detailModal} ${fullScreen ? styles.fullScreenOverlay : ""}`}
     >
       <main

--- a/src/mk/components/ui/DetailModal/detailModal.module.css
+++ b/src/mk/components/ui/DetailModal/detailModal.module.css
@@ -20,6 +20,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  min-height: 0;
   gap: 16px;
   padding: 24px;
   border-radius: 24px;
@@ -115,6 +116,7 @@
 .detailModal > main > section {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   gap: 12px;
   overflow-y: auto;
   overflow-x: hidden;
@@ -160,11 +162,19 @@
 
 .footer {
   display: flex;
+  flex: 0 0 auto;
   gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--cModalDivider);
 }
 
 .footer > button {
   width: 100%;
+}
+
+.footer > :not(button) {
+  width: 100%;
+  min-width: 0;
 }
 
 @media (max-width: 900px) {

--- a/src/mk/components/ui/NewModal/NewModal.tsx
+++ b/src/mk/components/ui/NewModal/NewModal.tsx
@@ -95,7 +95,11 @@ const NewModal = ({
 
   return (
     <div
-      style={{ visibility: open ? "visible" : "hidden", zIndex }}
+      style={{
+        visibility: open ? "visible" : "hidden",
+        pointerEvents: open ? "auto" : "none",
+        zIndex,
+      }}
       className={styles.dataModal}
       onClick={(e) => e.stopPropagation()}
     >

--- a/src/mk/contexts/AuthProvider.tsx
+++ b/src/mk/contexts/AuthProvider.tsx
@@ -9,7 +9,6 @@ import {
   useState,
 } from "react";
 import useAxios from "../hooks/useAxios";
-import { useRouter } from "next/navigation";
 import Login from "../components/auth/Login";
 import useToast, { ToastItem } from "../hooks/useToast";
 import Splash from "../../components/req/Splash";
@@ -39,7 +38,6 @@ const AuthProvider = ({ children, noAuth = false }: any): any => {
   const storeRef = useRef<any>(null);
   const [splash, setSplash] = useState(true);
   const [toasts, setToasts] = useState<ToastItem[]>([]);
-  const router: any = useRouter();
   const { showToast } = useToast(setToasts);
 
   const _setStore = useCallback(async (newStore: object) => {
@@ -66,11 +64,6 @@ const AuthProvider = ({ children, noAuth = false }: any): any => {
       } else if (currentUser?.client_id) {
         credentials.client_id = currentUser.client_id;
       }
-      if (client_id) {
-        credentials.client_id = client_id;
-      } else if (currentUser?.client_id) {
-        credentials.client_id = currentUser.client_id;
-      }
       if (currentUser) {
         const { data, error }: any = await execute(
           process.env.NEXT_PUBLIC_AUTH_IAM,
@@ -92,22 +85,13 @@ const AuthProvider = ({ children, noAuth = false }: any): any => {
             localStorage.setItem("condaty_client_id", currentUser.client_id);
           }
 
-          if (client_id) {
-            currentUser.client_id = client_id;
-          } else if (credentials.client_id) {
-            currentUser.client_id = credentials.client_id;
-          }
-
-          if (currentUser.client_id) {
-            localStorage.setItem("condaty_client_id", currentUser.client_id);
-          }
-
           localStorage.setItem(
             (process.env.NEXT_PUBLIC_AUTH_IAM as string) + "token",
             JSON.stringify({ token: token.token, user: currentUser }),
           );
         } else {
-          if (error.status == 500) {
+          if (error?.status == 500) {
+            setWaiting(-1, "-getUser500");
             setTimeout(async () => {
               localStorage.removeItem(
                 (process.env.NEXT_PUBLIC_AUTH_IAM as string) + "token",
@@ -115,20 +99,16 @@ const AuthProvider = ({ children, noAuth = false }: any): any => {
               setUser(false);
               setSplash(false);
             }, 1000);
-            return;
+            return false;
           }
           localStorage.removeItem(
             (process.env.NEXT_PUBLIC_AUTH_IAM as string) + "token",
           );
           localStorage.removeItem("condaty_client_id");
-          localStorage.removeItem("condaty_client_id");
           setUser(false);
           setWaiting(-1, "-getUser");
           setSplash(false);
-          // setSplash(false);
-          // router.reload();
-          // router.reload();
-          return;
+          return false;
         }
       }
     } catch (e) {
@@ -137,6 +117,7 @@ const AuthProvider = ({ children, noAuth = false }: any): any => {
     setUser(currentUser);
     setWaiting(-1, "-getUser2");
     setSplash(false);
+    return currentUser;
   };
 
   const userCan = (

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -2209,6 +2209,7 @@ const useCrud = ({
           {runtime.openList && (
             <CurrentAddMenu
               filters={filters}
+              onClick={props.onAddClick}
               extraButtons={runtime.extraButtons}
               data={sortedData}
               breakPoint={props.filterBreakPoint}

--- a/src/mk/utils/__tests__/dashboardCounts.test.ts
+++ b/src/mk/utils/__tests__/dashboardCounts.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  firstCountOrZero,
+  getUnitTotalCount,
+  getUnitTypeCounts,
+  toCount,
+} from "../dashboardCounts";
+
+describe("dashboardCounts", () => {
+  it("keeps the first real unit type instead of skipping by index", () => {
+    const counts = getUnitTypeCounts({
+      Casa: 10,
+      Departamento: 5,
+    });
+
+    expect(counts).toEqual([
+      { id: "Casa", name: "Casa", value: 10 },
+      { id: "Departamento", name: "Departamento", value: 5 },
+    ]);
+    expect(getUnitTotalCount({ Casa: 10, Departamento: 5 })).toBe(15);
+  });
+
+  it("uses explicit aggregate totals without rendering them as unit types", () => {
+    const summary = {
+      total: "20",
+      Casa: "8",
+      Departamento: "12",
+    };
+
+    expect(getUnitTypeCounts(summary)).toEqual([
+      { id: "Casa", name: "Casa", value: 8 },
+      { id: "Departamento", name: "Departamento", value: 12 },
+    ]);
+    expect(getUnitTotalCount(summary)).toBe(20);
+  });
+
+  it("falls back when the units summary is unavailable", () => {
+    expect(getUnitTotalCount(undefined, "7")).toBe(7);
+  });
+
+  it("normalizes count values safely", () => {
+    expect(toCount(["a", "b"])).toBe(2);
+    expect(toCount({ count: "3" })).toBe(3);
+    expect(toCount("not-a-number")).toBe(0);
+  });
+
+  it("uses the first valid count fallback", () => {
+    expect(firstCountOrZero(undefined, "", "bad", "4")).toBe(4);
+    expect(firstCountOrZero(undefined, null)).toBe(0);
+  });
+});

--- a/src/mk/utils/dashboardCounts.ts
+++ b/src/mk/utils/dashboardCounts.ts
@@ -1,0 +1,98 @@
+export type UnitTypeCount = {
+  id: string;
+  name: string;
+  value: number;
+};
+
+const AGGREGATE_UNIT_KEYS = new Set([
+  "all",
+  "todos",
+  "total",
+  "totales",
+  "total_units",
+  "totalunits",
+  "units_total",
+  "total_unidades",
+  "unidades_totales",
+]);
+
+const isEmptyValue = (value: unknown) =>
+  value === null || value === undefined || value === "";
+
+const parseCount = (value: unknown): number | null => {
+  if (isEmptyValue(value)) return null;
+
+  if (Array.isArray(value)) return value.length;
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return firstCount(
+      record.total,
+      record.count,
+      record.value,
+      record.quantity,
+    );
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const toCount = (value: unknown): number => parseCount(value) ?? 0;
+
+export const firstCount = (...values: unknown[]): number | null => {
+  for (const value of values) {
+    const count = parseCount(value);
+    if (count !== null) return count;
+  }
+
+  return null;
+};
+
+export const firstCountOrZero = (...values: unknown[]): number =>
+  firstCount(...values) ?? 0;
+
+export const isAggregateUnitKey = (key: string): boolean =>
+  AGGREGATE_UNIT_KEYS.has(key.trim().toLowerCase());
+
+const getSummaryEntries = (
+  unitsSummary: unknown,
+): Array<[string, unknown]> => {
+  if (
+    !unitsSummary ||
+    typeof unitsSummary !== "object" ||
+    Array.isArray(unitsSummary)
+  ) {
+    return [];
+  }
+
+  return Object.entries(unitsSummary as Record<string, unknown>);
+};
+
+export const getUnitTypeCounts = (unitsSummary: unknown): UnitTypeCount[] =>
+  getSummaryEntries(unitsSummary)
+    .filter(([key]) => !isAggregateUnitKey(key))
+    .map(([key, value]) => ({
+      id: key,
+      name: key,
+      value: toCount(value),
+    }));
+
+export const getUnitTotalCount = (
+  unitsSummary: unknown,
+  fallback: unknown = 0,
+): number => {
+  const entries = getSummaryEntries(unitsSummary);
+  const aggregate = entries.find(([key]) => isAggregateUnitKey(key));
+
+  if (aggregate) return toCount(aggregate[1]);
+
+  if (entries.length > 0) {
+    return getUnitTypeCounts(unitsSummary).reduce(
+      (total, item) => total + item.value,
+      0,
+    );
+  }
+
+  return toCount(fallback);
+};

--- a/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
@@ -210,6 +210,10 @@ const FourPart = ({ item }: { item: any }) => {
               title={"Reservación por semana"}
               value={item?.max_reservations_per_week}
             />
+            <KeyValue
+              title={"Anticipación mínima"}
+              value={`${item?.min_reservation_advance_hours ?? 0}h`}
+            />
             {item?.price > 0 && (
               <KeyValue
                 title={"Cancelación sin multa"}

--- a/src/modulos/Areas/RenderForm/Partes/ThirdPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/ThirdPart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "../RenderForm.module.css";
 import TextArea from "@/mk/components/forms/TextArea/TextArea";
 import Switch from "@/mk/components/forms/Switch/Switch";
+import Input from "@/mk/components/forms/Input/Input";
 import Br from "@/components/Detail/Br";
 interface PropsType {
   handleChange: any;
@@ -33,6 +34,22 @@ const ThirdPart = ({ handleChange, errors, formState }: PropsType) => {
           value={formState?.penalty_or_debt_restriction}
         />
       </div>
+      <Br />
+      <div className={styles.sectionBlock}>
+        <p className={styles.title}>Anticipación de reservas</p>
+        <p className={styles.subtitle}>
+          Define cuántas horas antes del turno puede reservar un residente.
+        </p>
+      </div>
+      <Input
+        type="number"
+        label="Horas mínimas de anticipación"
+        name="min_reservation_advance_hours"
+        value={formState?.min_reservation_advance_hours ?? 0}
+        onChange={handleChange}
+        error={errors}
+        min={0}
+      />
       <Br />
       <div className={styles.sectionBlock}>
         <p className={styles.title}>Políticas de uso</p>

--- a/src/modulos/Areas/RenderForm/RenderForm.tsx
+++ b/src/modulos/Areas/RenderForm/RenderForm.tsx
@@ -85,6 +85,8 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
     has_price: item?.price ? "S" : "N",
     requires_approval: item?.requires_approval || "X",
     penalty_or_debt_restriction: item?.penalty_or_debt_restriction || "X",
+    min_reservation_advance_hours:
+      item?.min_reservation_advance_hours ?? 0,
   });
   const { showToast } = useAuth();
   const [level, setLevel] = useState(1);
@@ -239,6 +241,21 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
   };
   const validateLevel3 = () => {
     let errors: any = {};
+    const advanceHoursValue = formState?.min_reservation_advance_hours;
+
+    if (
+      advanceHoursValue !== undefined &&
+      advanceHoursValue !== null &&
+      String(advanceHoursValue).trim() !== ""
+    ) {
+      const advanceHours = Number(advanceHoursValue);
+
+      if (!Number.isInteger(advanceHours) || advanceHours < 0) {
+        errors.min_reservation_advance_hours =
+          "Ingresa un número entero mayor o igual a 0";
+      }
+    }
+
     setErrors(errors);
     return errors;
   };
@@ -291,6 +308,10 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
         usage_rules: formState?.usage_rules,
         cancellation_policy: formState?.cancellation_policy,
         approval_response_hours: formState?.approval_response_hours,
+        min_reservation_advance_hours:
+          formState?.min_reservation_advance_hours === ""
+            ? 0
+            : Number(formState?.min_reservation_advance_hours || 0),
         penalty_or_debt_restriction: formState?.penalty_or_debt_restriction,
         booking_mode: formState?.booking_mode,
         max_reservations_per_day: formState?.max_reservations_per_day,

--- a/src/modulos/Calendar/CalendarPage.tsx
+++ b/src/modulos/Calendar/CalendarPage.tsx
@@ -62,9 +62,13 @@ import type {
   ReservationArea,
   ReservationExtraData,
   ReservationListItem,
-  ReservationResident,
   ReservationUnit,
 } from "@/modulos/Reservas/types";
+import {
+  buildReservationUnitChoices,
+  getReservationUnitOwnerId,
+  type ReservationUnitChoice,
+} from "@/modulos/Reservas/utils/reservationUnits";
 import {
   CALENDAR_WEEK_DAYS,
   type CalendarReservationEntry,
@@ -182,84 +186,6 @@ type CalendarAreaLocalAvailabilityLookup = {
   byName: Record<string, CalendarAreaLocalAvailability>;
 };
 
-type CalendarUnitChoice = {
-  id: string;
-  name: string;
-  unit: ReservationUnit;
-  resident: ReservationResident | null;
-  roleLabel: string;
-};
-
-const buildCalendarUnitChoices = (unit: ReservationUnit): CalendarUnitChoice[] => {
-  const unitLabel = getUnitLabel(unit);
-  const seenResidents = new Set<string>();
-  const choices: CalendarUnitChoice[] = [];
-
-  const pushChoice = (
-    resident: ReservationResident | null | undefined,
-    roleLabel: string,
-    fallbackKey: string,
-  ) => {
-    if (!resident) return;
-
-    const residentName = getResidentName(resident, roleLabel);
-    const dedupeKey = String(resident.id || residentName || fallbackKey);
-
-    if (seenResidents.has(dedupeKey)) {
-      return;
-    }
-
-    seenResidents.add(dedupeKey);
-    choices.push({
-      id: `${unit.id}:${fallbackKey}:${resident.id || residentName}`,
-      name: `${unitLabel}: ${residentName} · ${roleLabel}`,
-      unit,
-      resident,
-      roleLabel,
-    });
-  };
-
-  pushChoice(unit.tenant, "Inquilino", "tenant");
-  pushChoice(unit.homeowner, "Propietario", "homeowner");
-  pushChoice(unit.titular?.owner, "Titular", "titular");
-
-  const homeownerDependents = Array.isArray(unit.homeowner?.dependientes)
-    ? unit.homeowner.dependientes
-    : [];
-  homeownerDependents.forEach((dependent, index) => {
-    pushChoice(
-      dependent?.owner,
-      "Dependiente de propietario",
-      `homeowner-dependent-${dependent?.owner_id || index}`,
-    );
-  });
-
-  const tenantDependents = Array.isArray(unit.tenant?.dependientes)
-    ? unit.tenant.dependientes
-    : [];
-  tenantDependents.forEach((dependent, index) => {
-    pushChoice(
-      dependent?.owner,
-      "Dependiente de inquilino",
-      `tenant-dependent-${dependent?.owner_id || index}`,
-    );
-  });
-
-  if (choices.length > 0) {
-    return choices;
-  }
-
-  return [
-    {
-      id: `${unit.id}:unit`,
-      name: `${unitLabel}: Sin residente`,
-      unit,
-      resident: null,
-      roleLabel: "Sin residente",
-    },
-  ];
-};
-
 const CalendarPage = () => {
   const router = useRouter();
   const { contextInstance } = useContext(AxiosContext);
@@ -332,6 +258,7 @@ const CalendarPage = () => {
   const reservationAvailabilityRequestRef = useRef(0);
   const modalAreaAvailabilityRequestRef = useRef(0);
   const selectedDayTimeLimitRequestRef = useRef(0);
+  const openedReservationQueryRef = useRef("");
   const gridRef = useRef<HTMLDivElement>(null);
 
   const canView = userCan("reservations", "R");
@@ -743,8 +670,8 @@ const CalendarPage = () => {
     [visibleAreaOptions],
   );
 
-  const unitOptions = useMemo<CalendarUnitChoice[]>(
-    () => units.flatMap((unit) => buildCalendarUnitChoices(unit)),
+  const unitOptions = useMemo<ReservationUnitChoice[]>(
+    () => buildReservationUnitChoices(units),
     [units],
   );
 
@@ -1243,7 +1170,7 @@ const CalendarPage = () => {
   const reservationMaintenanceSlots = reservationLiveAvailability?.maintenance || [];
 
   const selectedReservationOwnerId = String(
-    selectedReservationUnit?.titular?.id || "",
+    getReservationUnitOwnerId(selectedReservationUnit),
   );
 
   const selectedReservationResidentLabel = useMemo(() => {
@@ -1457,6 +1384,51 @@ const CalendarPage = () => {
   const closeDayActionMenu = useCallback(() => {
     setDayActionMenu(null);
   }, []);
+
+  const openCreateReservationModal = useCallback(
+    (day?: Date) => {
+      const today = startOfDay(new Date());
+      const candidateDay = day ? startOfDay(day) : selectedDate;
+      const safeDay =
+        candidateDay && candidateDay >= today ? candidateDay : today;
+      const dayKey = formatDateKey(safeDay);
+      const dayEntries = entriesByDay.get(dayKey) || [];
+
+      closeDayActionMenu();
+      setSelectedDate(safeDay);
+      setCalendarActionModal({
+        action: "create_reservation",
+        row: {
+          day: safeDay,
+          dayKey,
+          reservationCount: dayEntries.length,
+        },
+      });
+    },
+    [closeDayActionMenu, entriesByDay, selectedDate],
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const searchParams = new URLSearchParams(window.location.search);
+    const shouldOpenReservationModal =
+      searchParams.get("newReservation") === "1" ||
+      searchParams.get("action") === "new-reservation";
+
+    if (!shouldOpenReservationModal) return;
+
+    const queryKey = searchParams.toString();
+    if (openedReservationQueryRef.current === queryKey) return;
+
+    openedReservationQueryRef.current = queryKey;
+
+    if (canCreate) {
+      openCreateReservationModal();
+    }
+
+    router.replace("/calendar", { scroll: false });
+  }, [canCreate, openCreateReservationModal, router]);
 
   useEffect(() => {
     if (!calendarActionModal || calendarActionModal.action !== "create_reservation") {
@@ -1839,10 +1811,7 @@ const CalendarPage = () => {
         disabled: !canCreate,
         onClick: ({ row, closeMenu }) => {
           closeMenu();
-          setCalendarActionModal({
-            action: "create_reservation",
-            row,
-          });
+          openCreateReservationModal(row.day);
         },
       },
       {
@@ -1857,7 +1826,7 @@ const CalendarPage = () => {
         },
       },
     ],
-    [canCreate],
+    [canCreate, openCreateReservationModal],
   );
 
   const handlePeriodSelect = useCallback(
@@ -2125,7 +2094,7 @@ const CalendarPage = () => {
               {canCreate ? (
                 <Button
                   variant="primary"
-                  onClick={() => router.push("/create-reservas")}
+                  onClick={() => openCreateReservationModal()}
                   className={styles.toolbarActionButton}
                   style={{ height: 48, width: "auto", fontWeight: 700 }}
                 >

--- a/src/modulos/Calendar/helpers.ts
+++ b/src/modulos/Calendar/helpers.ts
@@ -22,6 +22,7 @@ import type {
 } from "@/modulos/Reservas/types";
 import { resolveReservationDisplayStatus } from "@/modulos/Reservas/utils/reservationStatus";
 import { getReservationDisplayStatusInput } from "@/modulos/Reservas/utils/reservationPayment";
+import { getReservationUnitPrimaryResident } from "@/modulos/Reservas/utils/reservationUnits";
 
 const WEEK_STARTS_ON_SUNDAY = { weekStartsOn: 0 as const };
 
@@ -133,7 +134,7 @@ export const dedupeReservationsById = (reservations: ReservationListItem[]) =>
   );
 
 export const getResidentFromUnit = (unit?: ReservationUnit | null) =>
-  unit?.tenant || unit?.homeowner || unit?.titular?.owner || null;
+  getReservationUnitPrimaryResident(unit);
 
 export const getResidentName = (
   resident?: ReservationResident | null,

--- a/src/modulos/Config/DptoConfig/DptoConfig.tsx
+++ b/src/modulos/Config/DptoConfig/DptoConfig.tsx
@@ -105,6 +105,10 @@ const createFormState = (client_config: Record<string, any>) => ({
     Number(client_config?.has_soft_reservation) === 1 ||
     client_config?.has_soft_reservation === true ||
     client_config?.has_soft_reservation === "Y",
+  has_reservation_advance_limit:
+    Number(client_config?.has_reservation_advance_limit) === 1 ||
+    client_config?.has_reservation_advance_limit === true ||
+    client_config?.has_reservation_advance_limit === "Y",
   has_tasks_visible:
     Number(client_config?.has_tasks_visible) === 1 ||
     client_config?.has_tasks_visible === true ||
@@ -265,6 +269,13 @@ const DptoConfig = ({
       setFormState((prev: any) => ({
         ...prev,
         has_soft_reservation: isEnabled,
+      }));
+    } else if (name === "has_reservation_advance_limit") {
+      const isEnabled = value === "Y";
+
+      setFormState((prev: any) => ({
+        ...prev,
+        has_reservation_advance_limit: isEnabled,
       }));
     } else if (name === "has_tasks_visible") {
       const isEnabled = value === "Y";
@@ -990,6 +1001,27 @@ const DptoConfig = ({
                   disabled={!editMode}
                 />
               )}
+
+              <div className={styles.switchContainer}>
+                <div className={styles.switchContent}>
+                  <p className={styles.textTitle}>
+                    Respetar anticipación mínima por área
+                  </p>
+                  <p className={styles.textSubtitle}>
+                    Bloquea para residentes los turnos que no cumplan las horas
+                    de anticipación configuradas en cada área social.
+                  </p>
+                </div>
+                <Switch
+                  name="has_reservation_advance_limit"
+                  label=""
+                  value={formState.has_reservation_advance_limit ? "Y" : "N"}
+                  onChange={handleSwitchChange}
+                  optionValue={["Y", "N"]}
+                  checked={formState.has_reservation_advance_limit}
+                  disabled={!editMode}
+                />
+              </div>
 
               <div className={styles.switchContainer}>
                 <div className={styles.switchContent}>

--- a/src/modulos/CreateReserva/CreateReserva.tsx
+++ b/src/modulos/CreateReserva/CreateReserva.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/components/layout/icons/IconsBiblioteca";
 import CalendarPicker from "./CalendarPicker/CalendarPicker";
 import useAxios from "@/mk/hooks/useAxios";
-import { getFullName } from "@/mk/utils/string";
 import { ApiArea, FormState } from "./Type";
 import DataModal from "@/mk/components/ui/DataModal/DataModal";
 import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
@@ -27,6 +26,12 @@ import HeaderBack from "@/mk/components/ui/HeaderBack/HeaderBack";
 import { formatBs, formatNumber } from "@/mk/utils/numbers";
 import Tooltip from "@/mk/components/ui/Tooltip/Tooltip";
 import RenderView from "../DebtsManager/TabComponents/AllDebts/RenderView/RenderView";
+import {
+  buildReservationUnitSelectOptions,
+  getReservationResidentFullName,
+  getReservationUnitOwnerId,
+  getReservationUnitPrimaryChoice,
+} from "@/modulos/Reservas/utils/reservationUnits";
 
 const initialState: FormState = {
   unidad: "",
@@ -116,7 +121,7 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
   const getCalendar = useCallback(
     async (date?: any) => {
       setLoadingCalendar(true);
-      const ownerId = selectedUnit?.titular?.id;
+      const ownerId = getReservationUnitOwnerId(selectedUnit);
       const { data } = await execute(
         "/reservations-calendar",
         "GET",
@@ -125,9 +130,11 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
           date_at: date || new Date().toISOString()?.split("T")[0],
           owner_id:
             ownerId ||
-            extraData?.dptos?.find(
-              (u: any) => String(u.id) === formState.unidad,
-            )?.titular?.id,
+            getReservationUnitOwnerId(
+              extraData?.dptos?.find(
+                (u: any) => String(u.id) === formState.unidad,
+              ),
+            ),
         },
         false,
         true,
@@ -160,23 +167,8 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
     if (!selectedArea) {
       return [];
     }
-    let data: any[] = [];
-    extraData?.dptos?.forEach((unidad: any) => {
-      if (selectedArea?.penalty_or_debt_restriction == "A") {
-        if (unidad?.defaulter == "X") {
-          data.push({
-            id: String(unidad.id),
-            name: `Unidad: ${unidad.nro} - ${getFullName(unidad.tenant)}`,
-          });
-        }
-      } else {
-        data.push({
-          id: String(unidad.id),
-          name: `Unidad: ${unidad.nro} - ${getFullName(unidad.tenant)} `,
-        });
-      }
-    });
-    return data;
+
+    return buildReservationUnitSelectOptions(extraData?.dptos || []);
   }, [extraData?.dptos, extraData?.areas, formState.area_social]);
 
   const selectedAreaDetails: ApiArea | undefined = useMemo(() => {
@@ -341,9 +333,13 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
     const selectedUnit = extraData?.dptos.find(
       (u: any) => String(u.id) === formState.unidad,
     );
-    const ownerId = selectedUnit?.titular?.id;
+    const ownerId = getReservationUnitOwnerId(selectedUnit);
     if (!ownerId) {
       setIsSubmitting(false);
+      showToast(
+        "La unidad seleccionada no tiene un titular configurado para crear la reserva.",
+        "error",
+      );
       return;
     }
 
@@ -471,6 +467,11 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
     onClose();
   };
   const currentImage = selectedAreaDetails?.images?.[currentImageIndex];
+  const selectedUnitResponsible = selectedUnit
+    ? getReservationUnitPrimaryChoice(selectedUnit).resident
+    : null;
+  const selectedUnitResponsibleName =
+    getReservationResidentFullName(selectedUnitResponsible);
   return (
     <div className={styles.pageWrapper}>
       <HeaderBack label="Volver a lista de reservas" onClick={_onClose} />
@@ -873,14 +874,14 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
                   <div className={styles.summaryOwnerInfo}>
                     <div className={styles.ownerIdentifier}>
                       <Avatar
-                        src={selectedUnit?.titular?.url_avatar}
-                        name={getFullName(selectedUnit?.titular)}
+                        src={selectedUnitResponsible?.url_avatar || undefined}
+                        name={selectedUnitResponsibleName}
                         w={40}
                         h={40}
                       />
                       <div className={styles.ownerText}>
                         <span className={styles.ownerName}>
-                          {getFullName(selectedUnit?.titular)}
+                          {selectedUnitResponsibleName}
                         </span>
                         <span className={styles.ownerUnit}>
                           Unidad {selectedUnit?.nro}

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
@@ -519,7 +519,7 @@ const AllDebts: React.FC<AllDebtsProps> = ({ onExtraDataChange }) => {
     ),
   };
 
-  const { userCan, List, onEdit, onDel, extraData, onFilter, reLoad } = useCrud(
+  const { List, onEdit, onDel, onView, extraData, onFilter } = useCrud(
     {
       paramsInitial,
       mod,
@@ -563,7 +563,11 @@ const AllDebts: React.FC<AllDebtsProps> = ({ onExtraDataChange }) => {
     const totalBalance = debtAmount + penaltyAmount;
 
     return (
-      <RenderItem item={item} onClick={() => {}} onLongPress={onLongPress}>
+      <RenderItem
+        item={item}
+        onClick={() => onView(item)}
+        onLongPress={onLongPress}
+      >
         <ItemList
           title={`Unidad ${item?.dpto?.nro || item?.dpto_id} - ${getStatusText(finalStatus)}`}
           subtitle={`Deuda: ${formatBs(debtAmount)} | Multa: ${formatBs(penaltyAmount)} | Total: ${formatBs(totalBalance)}`}
@@ -574,7 +578,9 @@ const AllDebts: React.FC<AllDebtsProps> = ({ onExtraDataChange }) => {
     );
   };
 
-  const onClickDetail = (row: any) => {};
+  const onClickDetail = (row: any) => {
+    onView(row);
+  };
 
   return (
     <>

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
@@ -410,6 +410,74 @@ const RenderView: React.FC<RenderViewProps> = ({
         ]
           .filter(Boolean)
           .join(" · ");
+  const showRegistrarPagoAction =
+    actions.showRegistrarPago && debtDetail?.status !== "F";
+  const showVerPagoAction = actions.showVerPago && resolvedPaymentId;
+  const showRelatedDetailAction = Boolean(detailButtonText);
+  const showEditAction =
+    actions.showEditar && onEdit && !hideEditAndDeleteButtons;
+  const showCancelAction =
+    actions.showAnular && onDel && !hideEditAndDeleteButtons;
+  const hasDebtActions =
+    showRegistrarPagoAction ||
+    showVerPagoAction ||
+    showRelatedDetailAction ||
+    showEditAction ||
+    showCancelAction;
+  const debtActionButtons =
+    !shouldShowLoading &&
+    Object.keys(debtDetail).length > 0 &&
+    hasDebtActions ? (
+      <div
+        className={`${paymentStyles.voucherButtonContainer} ${styles.actionsWrap}`}
+      >
+        {showRegistrarPagoAction && (
+          <Button
+            onClick={() => setShowPaymentForm(true)}
+            className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
+          >
+            Registrar Pago
+          </Button>
+        )}
+        {showVerPagoAction && (
+          <Button
+            onClick={() => setShowPaymentModal(true)}
+            variant="secondary"
+            className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
+          >
+            Ver pago
+          </Button>
+        )}
+        {showRelatedDetailAction && (
+          <Button
+            onClick={() => handleDetailButtonClick(debtType)}
+            variant="secondary"
+            className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
+            disabled={!hasApiData}
+          >
+            {detailButtonText}
+          </Button>
+        )}
+        {showEditAction && (
+          <Button
+            onClick={() => onEdit?.(debtDetail)}
+            variant="secondary"
+            className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
+          >
+            Editar
+          </Button>
+        )}
+        {showCancelAction && (
+          <Button
+            onClick={() => onDel?.(debtDetail)}
+            variant="secondary"
+            className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
+          >
+            Anular
+          </Button>
+        )}
+      </div>
+    ) : null;
 
   return (
     <>
@@ -423,6 +491,7 @@ const RenderView: React.FC<RenderViewProps> = ({
         headerDivider={false}
         minWidth={860}
         maxWidth={980}
+        buttonExtra={debtActionButtons}
       >
         {shouldShowLoading || Object.keys(debtDetail).length === 0 ? (
           <Loading />
@@ -585,56 +654,6 @@ const RenderView: React.FC<RenderViewProps> = ({
             <div className={paymentStyles.container}>
               <div className={styles.sectionHeading}>Detalles de la deuda</div>
               <div className={styles.detailsContent}>{debtDescription}</div>
-            </div>
-
-            <div
-              className={`${paymentStyles.voucherButtonContainer} ${styles.actionsWrap}`}
-            >
-              {actions.showRegistrarPago && debtDetail?.status !== "F" && (
-                <Button
-                  onClick={() => setShowPaymentForm(true)}
-                  className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
-                >
-                  Registrar Pago
-                </Button>
-              )}
-              {actions.showVerPago && resolvedPaymentId && (
-                <Button
-                  onClick={() => setShowPaymentModal(true)}
-                  variant="secondary"
-                  className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
-                >
-                  Ver pago
-                </Button>
-              )}
-              {detailButtonText && (
-                <Button
-                  onClick={() => handleDetailButtonClick(debtType)}
-                  variant="secondary"
-                  className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
-                  disabled={!hasApiData}
-                >
-                  {detailButtonText}
-                </Button>
-              )}
-              {actions.showEditar && onEdit && !hideEditAndDeleteButtons && (
-                <Button
-                  onClick={() => onEdit(debtDetail)}
-                  variant="secondary"
-                  className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
-                >
-                  Editar
-                </Button>
-              )}
-              {actions.showAnular && onDel && !hideEditAndDeleteButtons && (
-                <Button
-                  onClick={() => onDel(debtDetail)}
-                  variant="secondary"
-                  className={`${paymentStyles.voucherButton} ${styles.actionButtonStretch}`}
-                >
-                  Anular
-                </Button>
-              )}
             </div>
           </>
         )}

--- a/src/modulos/Dptos/Dptos.tsx
+++ b/src/modulos/Dptos/Dptos.tsx
@@ -9,6 +9,10 @@ import NotAccess from "@/components/layout/NotAccess/NotAccess";
 import useCrud, { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { getFullName, getUrlImages, pluralize } from "@/mk/utils/string";
+import {
+  getUnitTotalCount,
+  getUnitTypeCounts,
+} from "@/mk/utils/dashboardCounts";
 import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
 import { useRouter } from "next/navigation";
 import { UnitsType } from "@/mk/utils/utils";
@@ -392,6 +396,14 @@ const Dptos = () => {
     onEdit,
     onDel,
   });
+  const unitTypeCounts = useMemo(
+    () => getUnitTypeCounts(extraData?.units),
+    [extraData?.units],
+  );
+  const totalUnitsCount = useMemo(
+    () => getUnitTotalCount(extraData?.units, data?.message?.total),
+    [data?.message?.total, extraData?.units],
+  );
   const handleRowClick = (item: any) => {
     router.push(`/units/${item.id}`);
   };
@@ -455,17 +467,6 @@ const Dptos = () => {
     );
   };
 
-  const getFormatTypeUnit = () => {
-    let untis: any = [];
-    Object?.keys(extraData?.units || {}).map((c: any, i: number) => {
-      if (i !== 0) {
-        untis.push({ id: c, name: c, value: extraData?.units[c] });
-      }
-    });
-
-    return untis;
-  };
-
   if (!userCan(mod.permiso, "R")) return <NotAccess />;
   return (
     <div className={styles.departamentos}>
@@ -473,18 +474,18 @@ const Dptos = () => {
       <div className={styles.allStatsRow}>
         <WidgetDashCard
           title={"Unidades totales"}
-          data={data?.message?.total || 0}
+          data={totalUnitsCount}
           style={{ minWidth: "280px", maxWidth: "260px" }}
           icon={
             <IconUnidades
               color={
-                !data?.message?.total || data?.message?.total === 0
+                totalUnitsCount === 0
                   ? "var(--cWhiteV1)"
                   : "var(--cInfo)"
               }
               style={{
                 backgroundColor:
-                  !data?.message?.total || data?.message?.total === 0
+                  totalUnitsCount === 0
                     ? "var(--cHover)"
                     : "var(--cHoverCompl3)",
               }}
@@ -493,7 +494,7 @@ const Dptos = () => {
             />
           }
         />
-        {getFormatTypeUnit().map((item: any, i: number) => {
+        {unitTypeCounts.map((item: any) => {
           const isEmpty = !item.value || item.value === 0;
           const pluralizedTitle =
             pluralize(item.name, item.value || 0)
@@ -501,7 +502,7 @@ const Dptos = () => {
               .toUpperCase() + pluralize(item.name, item.value || 0).slice(1);
           return (
             <WidgetDashCard
-              key={i}
+              key={item.id}
               title={pluralizedTitle}
               data={item.value}
               style={{ minWidth: "160px", maxWidth: "268px" }}

--- a/src/modulos/HomeOwners/HomeOwners.tsx
+++ b/src/modulos/HomeOwners/HomeOwners.tsx
@@ -16,6 +16,7 @@ import {
 import ProfileModal from "@/components/ProfileModal/ProfileModal";
 import Input from "@/mk/components/forms/Input/Input";
 import Select from "@/mk/components/forms/Select/Select";
+import { firstCountOrZero } from "@/mk/utils/dashboardCounts";
 
 const paramsInitial = {
   perPage: 20,
@@ -456,23 +457,30 @@ const HomeOwners = () => {
     mod,
     fields,
   });
+  const homeownersCount = firstCountOrZero(
+    extraData?.homeowners,
+    extraData?.homeownersCount,
+    extraData?.owners,
+    extraData?.ownersCount,
+    data?.message?.total,
+  );
 
   if (!userCan(mod.permiso, "R")) return <NotAccess />;
   return (
     <div className={styles.style}>
       <WidgetDashCard
         title="Propietarios Registrados"
-        data={data?.message?.total || 0}
+        data={homeownersCount}
         icon={
           <IconHomeOwner
             color={
-              !data?.message?.total || data?.message?.total === 0
+              homeownersCount === 0
                 ? "var(--cWhiteV1)"
                 : "var(--cWhite)"
             }
             style={{
               backgroundColor:
-                !data?.message?.total || data?.message?.total === 0
+                homeownersCount === 0
                   ? "var(--cHover)"
                   : "rgba(255, 255, 255, 0.1)",
             }}

--- a/src/modulos/Owners/Owners.tsx
+++ b/src/modulos/Owners/Owners.tsx
@@ -24,6 +24,7 @@ import RenderForm from "../Owners/RenderForm/RenderForm";
 import ActiveOwner from "@/components/ActiveOwner/ActiveOwner";
 import RenderView from "./RenderView/RenderView";
 import { useAuth } from "@/mk/contexts/AuthProvider";
+import { firstCountOrZero } from "@/mk/utils/dashboardCounts";
 
 const paramsInitial = {
   perPage: 20,
@@ -405,6 +406,27 @@ const Owners = () => {
     onEdit,
     onDel,
   });
+  const homeownersCount = firstCountOrZero(
+    extraData?.homeowners,
+    extraData?.homeownersCount,
+    extraData?.owners,
+    extraData?.ownersCount,
+  );
+  const residentsCount = firstCountOrZero(
+    extraData?.tenants,
+    extraData?.tenantsCount,
+    extraData?.residents,
+    extraData?.residentsCount,
+  );
+  const dependentsCount = firstCountOrZero(
+    extraData?.dependents,
+    extraData?.dependentsCount,
+  );
+  const pendingOwnersCount = firstCountOrZero(
+    extraData?.pendingOwnersCount,
+    extraData?.pendingOwners,
+    extraData?.pending,
+  );
 
   if (!userCan(mod.permiso, "R")) return <NotAccess />;
   return (
@@ -435,18 +457,18 @@ const Owners = () => {
 
         <WidgetDashCard
           title="Propietarios"
-          data={String(extraData?.homeowners ?? extraData?.owners ?? 0)}
+          data={String(homeownersCount)}
           style={{ maxWidth: "250px" }}
           icon={
             <IconOwner
               color={
-                !extraData?.homeowners || (extraData?.homeowners ?? 0) === 0
+                homeownersCount === 0
                   ? "var(--cWhiteV1)"
                   : "var(--cSuccess)"
               }
               style={{
                 backgroundColor:
-                  !extraData?.homeowners || (extraData?.homeowners ?? 0) === 0
+                  homeownersCount === 0
                     ? "var(--cHover)"
                     : "var(--cHoverCompl2)",
               }}
@@ -458,18 +480,18 @@ const Owners = () => {
 
         <WidgetDashCard
           title="Residentes"
-          data={String(extraData?.tenants ?? 0)}
+          data={String(residentsCount)}
           style={{ maxWidth: "250px" }}
           icon={
             <IconHomePerson
               color={
-                !extraData?.tenants || extraData?.tenants === 0
+                residentsCount === 0
                   ? "var(--cWhiteV1)"
                   : "var(--cInfo)"
               }
               style={{
                 backgroundColor:
-                  !extraData?.tenants || extraData?.tenants === 0
+                  residentsCount === 0
                     ? "var(--cHover)"
                     : "var(--cHoverCompl3)",
               }}
@@ -481,18 +503,18 @@ const Owners = () => {
 
         <WidgetDashCard
           title="Dependientes"
-          data={String(extraData?.dependents ?? 0)}
+          data={String(dependentsCount)}
           style={{ maxWidth: "250px" }}
           icon={
             <IconHomePerson
               color={
-                !extraData?.dependents || extraData?.dependents === 0
+                dependentsCount === 0
                   ? "var(--cWhiteV1)"
                   : "var(--cWarning)"
               }
               style={{
                 backgroundColor:
-                  !extraData?.dependents || extraData?.dependents === 0
+                  dependentsCount === 0
                     ? "var(--cHover)"
                     : "var(--cHoverCompl4)",
               }}
@@ -504,11 +526,15 @@ const Owners = () => {
 
         <WidgetDashCard
           title="Por activar"
-          data={String(extraData?.pendingOwnersCount ?? 0)}
+          data={String(pendingOwnersCount)}
           style={{ maxWidth: "250px" }}
           icon={
             <IconHomePerson
-              color={"var(--cWhite)"}
+              color={
+                pendingOwnersCount === 0
+                  ? "var(--cWhiteV1)"
+                  : "var(--cWhite)"
+              }
               style={{
                 backgroundColor: "var(--cHover)",
               }}

--- a/src/modulos/Payments/RenderView/RenderView.tsx
+++ b/src/modulos/Payments/RenderView/RenderView.tsx
@@ -608,6 +608,81 @@ const RenderView: React.FC<DetailPaymentProps> = memo((props) => {
     }
   };
   const canReviewPayment = item?.status === "S";
+  const showCancelIncomeAction =
+    Boolean(item && onDel && item.status === "P" && item.user);
+  const showReceiptAction = item.status === "P";
+  const showShareReceiptAction = item.status === "P";
+  const showVoucherAction = hasVoucherUrls;
+  const showRejectPaymentAction = canReviewPayment;
+  const showApprovePaymentAction = canReviewPayment;
+  const hasPaymentActions =
+    showCancelIncomeAction ||
+    showReceiptAction ||
+    showShareReceiptAction ||
+    showVoucherAction ||
+    showRejectPaymentAction ||
+    showApprovePaymentAction;
+  const paymentActionButtons = !loading && hasPaymentActions ? (
+    <div className={styles.voucherButtonContainer}>
+      {showCancelIncomeAction && (
+        <Button
+          onClick={handleAnularClick}
+          className={styles.textButtonDanger}
+          variant="danger"
+        >
+          Anular ingreso
+        </Button>
+      )}
+
+      {showReceiptAction && (
+        <Button
+          variant="secondary"
+          className={styles.voucherButton}
+          onClick={() => handleGenerateReceipt(item)}
+        >
+          Ver Recibo
+        </Button>
+      )}
+      {showShareReceiptAction && (
+        <Button
+          variant="secondary"
+          className={styles.voucherButton}
+          onClick={handleShareReceiptWhatsApp}
+        >
+          Compartir por WhatsApp
+        </Button>
+      )}
+      {showVoucherAction && (
+        <Button
+          variant="secondary"
+          className={styles.voucherButton}
+          onClick={handleViewOrDownloadVouchers}
+        >
+          Ver comprobante
+        </Button>
+      )}
+      {showRejectPaymentAction && (
+        <Button
+          variant="secondary"
+          className={styles.voucherButton}
+          onClick={() => {
+            setOnRechazar(true);
+          }}
+        >
+          Rechazar pago
+        </Button>
+      )}
+      {showApprovePaymentAction && (
+        <Button
+          variant="primary"
+          className={styles.voucherButton}
+          onClick={() => onConfirm(true)}
+        >
+          Aprobar pago
+        </Button>
+      )}
+    </div>
+  ) : null;
 
   return (
     <>
@@ -622,6 +697,7 @@ const RenderView: React.FC<DetailPaymentProps> = memo((props) => {
         headerDivider={false}
         minWidth={860}
         maxWidth={980}
+        buttonExtra={paymentActionButtons}
       >
         {loading ? (
           <Loading />
@@ -861,68 +937,6 @@ const RenderView: React.FC<DetailPaymentProps> = memo((props) => {
                 </div>
               )}
 
-            <div className={styles.voucherButtonContainer}>
-              {item && onDel && item.status === "P" && item.user && (
-                <Button
-                  onClick={handleAnularClick}
-                  className={styles.textButtonDanger}
-                  // style={{ marginRight: 8 }}
-                  variant="danger"
-                >
-                  Anular ingreso
-                </Button>
-              )}
-
-              {item.status === "P" && (
-                <Button
-                  variant="secondary"
-                  className={styles.voucherButton}
-                  // style={hasVoucherUrls ? { marginRight: 8 } : {}}
-                  onClick={() => handleGenerateReceipt(item)}
-                >
-                  Ver Recibo
-                </Button>
-              )}
-              {item.status === "P" && (
-                <Button
-                  variant="secondary"
-                  className={styles.voucherButton}
-                  // style={{ marginRight: 8 }}
-                  onClick={handleShareReceiptWhatsApp}
-                >
-                  Compartir por WhatsApp
-                </Button>
-              )}
-              {hasVoucherUrls && (
-                <Button
-                  variant="secondary"
-                  className={styles.voucherButton}
-                  onClick={handleViewOrDownloadVouchers}
-                >
-                  Ver comprobante
-                </Button>
-              )}
-              {canReviewPayment && (
-                <Button
-                  variant="secondary"
-                  className={styles.voucherButton}
-                  onClick={() => {
-                    setOnRechazar(true);
-                  }}
-                >
-                  Rechazar pago
-                </Button>
-              )}
-              {canReviewPayment && (
-                <Button
-                  variant="primary"
-                  className={styles.voucherButton}
-                  onClick={() => onConfirm(true)}
-                >
-                  Aprobar pago
-                </Button>
-              )}
-            </div>
           </>
         )}
       </DataModal>

--- a/src/modulos/Reservas/Reserva.tsx
+++ b/src/modulos/Reservas/Reserva.tsx
@@ -13,6 +13,8 @@ import DateRangeFilterModal from "@/components/DateRangeFilterModal/DateRangeFil
 import CreateReserva from "../CreateReserva/CreateReserva";
 import { IconCalendar } from "@/components/layout/icons/IconsBiblioteca";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/mk/contexts/AuthProvider";
 import {
   RESERVATION_STATUS_CONFIG,
   RESERVATION_STATUS_OPTIONS,
@@ -108,6 +110,8 @@ const ReservationStatusBadge = ({ item }: { item: any }) => {
 };
 
 const Reserva = () => {
+  const router = useRouter();
+  const { showToast } = useAuth();
   const [openCustomFilter, setOpenCustomFilter] = useState(false);
   const [customDateErrors, setCustomDateErrors] = useState<{
     startDate?: string;
@@ -341,6 +345,14 @@ const Reserva = () => {
     <>
       <List
         height={"100%"}
+        onAddClick={() => {
+          if (!userCan(mod.permiso, "C")) {
+            showToast("No tiene permisos para crear reservas", "error");
+            return;
+          }
+
+          router.push("/calendar?newReservation=1");
+        }}
         emptyMsg="Sin reservas pendientes. cuando los residentes comiencen"
         emptyLine2="a solicitar reservas de áreas sociales lo verás reflejado aquí."
         emptyIcon={<IconCalendar size={80} color="var(--cWhiteV1)" />}

--- a/src/modulos/Reservas/__tests__/reservationUnits.test.ts
+++ b/src/modulos/Reservas/__tests__/reservationUnits.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReservationUnitChoices,
+  buildReservationUnitSelectOptions,
+  getReservationUnitOwnerId,
+} from "../utils/reservationUnits";
+import type { ReservationUnit } from "../types";
+
+describe("reservationUnits", () => {
+  it("ordena naturalmente las unidades por numero", () => {
+    const units = [
+      { id: 10, nro: "10" },
+      { id: 2, nro: "2" },
+      { id: 1, nro: "1" },
+    ] as ReservationUnit[];
+
+    expect(buildReservationUnitSelectOptions(units).map((option) => option.id)).toEqual([
+      "1",
+      "2",
+      "10",
+    ]);
+  });
+
+  it("mantiene unidades aunque no tengan residente asignado", () => {
+    const units = [
+      { id: 2, nro: "2", tenant: null },
+      {
+        id: 1,
+        nro: "1",
+        homeowner: { id: 7, name: "Ana", last_name: "Lopez" },
+      },
+    ] as ReservationUnit[];
+
+    expect(buildReservationUnitSelectOptions(units)).toEqual([
+      {
+        id: "1",
+        name: "Unidad 1 - Ana Lopez · Propietario",
+      },
+      {
+        id: "2",
+        name: "Unidad 2 - Sin residente",
+      },
+    ]);
+  });
+
+  it("rotula como propietario/residente cuando es la misma persona", () => {
+    const units = [
+      {
+        id: 3,
+        nro: "3",
+        homeowner: { id: 8, name: "Luis", last_name: "Rojas" },
+        tenant: { id: 8, name: "Luis", last_name: "Rojas" },
+      },
+    ] as ReservationUnit[];
+
+    expect(buildReservationUnitChoices(units)).toMatchObject([
+      {
+        roleLabel: "Propietario/Residente",
+        name: "Unidad 3 - Luis Rojas · Propietario/Residente",
+      },
+    ]);
+  });
+
+  it("resuelve el owner_id desde el titular anidado cuando existe", () => {
+    const unit = {
+      id: 4,
+      nro: "4",
+      titular: {
+        id: 99,
+        owner_id: "15",
+        owner: { id: 15, name: "Marta", last_name: "Paz" },
+      },
+    } as unknown as ReservationUnit;
+
+    expect(getReservationUnitOwnerId(unit)).toBe("15");
+  });
+});

--- a/src/modulos/Reservas/utils/reservationUnits.ts
+++ b/src/modulos/Reservas/utils/reservationUnits.ts
@@ -1,0 +1,250 @@
+import { getFullName } from "@/mk/utils/string";
+import type {
+  ReservationResident,
+  ReservationUnit,
+} from "@/modulos/Reservas/types";
+
+export type ReservationUnitChoice = {
+  id: string;
+  name: string;
+  unit: ReservationUnit;
+  resident: ReservationResident | null;
+  roleLabel: string;
+};
+
+const unitCollator = new Intl.Collator("es", {
+  numeric: true,
+  sensitivity: "base",
+});
+
+const normalizeText = (value: unknown) =>
+  String(value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+
+const getResidentIdentity = (resident?: ReservationResident | null) => {
+  if (!resident) return "";
+  if (resident.id !== undefined && resident.id !== null) return String(resident.id);
+
+  return normalizeText(getReservationResidentFullName(resident));
+};
+
+const isSameResident = (
+  left?: ReservationResident | null,
+  right?: ReservationResident | null,
+) => {
+  const leftKey = getResidentIdentity(left);
+  const rightKey = getResidentIdentity(right);
+
+  return Boolean(leftKey && rightKey && leftKey === rightKey);
+};
+
+export const getReservationUnitNumber = (unit?: ReservationUnit | null) =>
+  String(unit?.nro ?? "").trim();
+
+export const compareReservationUnits = (
+  left?: ReservationUnit | null,
+  right?: ReservationUnit | null,
+) => {
+  const leftNumber = getReservationUnitNumber(left);
+  const rightNumber = getReservationUnitNumber(right);
+  const byNumber = unitCollator.compare(leftNumber, rightNumber);
+
+  if (byNumber !== 0) return byNumber;
+
+  return unitCollator.compare(String(left?.id ?? ""), String(right?.id ?? ""));
+};
+
+export const sortReservationUnits = (units: ReservationUnit[] = []) =>
+  [...units].sort(compareReservationUnits);
+
+export const getReservationResidentFullName = (
+  resident?: ReservationResident | null,
+) =>
+  getFullName({
+    name: resident?.name || undefined,
+    middle_name: resident?.middle_name || undefined,
+    last_name: resident?.last_name || undefined,
+    mother_last_name: resident?.mother_last_name || undefined,
+  });
+
+export const getReservationUnitTitular = (
+  unit?: ReservationUnit | null,
+): ReservationResident | null => {
+  const titular = unit?.titular as
+    | (Record<string, any> & { owner?: ReservationResident | null })
+    | null
+    | undefined;
+
+  if (!titular) return null;
+  if (titular.owner) return titular.owner;
+  if (titular.name || titular.last_name || titular.middle_name) {
+    return titular as ReservationResident;
+  }
+
+  return null;
+};
+
+export const getReservationUnitOwnerId = (
+  unit?: ReservationUnit | null,
+): string => {
+  const titular = unit?.titular as Record<string, any> | null | undefined;
+  const titularOwner = getReservationUnitTitular(unit);
+
+  return String(titularOwner?.id ?? titular?.owner_id ?? titular?.id ?? "");
+};
+
+export const getReservationUnitPrimaryChoice = (
+  unit?: ReservationUnit | null,
+): ReservationUnitChoice => {
+  const fallbackUnit = unit as ReservationUnit;
+  const choices = unit ? buildReservationUnitChoicesForUnit(unit, false) : [];
+
+  return (
+    choices[0] || {
+      id: `${fallbackUnit?.id ?? "unit"}:unit`,
+      name: `${getReservationUnitDisplayLabel(unit)}: Sin residente`,
+      unit: fallbackUnit,
+      resident: null,
+      roleLabel: "Sin residente",
+    }
+  );
+};
+
+export const getReservationUnitPrimaryResident = (
+  unit?: ReservationUnit | null,
+) => getReservationUnitPrimaryChoice(unit).resident;
+
+export const getReservationUnitDisplayLabel = (
+  unit?: ReservationUnit | null,
+) => {
+  if (!unit) return "Sin unidad";
+
+  const unitNumber = getReservationUnitNumber(unit);
+  return unitNumber ? `Unidad ${unitNumber}` : "Unidad sin número";
+};
+
+export const formatReservationUnitChoiceName = (
+  unit: ReservationUnit,
+  resident?: ReservationResident | null,
+  roleLabel = "Sin residente",
+) => {
+  const residentName = resident ? getReservationResidentFullName(resident) : "";
+  const meta = residentName
+    ? `${residentName} · ${roleLabel}`
+    : roleLabel;
+
+  return `${getReservationUnitDisplayLabel(unit)} - ${meta}`;
+};
+
+const buildReservationUnitChoicesForUnit = (
+  unit: ReservationUnit,
+  includeDependents = true,
+): ReservationUnitChoice[] => {
+  const choices: ReservationUnitChoice[] = [];
+  const seenResidents = new Set<string>();
+
+  const pushChoice = (
+    resident: ReservationResident | null | undefined,
+    roleLabel: string,
+    fallbackKey: string,
+  ) => {
+    if (!resident) return;
+
+    const residentName = getReservationResidentFullName(resident) || roleLabel;
+    const dedupeKey = getResidentIdentity(resident) || `${fallbackKey}:${residentName}`;
+
+    if (seenResidents.has(dedupeKey)) {
+      return;
+    }
+
+    seenResidents.add(dedupeKey);
+    choices.push({
+      id: `${unit.id}:${fallbackKey}:${dedupeKey}`,
+      name: formatReservationUnitChoiceName(unit, resident, roleLabel),
+      unit,
+      resident,
+      roleLabel,
+    });
+  };
+
+  const homeowner = unit.homeowner || null;
+  const tenant = unit.tenant || null;
+  const titular = getReservationUnitTitular(unit);
+
+  if (homeowner && tenant && isSameResident(homeowner, tenant)) {
+    pushChoice(homeowner, "Propietario/Residente", "homeowner-resident");
+  } else {
+    pushChoice(homeowner, "Propietario", "homeowner");
+    pushChoice(tenant, "Residente", "tenant");
+  }
+
+  if (
+    titular &&
+    !isSameResident(titular, homeowner) &&
+    !isSameResident(titular, tenant)
+  ) {
+    pushChoice(titular, "Titular", "titular");
+  }
+
+  if (includeDependents) {
+    const homeownerDependents = Array.isArray(homeowner?.dependientes)
+      ? homeowner.dependientes
+      : [];
+    homeownerDependents.forEach((dependent, index) => {
+      pushChoice(
+        dependent?.owner,
+        "Dependiente de propietario",
+        `homeowner-dependent-${dependent?.owner_id || index}`,
+      );
+    });
+
+    const tenantDependents = Array.isArray(tenant?.dependientes)
+      ? tenant.dependientes
+      : [];
+    tenantDependents.forEach((dependent, index) => {
+      pushChoice(
+        dependent?.owner,
+        "Dependiente de residente",
+        `tenant-dependent-${dependent?.owner_id || index}`,
+      );
+    });
+  }
+
+  if (choices.length > 0) {
+    return choices;
+  }
+
+  return [
+    {
+      id: `${unit.id}:unit`,
+      name: `${getReservationUnitDisplayLabel(unit)} - Sin residente`,
+      unit,
+      resident: null,
+      roleLabel: "Sin residente",
+    },
+  ];
+};
+
+export const buildReservationUnitChoices = (units: ReservationUnit[] = []) =>
+  sortReservationUnits(units).flatMap((unit) =>
+    buildReservationUnitChoicesForUnit(unit),
+  );
+
+export const buildReservationUnitSelectOptions = (
+  units: ReservationUnit[] = [],
+) =>
+  sortReservationUnits(units).map((unit) => {
+    const choice = getReservationUnitPrimaryChoice(unit);
+
+    return {
+      id: String(unit.id),
+      name: formatReservationUnitChoiceName(
+        unit,
+        choice.resident,
+        choice.roleLabel,
+      ),
+    };
+  });


### PR DESCRIPTION
## Summary

- Normalizes reservation unit ordering and owner/resident labels across the old and new reservation flows.
- Routes reservation entry points to the new modal while keeping the legacy flow available.
- Improves shared select responsiveness and modal footer behavior for payments/debts.
- Restores debt detail opening from rows and hardens modal overlay cleanup.
- Forces a browser reload after condominium changes.
- Fixes dashboard/unit/owner/resident counters with shared count normalization and tests.

## Validation

- `pnpm vitest --run src/mk/utils/__tests__/dashboardCounts.test.ts src/modulos/Reservas/__tests__/reservationUnits.test.ts src/modulos/Calendar/__tests__/helpers.test.ts`
- `git diff --check`
- Local Next checks: `/`, `/units`, `/owners`, `/homeowners` returned `200`.

## Notes

Direct push to `test` was rejected by repository rules because changes must go through a pull request. `pnpm exec tsc --noEmit` still fails on the pre-existing Vitest global imports missing in `src/modulos/Reports/__tests__/reportFeatureFlags.test.ts`.
