### PR TITLE
fix(admin): S4-T1.1 migrate MaintenanceModal status_reservation filter char→numeric

### DIFF
--- a/src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx
+++ b/src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx
@@ -13,6 +13,7 @@ import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
 import { IconX } from "@/components/layout/icons/IconsBiblioteca";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import SkeletonAdapterComponent from "@/mk/components/ui/LoadingScreen/SkeletonAdapter";
+import { ReservationStatus } from "@/modulos/Reservas/constants/reservationConstants";
 
 interface Props {
   open: boolean;
@@ -132,7 +133,7 @@ const MaintenanceModal = ({ open, onClose, areas }: Props) => {
       "GET",
       {
         fullType: "L",
-        filterBy: "status_reservation:M",
+        filterBy: `status_reservation:${ReservationStatus.MAINTENANCE}`,
         perPage: -1,
         page: 1,
       },


### PR DESCRIPTION
## S4 — Consumers cross-app migration (P4: status char→numeric)

### What
Mantenimiento consume la API de Reservations con `filterBy: 'status_reservation:M'` (char legacy M=MAINTENANCE). El backend pineó fail-loud post-S2 (InvalidArgumentException en filtros char). El filter se ignoraba silenciosamente antes; ahora matchea correctamente la rama 'ALL' del controller (que pineá `where status != MAINTENANCE->value`).

### Change
`src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx` (1 archivo, 2 LOC):
- `filterBy: 'status_reservation:M'` → `filterBy: `status_reservation:${ReservationStatus.MAINTENANCE}``
- +import `ReservationStatus` desde constants

### Audit S4 cross-app (completo)
**admin (condaty2025-admin)**: 1 call site con char hardcoded en filterBy → migrado.
- `/categories?type=D` (DebtsManager) es router.push frontend, no API call. El componente `useCategories` ya pineá `typeToUse` numeric (1=INCOME, 2=EXPENSE) en el API call. OK.
- `/comments?type=C` (CommentsModal, Reel) pineá endpoint que NO EXISTE en routes (404). Pre-existente, fuera de scope S4.
- Demás dropdowns en admin ya pinean enums TS numeric (PaymentStatus, ReservationStatus, etc.).

**rnGuard**: 0 call sites con status char en filterBy (solo `filterBy: 'ALL'` sentinel).

**rnOwner**: 0 call sites problemáticos. `/others/{id} PUT { status: 'X' }` (OrderDetail) pineá char, pero el backend de Other es char legacy (no int). OK.

### Why
Backend pineó `InvalidArgumentException` para filtros char en S2-T1 (rule 'no compat layer' per DM-2). Consumers cross-app que pineen chars se rompen silenciosamente o con 422.

### Cross-IA note
S4 cross-app scope es **solo este PR** (1 archivo). El resto del audit confirma que admin/rnGuard/rnOwner ya pinean enums numéricos o backend es char legacy. S4 cierra con esto.

Refs: PLAN-FIX-FINANZAS-2026-07-15 §6 S4 (P4 consumers migration).