### PR TITLE
refactor(clientconfig): sincronizar enums de client_configs a numérico

### DIFF
--- a/src/modulos/BankProviderTester/BankProviderTester.tsx
+++ b/src/modulos/BankProviderTester/BankProviderTester.tsx
@@ -39,7 +39,7 @@ interface TokenData {
 interface QrConfig {
   mode: number;
   mode_label: string;
-  environment: string;
+  environment: number; // 0=sandbox, 1=production (QrEnvironmentEnum)
   environment_label: string;
   source: string;
   has_credentials: boolean;

--- a/src/modulos/Config/DefaulterConfig/DefaulterConfig.tsx
+++ b/src/modulos/Config/DefaulterConfig/DefaulterConfig.tsx
@@ -13,8 +13,10 @@ interface DefaulterConfigProps {
   onSave?: (e: object) => Promise<void> | void;
 }
 
+// Claves numéricas espejo de LimitType (backend: app/Modules/Clients/Enums/LimitType.php)
+// 1=COUNT (cantidad), 2=DAYS (días), 3=MONTH (fin de mes)
 const limit_msgs: any = {
-  C: {
+  1: {
     label: "Cantidad",
     soft: {
       title:
@@ -30,7 +32,7 @@ const limit_msgs: any = {
         "El bloqueo es la configuración que define cuántas expensas impagas puede acumular un residente antes de que el sistema restrinja automáticamente su acceso a la aplicación del condominio.",
     },
   },
-  D: {
+  2: {
     label: "Dias",
     soft: {
       title:
@@ -45,7 +47,7 @@ const limit_msgs: any = {
         "El bloqueo es la configuración que define después de cuántos días desde el vencimiento de la expensa mas antigua impaga, el sistema restrinja automáticamente su acceso a la aplicación del condominio.",
     },
   },
-  M: {
+  3: {
     label: "Fin de mes",
     soft: {
       title:
@@ -63,9 +65,9 @@ const limit_msgs: any = {
 };
 
 const lLimit_type = [
-  { id: "C", name: "Por cantidad de expensas impagas" },
-  { id: "D", name: "Por días desde el vencimiento de la deuda mas antigua" },
-  { id: "M", name: "Por fin de mes" },
+  { id: 1, name: "Por cantidad de expensas impagas" },
+  { id: 2, name: "Por días desde el vencimiento de la deuda mas antigua" },
+  { id: 3, name: "Por fin de mes" },
 ];
 const lcheckMora = [
   { id: 0, name: "No" },
@@ -293,7 +295,7 @@ const DefaulterConfig = ({ client_config, onSave }: DefaulterConfigProps) => {
             />
           </div>
         </div>
-        {formState?.limit_type != "M" && (
+        {formState?.limit_type != 3 && (
           <>
             <div className={styles.sectionContainer}>
               <div>

--- a/src/modulos/QrDinamico/QrDynamicConfig/QrDynamicConfig.tsx
+++ b/src/modulos/QrDinamico/QrDynamicConfig/QrDynamicConfig.tsx
@@ -504,7 +504,7 @@ const QrDynamicConfig: React.FC<QrDynamicConfigProps> = ({
         )}
 
         {/* Info según entorno */}
-        {formState.qr_dynamic_environment === "S" && (
+        {formState.qr_dynamic_environment === QrEnvironment.SANDBOX && (
           <div className={styles.sectionContainer}>
             <Card style={{ backgroundColor: "rgba(245, 158, 11, 0.1)" }}>
               <h3 className={styles.infoTitle}>Modo Sandbox Activo</h3>
@@ -517,7 +517,7 @@ const QrDynamicConfig: React.FC<QrDynamicConfigProps> = ({
           </div>
         )}
 
-        {formState.qr_dynamic_environment === "P" && (
+        {formState.qr_dynamic_environment === QrEnvironment.PRODUCTION && (
           <div className={styles.sectionContainer}>
             <Card style={{ backgroundColor: "rgba(0, 227, 140, 0.1)" }}>
               <h3 className={styles.infoTitle}>Modo Producción</h3>

--- a/src/modulos/QrDinamico/types.ts
+++ b/src/modulos/QrDinamico/types.ts
@@ -21,12 +21,12 @@ export enum QrDynamicMode {
 /**
  * Entorno del QR dinámico.
  * @see QrEnvironmentEnum (backend: app/Modules/QrDinamico/Enums/QrEnvironmentEnum.php)
- * - 'S': sandbox  → entorno de pruebas
- * - 'P': production → entorno de producción
+ * - 0: sandbox    → entorno de pruebas
+ * - 1: production → entorno de producción
  */
 export enum QrEnvironment {
-  SANDBOX = "S",
-  PRODUCTION = "P",
+  SANDBOX = 0,
+  PRODUCTION = 1,
 }
 
 /**


### PR DESCRIPTION
## Contexto
Frontend del pase a numérico de los enums de `client_configs`. Espejo del contrato del backend **mariogfos/condaty2025-api#70** (mergear coordinado).

## Cambios
- **qr env** (`QrDinamico/types.ts`, `QrDynamicConfig.tsx`, `BankProviderTester.tsx`): enum `QrEnvironment` `'S'`/`'P'` → `0`/`1`; comparaciones del toggle sandbox/prod vía enum; tipo `environment` string → number.
- **limit_type** (`Config/DefaulterConfig/DefaulterConfig.tsx`): `limit_msgs` y opciones del select re-keados `'C'`/`'D'`/`'M'` → `1`/`2`/`3`; comparación "fin de mes" (`!= 'M'`) → `!= 3`.

El `<Select>` custom preserva el `id` numérico (mismo patrón ya probado en `qr_dynamic_mode`); SANDBOX=0 queda primero en las opciones.

## Relacionados
- Backend: mariogfos/condaty2025-api#70
- rnOwner: `refactor/clientconfig-enums-numeric` en condaty2025-rnOwner