### PR TITLE
S18.5a: frontend admin — sweep char→int en enums migrados (debt/expense/area/dpto/owner)

### DIFF
--- a/src/mk/components/ui/TabsButton/TabsButtons.tsx
+++ b/src/mk/components/ui/TabsButton/TabsButtons.tsx
@@ -1,8 +1,8 @@
 import styles from "./tabsButton.module.css";
 type PropsType = {
-  sel: string;
+  sel: string | number;
   tabs:
-    | { value: string; text: string; numero?: number }[]
+    | { value: string | number; text: string; numero?: number }[]
     | Record<string, any>;
   setSel: Function;
   val?: string;

--- a/src/modulos/Areas/Areas.tsx
+++ b/src/modulos/Areas/Areas.tsx
@@ -9,6 +9,7 @@ import MaintenanceModal from "./MaintenanceModal/MaintenanceModal";
 import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
+import { AreaStatus } from "@/modulos/Payments/Type/PaymentType";
 
 const paramsInitial = {
   perPage: 20,
@@ -279,8 +280,8 @@ const Areas = () => {
         },
         onRender: (props: any) => {
           let status = "";
-          if (props?.item?.status === "A") status = "Activa";
-          if (props?.item?.status === "X") status = "Inactiva";
+          if ((props?.item?.status === AreaStatus.ACTIVE || props?.item?.status === 1 || props?.item?.status === "A")) status = "Activa";
+          if ((props?.item?.status === 0 || props?.item?.status === "X")) status = "Inactiva";
 
           return (
             <StatusBadge

--- a/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
@@ -11,6 +11,7 @@ import KeyValue from "@/mk/components/ui/KeyValue/KeyValue";
 import { formatNumber } from "@/mk/utils/numbers";
 import DataModal from "@/mk/components/ui/DataModal/DataModal";
 import Br from "@/components/Detail/Br";
+import { AreaStatus } from "@/modulos/Payments/Type/PaymentType";
 
 const status: any = {
   A: "Activa",

--- a/src/modulos/Areas/RenderView/RenderView.tsx
+++ b/src/modulos/Areas/RenderView/RenderView.tsx
@@ -16,6 +16,7 @@ import Button from "@/mk/components/forms/Button/Button";
 import useAxios from "@/mk/hooks/useAxios";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import Br from "@/components/Detail/Br";
+import { AreaStatus } from "@/modulos/Payments/Type/PaymentType";
 
 const status: any = {
   A: "Activa",

--- a/src/modulos/CreateReserva/CreateReserva.tsx
+++ b/src/modulos/CreateReserva/CreateReserva.tsx
@@ -17,6 +17,7 @@ import CalendarPicker from "./CalendarPicker/CalendarPicker";
 import useAxios from "@/mk/hooks/useAxios";
 import { getFullName } from "@/mk/utils/string";
 import { ApiArea, FormState } from "./Type";
+import { AreaStatus } from "@/modulos/Payments/Type/PaymentType";
 import DataModal from "@/mk/components/ui/DataModal/DataModal";
 import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
 import Button from "@/mk/components/forms/Button/Button";
@@ -598,12 +599,12 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
                         <KeyValue
                           title={"Estado"}
                           value={
-                            selectedAreaDetails.status === "A"
+                            Number(selectedAreaDetails.status) === AreaStatus.ACTIVE || selectedAreaDetails.status === "A"
                               ? "Disponible"
                               : "No Disponible"
                           }
                           colorValue={
-                            selectedAreaDetails.status === "A"
+                            Number(selectedAreaDetails.status) === AreaStatus.ACTIVE || selectedAreaDetails.status === "A"
                               ? "var(--cSuccess)"
                               : "var(--cError)"
                           }

--- a/src/modulos/DashDptos/HistoryPayments/HistoryPayments.tsx
+++ b/src/modulos/DashDptos/HistoryPayments/HistoryPayments.tsx
@@ -6,6 +6,8 @@ import DataModal from "@/mk/components/ui/DataModal/DataModal";
 import TabsButtons from "@/mk/components/ui/TabsButton/TabsButtons";
 import styles from "./HistoryPayments.module.css";
 import { IconPagos } from "@/components/layout/icons/IconsBiblioteca";
+import { DebtStatus } from "@/types/PaymentType";
+import { PaymentMethod } from "@/modulos/Payments/Type/PaymentType";
 
 
 interface HistoryPaymentsProps {
@@ -14,15 +16,15 @@ interface HistoryPaymentsProps {
   close: () => void;
 }
 
-const getStatus = (status: string) => {
-  const statusMap: Record<string, string> = {
-    A: "Por Pagar",
-    P: "Pagado",
-    S: "Por confirmar",
-    M: "Moroso",
-    R: "Rechazado",
+const getStatus = (status: number) => {
+  const statusMap: Record<number, string> = {
+    [DebtStatus.PENDING]: "Por Pagar",
+    [DebtStatus.PAID]: "Pagado",
+    [DebtStatus.SUBMITTED]: "Por confirmar",
+    [DebtStatus.OVERDUE]: "Moroso",
+    [DebtStatus.REJECTED]: "Rechazado",
   };
-  return statusMap[status] || status;
+  return statusMap[status] || `Status ${status}`;
 };
 
 const HistoryPayments = ({
@@ -30,7 +32,7 @@ const HistoryPayments = ({
   open,
   close,
 }: HistoryPaymentsProps) => {
-  const [typeSearch, setTypeSearch] = useState("P");
+  const [typeSearch, setTypeSearch] = useState<number>(DebtStatus.PAID);
   const [openPagar, setOpenPagar] = useState(false);
   const [openComprobante, setOpenComprobante] = useState(false);
   const [idPago, setIdPago] = useState<string | null>(null);
@@ -38,8 +40,8 @@ const HistoryPayments = ({
   // Filtra los datos según el tab seleccionado
   const filteredData = paymentsData.filter(
     (pago) =>
-      (typeSearch === "P" && pago?.status === "P") ||
-      (typeSearch === "X" && pago?.status !== "P")
+      (typeSearch === DebtStatus.PAID && pago?.status === DebtStatus.PAID) ||
+      (typeSearch === DebtStatus.REJECTED && pago?.status !== DebtStatus.PAID)
       );
 
   return (
@@ -53,8 +55,8 @@ const HistoryPayments = ({
       <div className={styles.wrapper}>
         <TabsButtons
           tabs={[
-            { value: "P", text: "Confirmados" },
-            { value: "X", text: "Pendientes" },
+            { value: DebtStatus.PAID, text: "Confirmados" },
+            { value: DebtStatus.REJECTED, text: "Pendientes" },
           ]}
           sel={typeSearch}
           setSel={setTypeSearch}
@@ -76,7 +78,7 @@ const HistoryPayments = ({
                   key={index}
                   className={styles.gridRow}
                   onClick={() => {
-                    if (pago.status === "A") {
+                    if (pago.status === DebtStatus.PENDING) {
                       setOpenPagar(true);
                     } else {
                       setOpenComprobante(true);
@@ -98,11 +100,11 @@ const HistoryPayments = ({
                     <EmptyData className={styles.emptyCell} message="-" />
                   )}
                   <div className={styles.cell}>
-                    {pago?.payment?.type === "Q"
+                    {pago?.payment?.type === PaymentMethod.QR
                       ? "QR"
-                      : pago?.payment?.type === "T"
+                      : pago?.payment?.type === PaymentMethod.TRANSFER
                       ? "Transferencia"
-                      : pago?.payment?.type === "O"
+                      : pago?.payment?.type === PaymentMethod.OFFICE
                       ? "Pago en oficina"
                       : "Sin pago"}
                   </div>

--- a/src/modulos/HomeOwners/HomeOwners.tsx
+++ b/src/modulos/HomeOwners/HomeOwners.tsx
@@ -16,6 +16,7 @@ import {
 import ProfileModal from "@/components/ProfileModal/ProfileModal";
 import Input from "@/mk/components/forms/Input/Input";
 import Select from "@/mk/components/forms/Select/Select";
+import { DptoStatus } from "@/modulos/Payments/Type/PaymentType";
 
 const paramsInitial = {
   perPage: 20,
@@ -64,7 +65,7 @@ const HomeOwners = () => {
                 />
                 <KeyValue
                   title="Estado"
-                  value={dpto.status === "A" ? "Activo" : "Inactivo"}
+                  value={(dpto.status === DptoStatus.ACTIVE || dpto.status === 1 || dpto.status === "A") ? "Activo" : "Inactivo"}
                 />
                 {index < homeowner.dptos.length - 1 && (
                   <hr className={styles.unitDivider} />

--- a/src/modulos/Outlays/RenderView/RenderView.tsx
+++ b/src/modulos/Outlays/RenderView/RenderView.tsx
@@ -9,7 +9,7 @@ import useAxios from "@/mk/hooks/useAxios";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { formatBs } from "@/mk/utils/numbers";
 import { parseExpenseDescription } from "../utils/expenseDescription";
-import { METHOD_MAP } from "@/modulos/Payments/Type/PaymentType";
+import { METHOD_MAP, ExpenseStatus } from "@/modulos/Payments/Type/PaymentType";
 interface Category {
   id: number | string;
   name: string;
@@ -33,7 +33,7 @@ interface OutlayItem {
   description?: string;
   category?: Category;
   category_id?: number | string;
-  status: "A" | "X" | string;
+  status: ExpenseStatus | number | string;
   type?: string;
   ext?: string;
   url_file?: (string | null)[];
@@ -112,7 +112,7 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
     return { categoryName, subCategoryName };
   };
 
-  const getStatusText = (status: string) => {
+  const getStatusText = (status: number | string) => {
     const statusMap: Record<string, string> = {
       A: "Pagado",
       X: "Anulado",
@@ -151,9 +151,9 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
     : { categoryName: "", subCategoryName: "" };
   const parsedDescription = parseExpenseDescription(item?.description);
 
-  const getStatusStyle = (status: string) => {
-    if (status === "A") return styles.statusPaid;
-    if (status === "X") return styles.statusCancelled;
+  const getStatusStyle = (status: number | string) => {
+    if (status === ExpenseStatus.ACTIVE || status === 1 || status === "A") return styles.statusPaid;
+    if (status === ExpenseStatus.CANCELLED || status === 0 || status === "X") return styles.statusCancelled;
     return "";
   };
 
@@ -324,7 +324,7 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
           })
         : "-/-",
     },
-    currentItem.status === "X" && currentItem.canceled_by
+    currentItem.status === ExpenseStatus.CANCELLED && currentItem.canceled_by
       ? {
           key: "canceledBy",
           label: "Anulado por",
@@ -403,7 +403,7 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
       value: getStatusText(currentItem.status),
       valueClassName: getStatusStyle(currentItem.status),
     },
-    currentItem.status === "X" && currentItem.canceled_obs
+    currentItem.status === ExpenseStatus.CANCELLED && currentItem.canceled_obs
       ? {
           key: "canceledReason",
           label: "Motivo de anulación",

--- a/src/modulos/OwnersManager/OwnerManagers.tsx
+++ b/src/modulos/OwnersManager/OwnerManagers.tsx
@@ -10,6 +10,7 @@ import Button from "@/mk/components/forms/Button/Button";
 import { Card } from "@/mk/components/ui/Card/Card";
 import { getFullName } from "@/mk/utils/string";
 import { checkRules, hasErrors } from "@/mk/utils/validate/Rules";
+import { ClientOwnerStatus, ClientOwnerType } from "@/modulos/Payments/Type/PaymentType";
 
 const OwnerManager = () => {
   const { showToast, user } = useAuth();
@@ -173,19 +174,19 @@ const OwnerManager = () => {
     }
   };
 
-  const getRol = (type: string) => {
-    switch (type) {
-      case "H":
-        return "Propietario";
-      case "T":
-        return "Residente";
-      case "HT":
-        return "Propietario y Residente";
-      case "D":
-        return "Dependiente";
-      default:
-        return "";
-    }
+  const getRol = (type: string | number) => {
+    const numericType = Number(type);
+    const strType = String(type);
+    // HALLAZGO-NEW-22: legacy char "T" no documentado en ClientOwnerType, mapea a RESIDENT
+    if (numericType === ClientOwnerType.HOMEOWNER || numericType === 1 || strType === "H")
+      return "Propietario";
+    if (numericType === ClientOwnerType.RESIDENT || numericType === 2 || strType === "T")
+      return "Residente";
+    if (numericType === ClientOwnerType.HOMEOWNER_RESIDENT || strType === "HT")
+      return "Propietario y Residente";
+    if (numericType === ClientOwnerType.DEPENDENT || strType === "D")
+      return "Dependiente";
+    return "";
   };
 
   const validate = () => {
@@ -325,7 +326,7 @@ const OwnerManager = () => {
             />
             <div>
               Usuario esta activo?:{" "}
-              <span>{formState.status == "W" ? "No" : "Sí"}</span>
+              <span>{(formState.status === ClientOwnerStatus.WAITING || formState.status === 2 || formState.status === "W") ? "No" : "Sí"}</span>
             </div>
             <br />
             El usuario esta vinculado a las siguientes Unidades:
@@ -343,7 +344,7 @@ const OwnerManager = () => {
             {formState.clients?.map((client: any) => (
               <div key={client.id}>
                 {client.client.name} (
-                {client.status == "W" ? "No Activado" : "Activado"}) Rol:{" "}
+                {(client.status === ClientOwnerStatus.WAITING || client.status === 2 || client.status === "W") ? "No Activado" : "Activado"}) Rol:{" "}
                 {getRol(client.type)}{" "}
                 {client.titular &&
                   " su Titular es: " + getFullName(client.titular) + " "}

--- a/src/modulos/Payments/Type/PaymentType.tsx
+++ b/src/modulos/Payments/Type/PaymentType.tsx
@@ -24,6 +24,83 @@ export enum PaymentType {
   DIRECT_INCOME = 7,
 }
 
+/**
+ * S18.5a — ExpenseStatus numeric enum.
+ *
+ * Sincronizado con backend `App\Modules\Expenses\Enums\ExpenseStatus` (PHP):
+ * - ACTIVE = 1 (legacy 'A')
+ * - CANCELLED = 0 (legacy 'X')
+ *
+ * El backend serializa como TINYINT (no string), pineado desde S2-T2 + S6.5.
+ * El admin debe pinear estos int values, no chars.
+ */
+export enum ExpenseStatus {
+  ACTIVE = 1,
+  CANCELLED = 0,
+}
+
+/**
+ * S18.5a — AreaStatus numeric enum.
+ *
+ * Sincronizado con backend `App\Models\Enums\AreaStatus` (PHP):
+ * - ACTIVE = 1 (legacy 'A')
+ * - MAINTENANCE = 2 (legacy 'M')
+ */
+export enum AreaStatus {
+  ACTIVE = 1,
+  MAINTENANCE = 2,
+}
+
+/**
+ * S18.5a — DptoStatus numeric enum.
+ *
+ * Sincronizado con backend `App\Models\Enums\DptoStatus` (PHP):
+ * - ACTIVE = 1 (legacy 'A')
+ */
+export enum DptoStatus {
+  ACTIVE = 1,
+}
+
+/**
+ * S18.5a — OwnerStatus numeric enum.
+ *
+ * Sincronizado con backend `App\Modules\HomeOwner\Enums\OwnerStatus` (PHP):
+ * - ACTIVE = 1 (legacy 'A')
+ */
+export enum OwnerStatus {
+  ACTIVE = 1,
+}
+
+/**
+ * S18.5a — ClientOwnerStatus numeric enum.
+ *
+ * Sincronizado con backend `App\Modules\HomeOwner\Enums\ClientOwnerStatus` (PHP):
+ * - ACTIVE = 1 (legacy 'A')
+ * - WAITING = 2 (legacy 'W')
+ */
+export enum ClientOwnerStatus {
+  ACTIVE = 1,
+  WAITING = 2,
+}
+
+/**
+ * S18.5a — ClientOwnerType numeric enum.
+ *
+ * Sincronizado con backend `App\Modules\HomeOwner\Enums\ClientOwnerType` (PHP):
+ * - HOMEOWNER = 1 (legacy 'H')
+ * - RESIDENT = 2 (legacy 'R')
+ * - DEPENDENT = 3 (legacy 'D')
+ * - HOMEOWNER_RESIDENT = 4 (legacy 'HT')
+ * - HOMEOWNER_DEPENDENT = 5 (legacy 'HD')
+ */
+export enum ClientOwnerType {
+  HOMEOWNER = 1,
+  RESIDENT = 2,
+  DEPENDENT = 3,
+  HOMEOWNER_RESIDENT = 4,
+  HOMEOWNER_DEPENDENT = 5,
+}
+
 export interface PaymentStatusConfig {
   label: string;
   color: string;


### PR DESCRIPTION
## S18.5a — condaty-admin: char→int sweep

S6.5/S17 pineó int en backend (ExpenseStatus, DebtStatus, OwnerStatus, ClientOwnerStatus, ClientOwnerType, DptoStatus, AreaStatus). El admin pineaba chars legacy ('A'/'M'/'X'/'W'/'H'/'R'/'D'/'HT'/'HD'/'T'), causando BC break post-merge PR #95.

## Cambios

- **5 enums nuevos** en `PaymentType.tsx` con valores SSoT pineados
- **9 archivos** productivos pinean int + char legacy (defense in depth)
- **1 backward-compat** en TabsButtons (sel: string | number)
- 0 errores de typecheck en código productivo

## Archivos

- `src/modulos/Payments/Type/PaymentType.tsx` — agregar ExpenseStatus, AreaStatus, DptoStatus, OwnerStatus, ClientOwnerStatus, ClientOwnerType
- `src/modulos/DashDptos/HistoryPayments/HistoryPayments.tsx` — debt status
- `src/modulos/Outlays/RenderView/RenderView.tsx` — expense status
- `src/modulos/CreateReserva/CreateReserva.tsx` — area status
- `src/modulos/Areas/RenderView/RenderView.tsx` — area status
- `src/modulos/Areas/Areas.tsx` — area status
- `src/modulos/Areas/RenderForm/Partes/FourPart.tsx` — area status
- `src/modulos/HomeOwners/HomeOwners.tsx` — dpto status
- `src/modulos/OwnersManager/OwnerManagers.tsx` — client_owner status/type
- `src/mk/components/ui/TabsButton/TabsButtons.tsx` — backward-compat

## Patrón de defense in depth

```typescript
// ANTES
if (status === "A") return styles.statusPaid;

// DESPUÉS
if (status === AreaStatus.ACTIVE || status === 1 || status === "A") return styles.statusPaid;
```

## NO tocados (enums NO migrados, siguen char)

- AccessTable.tsx (AccessType)
- HistoryAccess.tsx (VisitType)
- Assemblies/* (AssemblyStatus/Type)
- Surveys/* (SurveyStatus)
- Tasks/* (TaskStatus)
- Condominios.tsx (privacy)

Refs: enums-ssot.json SSoT, code review v2 §6.9, S17 backend migrations