### PR TITLE
Validate access report export period

### DIFF
--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -93,6 +93,10 @@ export type ModCrudType = {
   };
   getListRows?: (response: any, params?: Record<string, any>) => any[];
   reportPreset?: string;
+  validateExport?: (input: {
+    params: Record<string, any>;
+    type?: string;
+  }) => string | null | undefined | false;
 };
 
 export type TypeRenderForm = {
@@ -962,6 +966,14 @@ const useCrud = ({
   const openReportViewer = () => {
     if (!useNewReportsViewer || typeof window === "undefined") return;
 
+    const exportValidationMessage = mod?.validateExport?.({
+      params,
+      type: "pdf",
+    });
+    if (exportValidationMessage) {
+      return showToast(exportValidationMessage, "error");
+    }
+
     const nextState = encodeReportViewerState({
       params: {
         ...params,
@@ -981,6 +993,11 @@ const useCrud = ({
   ) => {
     if (!userCan(mod.permiso, "R"))
       return showToast("No tiene permisos para visualizar", "error");
+
+    const exportValidationMessage = mod?.validateExport?.({ params, type });
+    if (exportValidationMessage) {
+      return showToast(exportValidationMessage, "error");
+    }
 
     if (isExporting) return; // Evitar múltiples clics
     setIsExporting(true);

--- a/src/modulos/Activities/AccessTab/AccessTab.tsx
+++ b/src/modulos/Activities/AccessTab/AccessTab.tsx
@@ -33,6 +33,68 @@ const periodOptions = [
   { id: "custom", name: "Personalizado" },
 ];
 
+const ACCESS_REPORT_MAX_RANGE_DAYS = 60;
+const accessReportBlockedPeriods = new Set(["y", "ly"]);
+
+const parseFilterByString = (filterBy: string) => {
+  const parsed: Record<string, string> = {};
+
+  filterBy
+    .split("|")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .forEach((part) => {
+      const separatorIndex = part.indexOf(":");
+      if (separatorIndex === -1) return;
+
+      const key = part.slice(0, separatorIndex).trim();
+      const value = part.slice(separatorIndex + 1).trim();
+      if (key) parsed[key] = value;
+    });
+
+  return parsed;
+};
+
+const parseIsoDateToUtc = (value: string) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+  if (!match) return null;
+
+  const [, year, month, day] = match;
+  return Date.UTC(Number(year), Number(month) - 1, Number(day));
+};
+
+const validateAccessReportExport = ({ params }: { params?: any }) => {
+  const filters = parseFilterByString(String(params?.filterBy || ""));
+  const period = filters.in_at;
+
+  if (!period || period === "ALL") {
+    return "Debe elegir un periodo para poder generar el reporte.";
+  }
+
+  if (accessReportBlockedPeriods.has(period)) {
+    return "Para exportar el reporte seleccione un periodo menor a 60 días. Este año y Año anterior no están permitidos.";
+  }
+
+  if (!period.includes(",")) return null;
+
+  const [startDate = "", endDate = ""] = period
+    .split(",")
+    .map((value) => value.trim());
+  const startTime = parseIsoDateToUtc(startDate);
+  const endTime = parseIsoDateToUtc(endDate);
+
+  if (startTime === null || endTime === null || endTime < startTime) {
+    return "El rango de fechas seleccionado no es válido para exportar.";
+  }
+
+  const diffDays = Math.floor((endTime - startTime) / 86400000);
+  if (diffDays > ACCESS_REPORT_MAX_RANGE_DAYS) {
+    return "El rango personalizado no puede superar 60 días para exportar el reporte.";
+  }
+
+  return null;
+};
+
 const accessStatusTonePalette = {
   success: {
     color: "var(--cStatusSuccess)",
@@ -148,6 +210,7 @@ const AccessesTab: React.FC<AccessesTabProps> = ({
         del: true,
       },
       search: true,
+      validateExport: validateAccessReportExport,
       getListRows: (response: any, requestParams?: Record<string, any>) => {
         if (requestParams?.fullType !== "DET") {
           return Array.isArray(response?.data) ? response.data : [];


### PR DESCRIPTION
## Summary\n- Use the standard export flow validation hook for access reports.\n- Require an access period before exporting.\n- Block yearly periods and custom ranges over 60 days only at export time.\n\n## Checks\n- npx tsc --noEmit --pretty false --types vitest/globals\n- git diff --check