### PR TITLE
fix(expenses): S1 sprint critico admin (ADM-01 DebtStatus numerico)

### DIFF
--- a/src/mk/utils/__tests__/expenseSummarizers.test.ts
+++ b/src/mk/utils/__tests__/expenseSummarizers.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { DebtStatus } from "@/types/PaymentType";
+import {
+  paidUnits,
+  sumPaidUnits,
+  unitsPayable,
+  isUnitInDefault,
+} from "../utils";
+
+// Helper: minimal Assigned-shaped row
+const unit = (status: DebtStatus, amount = 100, penalty = 0) =>
+  ({
+    id: 1,
+    debt_id: "d",
+    amount,
+    penalty_amount: penalty,
+    status,
+  } as any);
+
+describe("expense summarizers — numeric DebtStatus", () => {
+  const asignados = [
+    unit(DebtStatus.PAID, 100, 10), // saldada
+    unit(DebtStatus.PENDING, 200), // por cobrar
+    unit(DebtStatus.OVERDUE, 300), // en mora
+    unit(DebtStatus.CANCELLED, 400), // anulada
+  ];
+
+  it("paidUnits counts only PAID units", () => {
+    expect(paidUnits(asignados)).toBe(1);
+    expect(paidUnits([unit(DebtStatus.PENDING)])).toBe(0);
+  });
+
+  it("sumPaidUnits sums amount + penalty of PAID units only", () => {
+    expect(sumPaidUnits(asignados)).toBe(110);
+  });
+
+  it("unitsPayable counts everything except PAID and CANCELLED", () => {
+    // PENDING + OVERDUE = 2 payable; PAID and CANCELLED excluded
+    expect(unitsPayable(asignados)).toBe(2);
+  });
+
+  it("isUnitInDefault is true only when there are payable units and it is past due", () => {
+    const pastDue = "2000-01-01";
+    const future = "2999-01-01";
+
+    // payable units + past due => in default
+    expect(
+      isUnitInDefault({ asignados, due_at: pastDue } as any)
+    ).toBe(true);
+
+    // payable units but not yet due => not in default
+    expect(
+      isUnitInDefault({ asignados, due_at: future } as any)
+    ).toBe(false);
+
+    // no payable units (all PAID) even past due => not in default
+    expect(
+      isUnitInDefault({
+        asignados: [unit(DebtStatus.PAID)],
+        due_at: pastDue,
+      } as any)
+    ).toBe(false);
+  });
+});

--- a/src/mk/utils/utils.tsx
+++ b/src/mk/utils/utils.tsx
@@ -1,3 +1,5 @@
+import { DebtStatus } from "@/types/PaymentType";
+
 export const setParamsCrud = (
   modulo: string,
   param: "searchBy" | "filterBy",
@@ -202,7 +204,7 @@ interface Assigned {
   debt_id: string;
   amount: number;
   penalty_amount: number;
-  status: string;
+  status: DebtStatus;
 }
 
 type AssignedList = Assigned[];
@@ -234,11 +236,14 @@ export const sumExpenses = (unidades: AssignedList) => {
   });
   return sum;
 };
+// Char→numeric mapping (ref: DebtsManager/TabComponents/constants.ts):
+//   'P' → DebtStatus.PAID     'X' → DebtStatus.CANCELLED
+// "paid unit"  = deuda saldada (PAID)
+// "payable"    = ni saldada ni anulada (igual que el viejo status != 'P' && != 'X')
 export const paidUnits = (unidades: AssignedList) => {
   let cont = 0;
   unidades.map((uni) => {
-    // && uni.status != "X"
-    if (uni.status == "P") {
+    if (uni.status === DebtStatus.PAID) {
       cont = cont + 1;
     }
   });
@@ -248,7 +253,7 @@ export const paidUnits = (unidades: AssignedList) => {
 export const sumPaidUnits = (unidades: AssignedList) => {
   let sum = 0;
   unidades.map((uni) => {
-    if (uni.status == "P") {
+    if (uni.status === DebtStatus.PAID) {
       sum += Number(uni.amount) + Number(uni.penalty_amount);
     }
   });
@@ -257,13 +262,11 @@ export const sumPaidUnits = (unidades: AssignedList) => {
 
 export const unitsPayable = (unidades: AssignedList) => {
   let cont = 0;
-  // let c = "";
   unidades.map((uni) => {
-    if (uni.status != "P" && uni.status != "X") {
+    if (uni.status !== DebtStatus.PAID && uni.status !== DebtStatus.CANCELLED) {
       cont = cont + 1;
     }
   });
-  // return c;
   return cont;
 };
 export const isUnitInDefault = (props: Debt) => {


### PR DESCRIPTION
## Sprint S1 — fix critico bloqueante en condaty-admin

Bloqueante: sumarizadores de expensas en admin comparan status 'P' contra DebtStatus numerico → 'Unidades al dia' y 'Total cobrado' siempre 0, 'Unidades por pagar' cuenta todo, saldo a cobrar inflado, gate Editar/Eliminar roto (expensas con pagos eliminables).

### 1 commit atomico

- **`<6477f179>` ADM-01** — reescribe paidUnits/sumPaidUnits/unitsPayable/isUnitInDefault en `src/mk/utils/utils.tsx` con DebtStatus numerico (patron de DebtsManager/TabComponents/constants.ts). Comentario explicativo de mapping char→num (P→PAID, X→CANCELLED).

### Tests

- expenseSummarizers.test.ts: **4/4 verde**
  - paidUnits counts only PAID units
  - sumPaidUnits sums amount + penalty of PAID units only
  - unitsPayable counts everything except PAID and CANCELLED
  - isUnitInDefault is true only when there are payable units and it is past due

### Out-of-scope (follow-ups)

- Smoke manual: ver totales de expensas correctos en /expensas.
- Tab Condonaciones (ADM-02) y ExpensesDetails (ADM-03) aun char-keyed → S2.5 / S2.6.
- ADM-04 guard isSubmitting + doble POST → S2.4.
- usePaymentsForm (ADM-05) + DefaulterConfig (ADM-06) + Select.tsx (ADM-07) → S3.

### Sprint source

`<audits/2026-07-04-condaty-finanzas-code-review/PLAN-CORRECCION.md>` § S1 + INFORME.md § condaty-admin (12 hallazgos total).

### Cross-repo

Hermano: rnOwner PR con S1.1 + S1.5 + S1.6. condaty-api PR con S1.2 + S1.3 + S1.6 backend. Coordinar merge en orden: admin → api → rnOwner.