### PR TITLE
fix(admin): S13 migrate consumers to v3 routes (debt-dptos, expenses, budgets, others, defaulters)

### DIFF
--- a/src/components/DefaultersView/DefaultersView.tsx
+++ b/src/components/DefaultersView/DefaultersView.tsx
@@ -30,7 +30,7 @@ const Defaulters = () => {
 
   // Definir el módulo para useCrud
   const mod = {
-    modulo: "defaulters",
+    modulo: "v3/defaulters",
     singular: "Moroso",
     plural: "Morosos",
     permiso: "defaulters",
@@ -131,7 +131,7 @@ const Defaulters = () => {
 
   // Exportar función para el botón de exportar
   const exportar = () => {
-    execute("/defaulters", "GET", { exportar: 1 }, false);
+    execute("/v3/defaulters", "GET", { exportar: 1 }, false);
   };
 
   // Botones adicionales para la tabla
@@ -170,7 +170,7 @@ const Defaulters = () => {
     try {
       // Usamos el mismo endpoint que useCrud usa para obtener los datos
       const { data: response } = await execute(
-        "/defaulters",
+        "/v3/defaulters",
         "GET",
         {
           fullType: "DET",

--- a/src/modulos/Activities/PedidosTab/PedidosTab.tsx
+++ b/src/modulos/Activities/PedidosTab/PedidosTab.tsx
@@ -88,7 +88,7 @@ const PedidosTab: React.FC<PedidosTabProps> = ({ paramsInitial }) => {
   // Definición del módulo Pedidos
   const modPedidos: ModCrudType = useMemo(() => {
     return {
-      modulo: "others",
+      modulo: "v3/others",
       singular: "Pedido",
       plural: "Pedidos",
       filter: true,

--- a/src/modulos/Budget/Budget/Budget.tsx
+++ b/src/modulos/Budget/Budget/Budget.tsx
@@ -134,7 +134,7 @@ const Budget = () => {
 
   const mod: ModCrudType = useMemo(
     () => ({
-      modulo: "budgets",
+      modulo: "v3/budgets",
       singular: "Presupuesto",
       plural: "Presupuestos",
       permiso: "budgets",

--- a/src/modulos/Budget/Budget/RenderForm/RenderForm.tsx
+++ b/src/modulos/Budget/Budget/RenderForm/RenderForm.tsx
@@ -101,7 +101,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
       return;
     }
 
-    const url = "/budgets" + (formState.id ? "/" + formState.id : "");
+    const url = "/v3/budgets" + (formState.id ? "/" + formState.id : "");
     const method = formState.id ? "PUT" : "POST";
 
     try {

--- a/src/modulos/Budget/BudgetDir/BudgetDir.tsx
+++ b/src/modulos/Budget/BudgetDir/BudgetDir.tsx
@@ -122,7 +122,7 @@ const getCategoryOptionsForFilter = (extraData: any) => [
 ];
 
 const mod: ModCrudType = {
-  modulo: "budgets",
+  modulo: "v3/budgets",
   singular: "Presupuesto",
   plural: "Presupuestos",
   permiso: "budgets",

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
@@ -457,7 +457,7 @@ const AllDebts: React.FC<AllDebtsProps> = ({ onExtraDataChange }) => {
   }, []);
 
   const mod: ModCrudType = {
-    modulo: "debt-dptos",
+    modulo: "v3/debt-dptos",
     singular: "Deuda",
     plural: "",
     // export: true,

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
@@ -80,7 +80,7 @@ const RenderView: React.FC<RenderViewProps> = ({
   const today = new Date();
 
   const { data, execute, loaded } = useAxios(
-    "/debt-dptos",
+    "/v3/debt-dptos",
     "GET",
     {
       searchBy: item?.id,
@@ -251,7 +251,7 @@ const RenderView: React.FC<RenderViewProps> = ({
   const reloadItem = async () => {
     try {
       const response = await executeRef.current(
-        "/debt-dptos",
+        "/v3/debt-dptos",
         "GET",
         {
           searchBy: currentItem.id,

--- a/src/modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx
+++ b/src/modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx
@@ -28,7 +28,7 @@ const Forgiveness = ({
 }: any) => {
 
   const mod = {
-    modulo: 'debt-dptos',
+    modulo: 'v3/debt-dptos',
     singular: 'condonación',
     plural: '',
     permiso: 'defaulters',

--- a/src/modulos/DebtsManager/TabComponents/Forgiveness/RenderForm/RenderForm.tsx
+++ b/src/modulos/DebtsManager/TabComponents/Forgiveness/RenderForm/RenderForm.tsx
@@ -218,7 +218,7 @@ const RenderForm = ({
     };
 
     const { data: response } = await execute(
-      "/debt-dptos" + (formState.id ? "/" + formState.id : ""),
+      "/v3/debt-dptos" + (formState.id ? "/" + formState.id : ""),
       method,
       dataToSend,
       false

--- a/src/modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx
@@ -223,7 +223,7 @@ const IndividualDebts: React.FC<IndividualDebtsProps> = ({
   ];
 
   const mod: ModCrudType = {
-    modulo: 'debt-dptos',
+    modulo: 'v3/debt-dptos',
     singular: 'Deuda',
     plural: '',
     export: true,

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
@@ -246,7 +246,7 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
   }, []);
 
   const mod: ModCrudType = {
-    modulo: "debt-dptos",
+    modulo: "v3/debt-dptos",
     singular: "Detalle",
     plural: "Detalles",
     export: true,

--- a/src/modulos/Defaulters/Defaulters.tsx
+++ b/src/modulos/Defaulters/Defaulters.tsx
@@ -40,7 +40,7 @@ const Defaulters = () => {
     return d;
   };
   const mod = {
-    modulo: "defaulters",
+    modulo: "v3/defaulters",
     singular: "Moroso",
     plural: "Morosos",
     permiso: "defaulters",

--- a/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
+++ b/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
@@ -151,7 +151,7 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
   };
 
   const mod: ModCrudType = {
-    modulo: "debt-dptos",
+    modulo: "v3/debt-dptos",
     singular: "",
     plural: "",
     filter: true,

--- a/src/modulos/Expenses/ExpensesDetails/RenderView/RenderView.tsx
+++ b/src/modulos/Expenses/ExpensesDetails/RenderView/RenderView.tsx
@@ -50,7 +50,7 @@ const RenderView = (props: {
 
   const reloadItem = async () => {
     const { data } = await props.execute(
-      "/debt-dptos",
+      "/v3/debt-dptos",
       "GET",
       {
         fullType: "DET",

--- a/src/modulos/Outlays/Outlays.tsx
+++ b/src/modulos/Outlays/Outlays.tsx
@@ -47,7 +47,7 @@ const Outlays = () => {
   };
 
   const mod: ModCrudType = {
-    modulo: "expenses",
+    modulo: "v3/expenses",
     singular: "Egreso",
     plural: "Egresos",
     filter: true,

--- a/src/modulos/Outlays/PerformBudget/PerformBudget.tsx
+++ b/src/modulos/Outlays/PerformBudget/PerformBudget.tsx
@@ -26,7 +26,7 @@ const PerformBudget = ({ open, onClose, reLoad }: Props) => {
 
   const { execute } = useAxios();
   const getApprovedBudgets = async () => {
-    const { data } = await execute("/approved-budgets", "GET", {
+    const { data } = await execute("/v3/budgets/approved-budgets", "GET", {
       page: 1,
       perPage: -1,
     });
@@ -54,7 +54,7 @@ const PerformBudget = ({ open, onClose, reLoad }: Props) => {
   }, [formState]);
 
   const onSave = async () => {
-    const { data } = await execute("/execute-budget", "POST", formState);
+    const { data } = await execute("/v3/budgets/execute-budget", "POST", formState);
 
     // Debug: Ver toda la respuesta
     console.log('🔍 Respuesta completa del API:', data);

--- a/src/modulos/Outlays/RenderDel/RenderDel.tsx
+++ b/src/modulos/Outlays/RenderDel/RenderDel.tsx
@@ -89,7 +89,7 @@ const RenderDel = memo(({ open, onClose, item, onSave, execute, reLoad }: Render
     };
 
     try {
-      const { data: response } = await execute(`/expenses/${item?.id}`, 'DELETE', params);
+      const { data: response } = await execute(`/v3/expenses/${item?.id}`, 'DELETE', params);
 
       if (response?.success) {
         onClose();

--- a/src/modulos/Reservas/RenderForm/RenderForm.tsx
+++ b/src/modulos/Reservas/RenderForm/RenderForm.tsx
@@ -265,7 +265,7 @@ const RenderForm = ({
 
     try {
       console.log("Enviando datos:", params);
-      const { data, error } = await execute("/expenses", "POST", params);
+      const { data, error } = await execute("/v3/expenses", "POST", params);
 
       if (data?.success) {
         showToast("Egreso registrado con éxito", "success");


### PR DESCRIPTION
## Symptom (reportado por Mario 2026-07-16)

Al dar click en una fila de la lista de expensas, donde deberían salir las deudas del periodo, salta error:

```json
{"message": "The route api/debt-dptos could not be found.", ...}
```

## Root cause

S11 (PLAN-FINANZAS-CLEANUP) porteó 5 controllers a v3 namespace (`/api/v3/{debt-dptos,expenses,budgets,others,defaulters}`) pero el admin frontend quedó con las URLs legacy `/api/{resource}`. El DetailModal de la lista de expensas hacía `execute("/debt-dptos", ...)` legacy → 404.

## Fix

Migración completa de consumers a v3 (DM-4: consumers se actualizan a la nueva versión, sin compat layer).

**22 cambios en 18 archivos**:

| Endpoint | Cambios | Archivos |
|---|---|---|
| debt-dptos | 9 | 8 (incluye 2 hardcoded en AllDebts/RenderView) |
| expenses | 3 | 3 (incluye 2 hardcoded en Reservas/RenderForm y Outlays/RenderDel) |
| budgets | 5 | 4 (incluye 3 hardcoded: Budget/RenderForm, PerformBudget x2) |
| others | 1 | 1 |
| defaulters | 4 | 2 (incluye 2 hardcoded en DefaultersView) |

**NO tocado** (intencional):
- `/debt-groups/*` — S6.5 ya lo montó en `/api/debt-groups` sin v3 prefix por diseño (ver `app/Modules/DebtDptos/Routes/api.php` del API).
- `mainMenuConfig.ts` hrefs `/expenses`, `/defaulters` — son Next.js SPA routes, no API endpoints.
- `Index.tsx` `window.location.href='/defaulters'` — idem.

## Validation

- `tsc --noEmit`: **0 errores nuevos** en archivos modificados.
- `vitest run`: 264/267 tests pass. Los 3 fails son **pre-existentes** en `Assemblies/AssemblyAttendanceList` (mock de `IconDownload`) y `Surveys` (env var InstantDB `appId`). Confirmado corriendo `git stash` + `vitest` en `dev` baseline: misma failure rate.
- Pre-commit-check-rules: PASS (0 errors, 0 warnings).

## Follow-up (out of S13 scope, flagged para sprint separado)

`src/mk/components/chat/chatBot/useChatBotLLM.tsx:540` llama a `/payments` legacy. El config de Payments ya pineó `modulo: 'v3/payments'` en S3, así que el chatBot es el único consumer legacy que queda. No es finanzas → no va en S13.

Verificado por grep exhaustivo de `execute()`/`useAxios()` que no quedan otros endpoints legacy de finanzas en el admin repo.

## Refs

- PLAN-FIX-FINANZAS-2026-07-15 §S11 (post-port consumer migration gap).
- S12 (test coverage post-port) y S12-T1 (SSoT relation) cerraron pre-existentes, pero el click → 404 era un gap visual que solo se ve en runtime.

🤖 Generated with [Mavis](https://MiniMax.dev)
