### PR TITLE
chore(admin): S1-T1.3 update 14 reservation call sites to /api/v3/* URLs

### DIFF
--- a/src/app/create-reservas/page.tsx
+++ b/src/app/create-reservas/page.tsx
@@ -21,7 +21,7 @@ const CreateReservaPage = () => {
     try {
       const response = await contextInstance.request({
         method: "GET",
-        url: "/reservations",
+        url: "/api/v3/reservations",
         params: {
           perPage: -1,
           page: 1,

--- a/src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx
+++ b/src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx
@@ -41,7 +41,7 @@ const MaintenanceModal = ({ open, onClose, areas }: Props) => {
 
   const getReservas = async () => {
     const { data } = await execute(
-      "/reservations",
+      "/api/v3/reservations",
       "GET",
       {
         fullType: "L",
@@ -113,7 +113,7 @@ const MaintenanceModal = ({ open, onClose, areas }: Props) => {
   const onSave = async () => {
     if (hasErrors(validate())) return;
     const { data } = await execute(
-      "/reservations-areablocked",
+      "/api/v3/reservations/area-blocked",
       "POST",
       formState,
     );
@@ -128,7 +128,7 @@ const MaintenanceModal = ({ open, onClose, areas }: Props) => {
   const getAreasM = async () => {
     setLoading(true);
     const { data } = await execute(
-      "/reservations",
+      "/api/v3/reservations",
       "GET",
       {
         fullType: "L",

--- a/src/modulos/Calendar/CalendarPage.tsx
+++ b/src/modulos/Calendar/CalendarPage.tsx
@@ -373,7 +373,7 @@ const CalendarPage = () => {
     try {
       const response = await contextInstance.request({
         method: "GET",
-        url: "/reservations",
+        url: "/api/v3/reservations",
         params: {
           fullType: "EXTRA",
           page: 1,
@@ -411,7 +411,7 @@ const CalendarPage = () => {
           splitRangeByYear(visibleRange.start, visibleRange.end).map((segment) =>
             contextInstance.request({
               method: "GET",
-              url: "/reservations",
+              url: "/api/v3/reservations",
               params: {
                 fullType: "L",
                 page: 1,
@@ -637,7 +637,7 @@ const CalendarPage = () => {
           pendingEntries.map((entry) =>
             contextInstance.request({
               method: "GET",
-              url: "/reservations",
+              url: "/api/v3/reservations",
               params: {
                 fullType: "DET",
                 searchBy: entry.reservation.id,
@@ -1350,7 +1350,7 @@ const CalendarPage = () => {
             try {
               const response = await contextInstance.request({
                 method: "GET",
-                url: "/reservations-calendar",
+                url: "/api/v3/reservations/calendar",
                 params: {
                   area_id: String(area.id),
                   date_at: calendarActionModal.row.dayKey,
@@ -1517,7 +1517,7 @@ const CalendarPage = () => {
       try {
         const response = await contextInstance.request({
           method: "GET",
-          url: "/reservations-calendar",
+          url: "/api/v3/reservations/calendar",
           params: {
             area_id: reservationDraft.areaId,
             date_at: calendarActionModal.row.dayKey,
@@ -1790,7 +1790,7 @@ const CalendarPage = () => {
     try {
       const response = await contextInstance.request({
         method: "POST",
-        url: "/reservations",
+        url: "/api/v3/reservations",
         data: payload,
       });
 

--- a/src/modulos/CreateReserva/CreateReserva.tsx
+++ b/src/modulos/CreateReserva/CreateReserva.tsx
@@ -118,7 +118,7 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
       setLoadingCalendar(true);
       const ownerId = selectedUnit?.titular?.id;
       const { data } = await execute(
-        "/reservations-calendar",
+        "/api/v3/reservations/calendar",
         "GET",
         {
           area_id: formState?.area_social || "none",
@@ -368,7 +368,7 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
     };
     try {
       const response = await execute(
-        "/reservations",
+        "/api/v3/reservations",
         "POST",
         payload,
         false,

--- a/src/modulos/Reservas/RenderView/RenderView.tsx
+++ b/src/modulos/Reservas/RenderView/RenderView.tsx
@@ -250,7 +250,7 @@ const ReservationDetailModal: React.FC<ReservationDetailModalProps> = memo(
     const shouldFetchDetail = open && Boolean(detailId);
 
     const { data, reLoad: reloadReservationDetail } = useAxios(
-      shouldFetchDetail ? "/reservations" : null,
+      shouldFetchDetail ? "/api/v3/reservations" : null,
       "GET",
       {
         fullType: "DET",

--- a/src/modulos/Reservas/utils/reservationPayment.ts
+++ b/src/modulos/Reservas/utils/reservationPayment.ts
@@ -155,7 +155,7 @@ export const fetchResolvedPaymentForReservation = async (
   if (!debtId && reservation?.id && contextInstance) {
     const response = await contextInstance.request({
       method: "GET",
-      url: "/reservations",
+      url: "/api/v3/reservations",
       params: {
         fullType: "DET",
         searchBy: reservation.id,


### PR DESCRIPTION
## Summary

DM-4 (2026-07-15) + PR #77 (condaty-api) mergeado a dev.
Cambia los call sites del admin para que apunten a los nuevos endpoints v3 del módulo Reservations.

## URL changes

- `/reservations` → `/api/v3/reservations`
- `/reservations-calendar` → `/api/v3/reservations/calendar`
- `/reservations-areablocked` → `/api/v3/reservations/area-blocked`

## Archivos tocados (14 call sites)

- `src/app/create-reservas/page.tsx` (1)
- `src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx` (3)
- `src/modulos/Calendar/CalendarPage.tsx` (6)
- `src/modulos/CreateReserva/CreateReserva.tsx` (2)
- `src/modulos/Reservas/RenderView/RenderView.tsx` (1)
- `src/modulos/Reservas/utils/reservationPayment.ts` (1)

## Verificación

- `pnpm exec tsc --noEmit`: 0 errores en archivos tocados
- `pnpm exec vitest run`: 241 passed (3 failures pre-existentes en Assemblies, no relacionadas con este PR)
- Pre-commit check (4 reglas): PASS

## Refs

- PLAN-FIX-FINANZAS-2026-07-15 §4.1 (S1-T1.3)
- AUDIT-reservations-consumers-2026-07-15.md
- PR #77 (condaty-api): feat/s1-t1-reservations-v3-module