### PR TITLE
fix(finanzas): S3 (MEDIUM) code review — Select, categorias fijas, DefaulterConfig y redondeo

### DIFF
--- a/src/mk/components/forms/Select/Select.tsx
+++ b/src/mk/components/forms/Select/Select.tsx
@@ -105,18 +105,18 @@ const Section = ({
                 ]
                   .filter(Boolean)
                   .join(" ")}
-                key={`li${name}${option[optionValue] || key}`}
+                key={`li${name}${option[optionValue] ?? key}`}
                 onClick={
                   isGroupLabel
                     ? undefined
                     : !multiSelect
                     ? (e) => {
-                        handleSelectClickElement(option[optionValue] || key);
+                        handleSelectClickElement(option[optionValue] ?? key);
                         e.stopPropagation();
                       }
                     : (e) => {
                         handleSelectMultiClickElement(
-                          option[optionValue] || key,
+                          option[optionValue] ?? key,
                         );
                         e.stopPropagation();
                       }

--- a/src/mk/utils/numbers.tsx
+++ b/src/mk/utils/numbers.tsx
@@ -10,6 +10,11 @@ export function formatNumberWithComma(value: string | number, decimals = 2) {
   formattedValue = formattedValue.replace(".", ","); // Reemplaza punto por coma
   return formattedValue.replace(/\B(?=(\d{3})+(?!\d))/g, "."); // Agrega puntos para los miles
 }
+export const roundMoney = (value: number | string): number => {
+  const num = Number(value);
+  if (isNaN(num)) return 0;
+  return Math.round((num + Number.EPSILON) * 100) / 100;
+};
 export const formatBs = (value: number | string): string => {
   if (value === null || value === undefined || value === "") return "Bs 0.00";
   const num = typeof value === "string" ? parseFloat(value.replace(/,/g, '')) : value;

--- a/src/modulos/Balance/Balance.tsx
+++ b/src/modulos/Balance/Balance.tsx
@@ -26,7 +26,7 @@ import WidgetGrafIngresos from "@/components/Widgets/WidgetGrafIngresos/WidgetGr
 import WidgetGrafBalance from "@/components/Widgets/WidgetGrafBalance/WidgetGrafBalance";
 import { ChartType, COLORS20 } from "@/mk/components/ui/Graphs/GraphsTypes";
 import { useAuth } from "@/mk/contexts/AuthProvider";
-import { formatNumber } from "@/mk/utils/numbers";
+import { formatNumber, roundMoney } from "@/mk/utils/numbers";
 import EmptyData from "@/components/NoData/EmptyData";
 import DateRangeFilterModal from "@/components/DateRangeFilterModal/DateRangeFilterModal";
 import { MONTHS_GRAPH } from "@/mk/utils/date";
@@ -321,7 +321,8 @@ const BalanceGeneral: React.FC = () => {
       if (!map.has(item.categ_id)) {
         map.set(item.categ_id, { name: item.name, total: 0 });
       }
-      map.get(item.categ_id).total += parseFloat(item.amount ?? 0);
+      const entry = map.get(item.categ_id);
+      entry.total = roundMoney(entry.total + parseFloat(item.amount ?? 0));
     });
     return Array.from(map.values());
   }, [finanzas?.data?.ingresosHist]);
@@ -331,7 +332,8 @@ const BalanceGeneral: React.FC = () => {
       if (!map.has(item.categ_id)) {
         map.set(item.categ_id, { name: item.name, total: 0 });
       }
-      map.get(item.categ_id).total += parseFloat(item.amount ?? 0);
+      const entry = map.get(item.categ_id);
+      entry.total = roundMoney(entry.total + parseFloat(item.amount ?? 0));
     });
     return Array.from(map.values());
   }, [finanzas?.data?.egresosHist]);
