### PR TITLE
refactor(currency-type): consume numeric status after v3 contract

### DIFF
--- a/src/modulos/CurrencyType/Type/CurrencyType.ts
+++ b/src/modulos/CurrencyType/Type/CurrencyType.ts
@@ -13,8 +13,7 @@ export interface CurrencyTypeItem {
   name: string;
   code: string;
   description?: string;
-  status_v3: CurrencyTypeStatus | number;
-  status?: string;
+  status: CurrencyTypeStatus | number;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
Sincroniza el frontend admin con el contract v3 de `currency_types` en el backend (PR condaty2025-api #63).

## Cambios
- `src/modulos/CurrencyType/Type/CurrencyType.ts`: `status_v3`→`status` numérico; retirado `status?: string`.

## Notas
- El tipo estaba **huérfano** (nada lo importa; las monedas llegan como opciones vía el módulo Banks) → cambio inocuo, alineado al contrato numérico.
- Categories fue **no-op** en frontends (admin ya consume `v3/categories` con enums numéricos; sin refs `_v3`), por eso este PR solo cubre CurrencyType.

## Test plan
- Sin cambios funcionales; tipo TypeScript alineado al Resource numérico del backend.