### PR TITLE
Add operational permission matrix UI

### DIFF
--- a/src/modulos/Config/DptoConfig/DptoConfig.module.css
+++ b/src/modulos/Config/DptoConfig/DptoConfig.module.css
@@ -532,25 +532,84 @@
   gap: 10px;
 }
 
-.permissionSwitchGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
-  gap: 10px;
-}
-
-.permissionSwitchRow {
-  display: flex;
-  justify-content: space-between;
-  gap: 14px;
-  align-items: flex-start;
-  padding: 14px;
-  border-radius: 14px;
+.permissionMatrix {
+  width: 100%;
+  overflow-x: auto;
   border: 1px solid var(--cModalBorder);
+  border-radius: 14px;
   background-color: color-mix(
     in srgb,
     var(--cModalSurfaceRaised) 64%,
     transparent
   );
+}
+
+.permissionMatrixRow {
+  display: grid;
+  grid-template-columns: minmax(210px, 1.2fr) repeat(4, minmax(112px, 0.7fr));
+  min-width: 660px;
+  border-bottom: 1px solid var(--cModalBorder);
+}
+
+.permissionMatrixRow:last-child {
+  border-bottom: 0;
+}
+
+.permissionMatrixHeader {
+  color: var(--cWhiteV1);
+  font-size: var(--body-xs-size);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+}
+
+.permissionMatrixHeader > div,
+.permissionRoleCell,
+.permissionActionCell {
+  padding: 12px;
+}
+
+.permissionMatrixHeader > div {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.permissionMatrixHeader > div:first-child {
+  justify-content: flex-start;
+}
+
+.permissionRoleCell {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.permissionRoleName {
+  color: var(--cWhite);
+  font-size: var(--body-sm-size);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.25;
+}
+
+.permissionRoleDescription {
+  color: var(--cWhiteV1);
+  font-size: var(--body-xs-size);
+  line-height: 1.35;
+}
+
+.permissionActionCell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.permissionMobileLabel {
+  display: none;
+  color: var(--cWhiteV1);
+  font-size: var(--body-sm-size);
 }
 
 .paymentMethodRow {
@@ -697,6 +756,33 @@
 
   .paymentMethodError {
     grid-column: 1;
+  }
+
+  .permissionMatrix {
+    overflow-x: visible;
+  }
+
+  .permissionMatrixHeader {
+    display: none;
+  }
+
+  .permissionMatrixRow {
+    grid-template-columns: 1fr;
+    min-width: 0;
+  }
+
+  .permissionRoleCell {
+    padding-bottom: 8px;
+  }
+
+  .permissionActionCell {
+    justify-content: space-between;
+    border-top: 1px solid var(--cModalBorder);
+    padding-block: 10px;
+  }
+
+  .permissionMobileLabel {
+    display: inline;
   }
 }
 

--- a/src/modulos/Config/DptoConfig/DptoConfig.tsx
+++ b/src/modulos/Config/DptoConfig/DptoConfig.tsx
@@ -37,37 +37,61 @@ const paymentMethodOptions = [
   { id: "W", name: "WhatsApp" },
 ] as const;
 
-const ownerActionPermissionOptions = [
+const operationalActionOptions = [
+  { id: "invitation", name: "QR" },
+  { id: "visit_approval", name: "Visitas" },
+  { id: "reservation", name: "Reservas" },
+  { id: "alert", name: "Alertas" },
+] as const;
+
+const operationalRoleOptions = [
   {
-    id: "owner_can_invite_without_residence",
-    name: "Invitación QR",
-    description: "Permite generar invitaciones QR.",
+    id: "homeowner_resident",
+    name: "Propietario residente",
+    description: "Propietario que también vive en la unidad.",
   },
   {
-    id: "owner_can_approve_visits_without_residence",
-    name: "Visitas en guardia",
-    description: "Permite recibir y aprobar visitas desde guardia.",
+    id: "homeowner_resident_dependent",
+    name: "Dep. prop. residente",
+    description: "Dependiente de propietario residente.",
   },
   {
-    id: "owner_can_reserve_without_residence",
-    name: "Reservas",
-    description: "Permite reservar áreas sociales desde la app.",
+    id: "homeowner_non_resident",
+    name: "Propietario no residente",
+    description: "Propietario que no vive en la unidad.",
   },
   {
-    id: "owner_can_alert_without_residence",
-    name: "Alertas",
-    description: "Permite enviar alertas de emergencia.",
+    id: "homeowner_non_resident_dependent",
+    name: "Dep. prop. no residente",
+    description: "Dependiente de propietario no residente.",
+  },
+  {
+    id: "tenant",
+    name: "Inquilino",
+    description: "Residente asignado como inquilino.",
+  },
+  {
+    id: "tenant_dependent",
+    name: "Dep. inquilino",
+    description: "Dependiente de inquilino.",
   },
 ] as const;
 
 type PaymentDebtType = (typeof paymentDebtTypes)[number]["id"];
 type PaymentMethod = (typeof paymentMethodOptions)[number]["id"];
-type OwnerActionPermission =
-  (typeof ownerActionPermissionOptions)[number]["id"];
+type OperationalAction = (typeof operationalActionOptions)[number]["id"];
+type OperationalRole = (typeof operationalRoleOptions)[number]["id"];
+type OperationalPermissionsConfig = Record<
+  OperationalRole,
+  Record<OperationalAction, boolean>
+>;
 
-const ownerActionPermissionFieldNames = ownerActionPermissionOptions.map(
-  (option) => option.id,
-);
+const legacyOperationalActionFieldNames: Record<OperationalAction, string> = {
+  invitation: "owner_can_invite_without_residence",
+  visit_approval: "owner_can_approve_visits_without_residence",
+  reservation: "owner_can_reserve_without_residence",
+  alert: "owner_can_alert_without_residence",
+};
 
 const normalizePaymentMethodsConfig = (value: any) => {
   const parsed =
@@ -115,6 +139,67 @@ const getSingleUrl = (value: unknown) => {
 const isEnabledConfigValue = (value: unknown) =>
   Number(value) === 1 || value === true || value === "Y";
 
+const buildDefaultOperationalPermissionsConfig = (
+  client_config: Record<string, any> = {},
+): OperationalPermissionsConfig => {
+  const residentDefaults = operationalActionOptions.reduce(
+    (acc, action) => ({ ...acc, [action.id]: true }),
+    {} as Record<OperationalAction, boolean>,
+  );
+  const nonResidentOwnerDefaults = operationalActionOptions.reduce(
+    (acc, action) => ({
+      ...acc,
+      [action.id]: isEnabledConfigValue(
+        client_config?.[legacyOperationalActionFieldNames[action.id]],
+      ),
+    }),
+    {} as Record<OperationalAction, boolean>,
+  );
+
+  return {
+    homeowner_resident: { ...residentDefaults },
+    homeowner_resident_dependent: { ...residentDefaults },
+    homeowner_non_resident: { ...nonResidentOwnerDefaults },
+    homeowner_non_resident_dependent: { ...nonResidentOwnerDefaults },
+    tenant: { ...residentDefaults },
+    tenant_dependent: { ...residentDefaults },
+  };
+};
+
+const normalizeOperationalPermissionsConfig = (
+  value: any,
+  client_config: Record<string, any> = {},
+): OperationalPermissionsConfig => {
+  const parsed =
+    typeof value === "string"
+      ? (() => {
+          try {
+            return JSON.parse(value);
+          } catch {
+            return {};
+          }
+        })()
+      : value || {};
+  const config = buildDefaultOperationalPermissionsConfig(client_config);
+
+  operationalRoleOptions.forEach((role) => {
+    operationalActionOptions.forEach((action) => {
+      if (
+        Object.prototype.hasOwnProperty.call(
+          parsed?.[role.id] || {},
+          action.id,
+        )
+      ) {
+        config[role.id][action.id] = isEnabledConfigValue(
+          parsed[role.id][action.id],
+        );
+      }
+    });
+  });
+
+  return config;
+};
+
 const createFormState = (client_config: Record<string, any>) => ({
   url_logo: client_config?.client?.url_logo || [],
   url_logo_print: client_config?.client?.url_logo_print || [],
@@ -143,17 +228,9 @@ const createFormState = (client_config: Record<string, any>) => ({
     Number(client_config?.has_reservation_advance_limit) === 1 ||
     client_config?.has_reservation_advance_limit === true ||
     client_config?.has_reservation_advance_limit === "Y",
-  owner_can_invite_without_residence: isEnabledConfigValue(
-    client_config?.owner_can_invite_without_residence,
-  ),
-  owner_can_approve_visits_without_residence: isEnabledConfigValue(
-    client_config?.owner_can_approve_visits_without_residence,
-  ),
-  owner_can_reserve_without_residence: isEnabledConfigValue(
-    client_config?.owner_can_reserve_without_residence,
-  ),
-  owner_can_alert_without_residence: isEnabledConfigValue(
-    client_config?.owner_can_alert_without_residence,
+  operational_permissions_config: normalizeOperationalPermissionsConfig(
+    client_config?.operational_permissions_config,
+    client_config,
   ),
   has_tasks_visible:
     Number(client_config?.has_tasks_visible) === 1 ||
@@ -184,6 +261,9 @@ const getComparableState = (formState: Record<string, any>) => ({
   url_banner: getSingleUrl(formState.url_banner),
   payment_methods_config: normalizePaymentMethodsConfig(
     formState.payment_methods_config,
+  ),
+  operational_permissions_config: normalizeOperationalPermissionsConfig(
+    formState.operational_permissions_config,
   ),
   payment_time_limit: formState.bookingRequiresPayment
     ? formState.payment_time_limit || ""
@@ -329,17 +409,31 @@ const DptoConfig = ({ client_config, onSave, mode = "condo" }: PropsType) => {
         ...prev,
         has_tasks_visible: isEnabled,
       }));
-    } else if (
-      ownerActionPermissionFieldNames.includes(name as OwnerActionPermission)
-    ) {
-      const isEnabled = value === "Y";
-
-      setFormState((prev: any) => ({
-        ...prev,
-        [name]: isEnabled,
-      }));
     }
   };
+
+  const handleOperationalPermissionSwitch =
+    (role: OperationalRole, action: OperationalAction) =>
+    ({ target: { value } }: any) => {
+      const isEnabled = value === "Y";
+
+      setFormState((prev: any) => {
+        const currentConfig = normalizeOperationalPermissionsConfig(
+          prev.operational_permissions_config,
+        );
+
+        return {
+          ...prev,
+          operational_permissions_config: {
+            ...currentConfig,
+            [role]: {
+              ...currentConfig[role],
+              [action]: isEnabled,
+            },
+          },
+        };
+      });
+    };
 
   const handlePaymentMethodSwitch =
     (debtType: PaymentDebtType, method: PaymentMethod) =>
@@ -594,6 +688,9 @@ const DptoConfig = ({ client_config, onSave, mode = "condo" }: PropsType) => {
     "Condominio";
   const paymentMethodsConfig = normalizePaymentMethodsConfig(
     formState.payment_methods_config,
+  );
+  const operationalPermissionsConfig = normalizeOperationalPermissionsConfig(
+    formState.operational_permissions_config,
   );
   const whatsappPaymentEnabled = hasWhatsAppPaymentMethod(paymentMethodsConfig);
 
@@ -1106,32 +1203,65 @@ const DptoConfig = ({ client_config, onSave, mode = "condo" }: PropsType) => {
 
                 <div className={styles.cardHeader}>
                   <p className={styles.textTitle}>
-                    Permisos de propietarios no residentes
+                    Permisos operativos por vínculo
                   </p>
                   <p className={styles.textSubtitle}>
-                    Define qué pueden hacer propietarios sin residencia activa y
-                    sus dependientes dentro del condominio.
+                    Controla qué puede hacer cada perfil y sus dependientes en
+                    la app y en guardia.
                   </p>
                 </div>
 
-                <div className={styles.permissionSwitchGrid}>
-                  {ownerActionPermissionOptions.map((option) => (
-                    <div className={styles.permissionSwitchRow} key={option.id}>
-                      <div className={styles.switchContent}>
-                        <p className={styles.textTitle}>{option.name}</p>
-                        <p className={styles.textSubtitle}>
-                          {option.description}
-                        </p>
+                <div className={styles.permissionMatrix}>
+                  <div
+                    className={`${styles.permissionMatrixRow} ${styles.permissionMatrixHeader}`}
+                  >
+                    <div>Vínculo</div>
+                    {operationalActionOptions.map((action) => (
+                      <div key={action.id}>{action.name}</div>
+                    ))}
+                  </div>
+
+                  {operationalRoleOptions.map((role) => (
+                    <div className={styles.permissionMatrixRow} key={role.id}>
+                      <div className={styles.permissionRoleCell}>
+                        <span className={styles.permissionRoleName}>
+                          {role.name}
+                        </span>
+                        <span className={styles.permissionRoleDescription}>
+                          {role.description}
+                        </span>
                       </div>
-                      <Switch
-                        name={option.id}
-                        label=""
-                        value={formState[option.id] ? "Y" : "N"}
-                        onChange={handleSwitchChange}
-                        optionValue={["Y", "N"]}
-                        checked={Boolean(formState[option.id])}
-                        disabled={!editMode}
-                      />
+
+                      {operationalActionOptions.map((action) => (
+                        <div
+                          className={styles.permissionActionCell}
+                          key={`${role.id}-${action.id}`}
+                        >
+                          <span className={styles.permissionMobileLabel}>
+                            {action.name}
+                          </span>
+                          <Switch
+                            name={`${role.id}_${action.id}`}
+                            label=""
+                            value={
+                              operationalPermissionsConfig[role.id]?.[action.id]
+                                ? "Y"
+                                : "N"
+                            }
+                            onChange={handleOperationalPermissionSwitch(
+                              role.id,
+                              action.id,
+                            )}
+                            optionValue={["Y", "N"]}
+                            checked={Boolean(
+                              operationalPermissionsConfig[role.id]?.[
+                                action.id
+                              ],
+                            )}
+                            disabled={!editMode}
+                          />
+                        </div>
+                      ))}
                     </div>
                   ))}
                 </div>

--- a/src/modulos/DashDptos/UnitInfo/UnitInfo.tsx
+++ b/src/modulos/DashDptos/UnitInfo/UnitInfo.tsx
@@ -204,6 +204,14 @@ const UnitInfo = ({
             </span>
           </div>
           <div className={styles.infoItem}>
+            <span className={styles.infoLabel}>Recibe visitas</span>
+            <span className={styles.infoValue}>
+              {datas?.data?.can_receive_visits === false
+                ? "Desactivado"
+                : "Activo"}
+            </span>
+          </div>
+          <div className={styles.infoItem}>
             <span className={styles.infoLabel}>Paga las expensas:</span>
             <div style={{ position: "relative" }}>
               <button

--- a/src/modulos/Dptos/RenderForm.tsx
+++ b/src/modulos/Dptos/RenderForm.tsx
@@ -30,6 +30,11 @@ const RenderForm = ({
   const [formState, setFormState]: any = useState({
     ...item,
     has_active_account_plan: parseBoolean(item?.has_active_account_plan),
+    can_receive_visits:
+      item?.can_receive_visits === undefined ||
+      item?.can_receive_visits === null
+        ? true
+        : parseBoolean(item?.can_receive_visits),
   });
   const [errors, setErrors]: any = useState({});
   const [typeFields, setTypeFields]: any = useState([]);
@@ -54,6 +59,11 @@ const RenderForm = ({
           has_active_account_plan: parseBoolean(
             item?.has_active_account_plan
           ),
+          can_receive_visits:
+            item?.can_receive_visits === undefined ||
+            item?.can_receive_visits === null
+              ? true
+              : parseBoolean(item?.can_receive_visits),
         };
 
         // Procesar field_values si existen
@@ -73,10 +83,10 @@ const RenderForm = ({
   const handleChange = (e: any) => {
     const { name, value, type, checked } = e.target;
 
-    if (name === "has_active_account_plan") {
+    if (name === "has_active_account_plan" || name === "can_receive_visits") {
       setFormState((prev: any) => ({
         ...prev,
-        has_active_account_plan: checked ?? parseBoolean(value),
+        [name]: checked ?? parseBoolean(value),
       }));
     } else if (name === "type") {
       const selectedType = extraData?.type?.find(
@@ -175,6 +185,7 @@ const RenderForm = ({
         expense_amount: formState.expense_amount,
         dimension: formState.dimension,
         has_active_account_plan: Boolean(formState.has_active_account_plan),
+        can_receive_visits: Boolean(formState.can_receive_visits),
         homeowner_id:
           formState.homeowner_id == "X" ? null : formState.homeowner_id,
         fields: fields,
@@ -299,6 +310,48 @@ const RenderForm = ({
           optionValue={["1", "0"]}
           value={formState.has_active_account_plan ? "1" : "0"}
           checked={Boolean(formState.has_active_account_plan)}
+          onChange={handleChange}
+        />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 16,
+          padding: "12px 0",
+          width: "100%",
+        }}
+      >
+        <div style={{ flex: "1 1 220px", minWidth: 0 }}>
+          <p
+            style={{
+              color: "var(--twhite)",
+              fontSize: "var(--sM)",
+              fontWeight: 600,
+              margin: 0,
+            }}
+          >
+            Esta unidad puede recibir visitas
+          </p>
+          <p
+            style={{
+              color: "var(--cWhiteV1)",
+              fontSize: "var(--sS)",
+              lineHeight: 1.4,
+              margin: "4px 0 0",
+            }}
+          >
+            Al desactivarlo, no aparecerá en la lista de visitas de guardia.
+          </p>
+        </div>
+        <Switch
+          name="can_receive_visits"
+          optionValue={["1", "0"]}
+          value={formState.can_receive_visits ? "1" : "0"}
+          checked={Boolean(formState.can_receive_visits)}
           onChange={handleChange}
         />
       </div>


### PR DESCRIPTION
## Resumen
- Agrega matriz de permisos operativos por vínculo en reglas operativas.
- Agrega switch por unidad para permitir o bloquear recepción de visitas.
- Muestra el estado de recepción de visitas en el detalle de unidad.

## Validación
- git diff --check