@@ -392,12 +394,12 @@ const BalanceGeneral: React.FC = () => {
         .reduce((acc: any[], item: any) => {
           let found = acc.find((a) => a.id === item.categ_id);
           if (found) {
-            found.total += parseFloat(item.amount ?? 0);
+            found.total = roundMoney(found.total + parseFloat(item.amount ?? 0));
           } else {
             acc.push({
               id: item.categ_id,
               name: item.name,
-              total: parseFloat(item.amount ?? 0),
+              total: roundMoney(parseFloat(item.amount ?? 0)),
             });
           }
           return acc;
@@ -415,12 +417,12 @@ const BalanceGeneral: React.FC = () => {
         .reduce((acc: any[], item: any) => {
           let found = acc.find((a) => a.id === item.categ_id);
           if (found) {
-            found.total += parseFloat(item.amount ?? 0);
+            found.total = roundMoney(found.total + parseFloat(item.amount ?? 0));
           } else {
             acc.push({
               id: item.categ_id,
               name: item.name,
-              total: parseFloat(item.amount ?? 0),
+              total: roundMoney(parseFloat(item.amount ?? 0)),
             });
           }
           return acc;

--- a/src/modulos/Config/DefaulterConfig/DefaulterConfig.tsx
+++ b/src/modulos/Config/DefaulterConfig/DefaulterConfig.tsx
@@ -224,6 +224,7 @@ const DefaulterConfig = ({ client_config, onSave }: DefaulterConfigProps) => {
     }
     setEditMode(false);
   };
+  const activeLimitMsg = limit_msgs[formState?.limit_type] ?? limit_msgs[1];
   return (
     <div className={styles.defaulterContainer}>
       <div className={styles.headerRow}>
@@ -279,7 +280,7 @@ const DefaulterConfig = ({ client_config, onSave }: DefaulterConfigProps) => {
               </Tooltip>
             </div>
             <p className={styles.sectionSubtitle}>
-              {limit_msgs[formState?.limit_type].soft.title}
+              {activeLimitMsg.soft.title}
             </p>
           </div>
           <div className={styles.inputField}>
@@ -303,20 +304,20 @@ const DefaulterConfig = ({ client_config, onSave }: DefaulterConfigProps) => {
                   <h2 className={styles.sectionTitle}>Pre-aviso</h2>
                   <Tooltip
                     position="right"
-                    title={limit_msgs[formState?.limit_type].soft.tooltip}
+                    title={activeLimitMsg.soft.tooltip}
                   >
                     <IconQuestion size={16} />
                   </Tooltip>
                 </div>
                 <p className={styles.sectionSubtitle}>
-                  {limit_msgs[formState?.limit_type].soft.title}
+                  {activeLimitMsg.soft.title}
                 </p>
               </div>
 
               <div className={styles.inputField}>
                 <Input
                   type="number"
-                  label={limit_msgs[formState?.limit_type].label}
+                  label={activeLimitMsg.label}
                   name="soft_limit"
                   error={errors}
                   required
@@ -335,20 +336,20 @@ const DefaulterConfig = ({ client_config, onSave }: DefaulterConfigProps) => {
                   <h2 className={styles.sectionTitle}>Bloqueo</h2>
                   <Tooltip
                     position="right"
-                    title={limit_msgs[formState?.limit_type].hard.tooltip}
+                    title={activeLimitMsg.hard.tooltip}
                   >
                     <IconQuestion size={16} />
                   </Tooltip>
                 </div>
                 <p className={styles.sectionSubtitle}>
-                  {limit_msgs[formState?.limit_type].hard.title}
+                  {activeLimitMsg.hard.title}
                 </p>
               </div>
 
               <div className={styles.inputField}>
                 <Input
                   type="number"
-                  label={limit_msgs[formState?.limit_type].label}
+                  label={activeLimitMsg.label}
                   name="hard_limit"
                   error={errors}
                   required

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -5,6 +5,7 @@ import { getTitular } from "@/mk/utils/adapters";
 import { paymentsApi } from "../api";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { FormPaymentType } from "../Type/PaymentType";
+import { CategoryFixed } from "@/modulos/Categories/Type/CategoryType";
 
 export interface Dpto {
   id: string | number;
@@ -338,7 +339,7 @@ export const usePaymentsForm = (
 
   const filteredCategories = useMemo(() => {
     const list = extraData?.categories || [];
-    return list.filter((cat) => String(cat.fixed) !== "Y");
+    return list.filter((cat) => Number(cat.fixed) !== CategoryFixed.YES);
   }, [extraData?.categories]);
 
   const getSubtotal = useCallback((periodo: Deuda) => {
@@ -511,7 +512,7 @@ export const usePaymentsForm = (
 
         if (selectedCategory?.hijos) {
           newSubcategories = (selectedCategory.hijos || []).filter(
-            (hijo: Subcategory) => String(hijo.fixed) !== "Y"
+            (hijo: Subcategory) => Number(hijo.fixed) !== CategoryFixed.YES
           );
 
           const catExpensasChild = newSubcategories.find(


### PR DESCRIPTION
Sprint S3 (MEDIUM) del code review finanzas post-refactor. 4 fixes work-unit, tsc en baseline (91 errores, 0 nuevos).

- **ADM-07** — `Select` usa `??` en vez de `||` para respetar option values falsy como 0 (base para enums con valor 0: CategoryStatus.INACTIVE, ApprovedStatus.NONE, CategoryFixed.NO).
- **ADM-05** — `usePaymentsForm` filtra categorias FIJAS con `CategoryFixed` numerico (antes comparaba String(fixed) !== 'Y' contra valor numerico -> nunca filtraba, categorias fijas seleccionables en pago directo).
- **ADM-06** — `DefaulterConfig` deriva `activeLimitMsg` con fallback: sin limit_type seteado ya no crashea con TypeError (pantalla en blanco).
- **ADM-10** — `Balance` redondea la acumulacion de montos con nuevo helper `roundMoney` para evitar drift de centavos.