### PR TITLE
Set support modal max width

### DIFF
--- a/src/components/SupportDataModal/SupportDataModal.tsx
+++ b/src/components/SupportDataModal/SupportDataModal.tsx
@@ -110,7 +110,7 @@ const SupportDataModal = () => {
       onSave={() => handleSubmit()}
       title="Datos de soporte"
       minWidth={640}
-      maxWidth="calc(100% - 40px)"
+      maxWidth={760}
     >
       {loading ? (
         <p>Cargando...</p>


### PR DESCRIPTION
## Summary
- Sets the Datos de soporte modal max width to 760px.

## Why
- 760px matches the repo pattern for medium forms and keeps this two-field support config modal readable without stretching to desktop-wide sizes.

## Validation
- git diff --check