### PR TITLE
refactor(admin): S20.5 — sync URLs to /v3/* (Surveys + Balance modules)

### DIFF
--- a/src/modulos/Balance/Balance.tsx
+++ b/src/modulos/Balance/Balance.tsx
@@ -78,7 +78,7 @@ const BalanceGeneral: React.FC = () => {
     data: finanzas,
     reLoad: reLoadFinanzas,
     loaded,
-  } = useAxios("/balances", "POST", {});
+  } = useAxios("/v3/balances", "POST", {});
 
   const [loadingLocal, setLoadingLocal] = useState(false);
   useEffect(() => {

--- a/src/modulos/Surveys/__tests__/useMySurveys.test.ts
+++ b/src/modulos/Surveys/__tests__/useMySurveys.test.ts
@@ -40,7 +40,7 @@ describe('useMySurveys Hook', () => {
     await waitFor(() => {
         expect(result.current.counts).toEqual(mockCounts);
     });
-    expect(mockExecute).toHaveBeenCalledWith("/surveys/my-counts", "GET", {}, false, true);
+    expect(mockExecute).toHaveBeenCalledWith("/v3/surveys/my-counts", "GET", {}, false, true);
   });
 
   it('fetchSurveys carga las encuestas correctamente', async () => {

--- a/src/modulos/Surveys/components/AssemblySurveyForm/AssemblySurveyForm.tsx
+++ b/src/modulos/Surveys/components/AssemblySurveyForm/AssemblySurveyForm.tsx
@@ -198,7 +198,7 @@ const AssemblySurveyForm: React.FC<AssemblySurveyFormProps> = ({
         ],
       };
 
-      const url = action === "edit" ? `/surveys/${editItem.id}` : "/surveys";
+      const url = action === "edit" ? `/v3/surveys/${editItem.id}` : "/v3/surveys";
       const method = action === "edit" ? "PUT" : "POST";
 
       const { data } = await execute(url, method, payload);

--- a/src/modulos/Surveys/components/RenderForm/ModalDestiny.tsx
+++ b/src/modulos/Surveys/components/RenderForm/ModalDestiny.tsx
@@ -21,7 +21,7 @@ const ModalDestiny = ({
     setSel(formState?.lDestiny || []);
   }, [formState]);
   // const getMeta = async () => {
-  //   const { data } = await execute("/surveys", "GET", {
+  //   const { data } = await execute("/v3/surveys", "GET", {
   //     destiny: sel,
   //     fullType: "DES",
   //     lDestinies: formState.lDestiny,

--- a/src/modulos/Surveys/components/RenderForm/RenderForm.tsx
+++ b/src/modulos/Surveys/components/RenderForm/RenderForm.tsx
@@ -64,7 +64,7 @@ const RenderForm = ({
         setIsLoadingDetails(true);
         try {
           const { data } = await execute(
-            "/surveys",
+            "/v3/surveys",
             "GET",
             {
               fullType: "DET",
@@ -170,7 +170,7 @@ const RenderForm = ({
 
       let method = formState.id ? "PUT" : "POST";
       const { data } = await execute(
-        "/surveys" + (formState.id ? "/" + formState.id : ""),
+        "/v3/surveys" + (formState.id ? "/" + formState.id : ""),
         method,
         {
           title: formState.title,

--- a/src/modulos/Surveys/components/RenderForm/SurveyTargeting.tsx
+++ b/src/modulos/Surveys/components/RenderForm/SurveyTargeting.tsx
@@ -100,7 +100,7 @@ export default function SurveyTargeting({
   const calculateAudience = async (criteria: any) => {
     try {
       const { data } = await execute(
-        "/surveys/calculate-audience",
+        "/v3/surveys/calculate-audience",
         "POST",
         { target_criteria: criteria },
         false,

--- a/src/modulos/Surveys/components/RenderView/RenderView.tsx
+++ b/src/modulos/Surveys/components/RenderView/RenderView.tsx
@@ -208,7 +208,7 @@ const RenderView = (props: {
     try {
       // Fetch Basic Details
       const detailRes = await execute(
-        "/surveys",
+        "/v3/surveys",
         "GET",
         { fullType: "DET", searchBy: id },
         false,
@@ -224,7 +224,7 @@ const RenderView = (props: {
 
       // Fetch Advanced Stats
       const statsRes = await execute(
-        "/surveys/results",
+        "/v3/surveys/results",
         "GET",
         { survey_id: id, ...filters },
         false,

--- a/src/modulos/Surveys/hooks/useMySurveys.ts
+++ b/src/modulos/Surveys/hooks/useMySurveys.ts
@@ -34,7 +34,7 @@ interface UseMySurveysReturn {
   reLoad: Function;
 }
 
-const modulePath = "/surveys";
+const modulePath = "/v3/surveys";
 
 export const useMySurveys = (): UseMySurveysReturn => {
   const [counts, setCounts] = useState<MySurveyCount | null>(null);
@@ -53,7 +53,7 @@ export const useMySurveys = (): UseMySurveysReturn => {
       setLoading(true);
       setError(null);
       const { data: response } = await execute(
-        "/surveys/my-counts",
+        "/v3/surveys/my-counts",
         "GET",
         {},
         false,


### PR DESCRIPTION
## S20.5 — sync URLs to `/v3/*` (Surveys + Balance modules)

Migrar URLs consumidas por `condaty-admin` del prefijo legacy (`/api/surveys`, `/api/balances`) al canónico pineado en el backend por S20 (`/v3/*` via baseURL).

### Cambios

8 archivos modificados, 11 líneas (sweep puro):
- `useAxios("/balances", ...)` → `useAxios("/v3/balances", ...)` (Balance.tsx)
- `useAxios("/surveys", ...)` → `useAxios("/v3/surveys", ...)` (Surveys/*)
- `execute("/surveys/results", ...)` → `execute("/v3/surveys/results", ...)`
- `execute("/surveys/calculate-audience", ...)` → `execute("/v3/surveys/calculate-audience", ...)`
- `execute("/surveys/my-counts", ...)` → `execute("/v3/surveys/my-counts", ...)`
- `execute("/surveys/answers", ...)` → `execute("/v3/surveys/answers", ...)`
- `execute(\`/surveys/${id}\`, ...)` → `execute(\`/v3/surveys/${id}\`, ...)`
- Test mock actualizado: `useMySurveys.test.ts`

### BC

Las rutas legacy `/api/surveys/*` y `/api/balances` siguen funcionando via main `routes/api.php` (alias S20). No hay riesgo de rotura en deploy.

### HALLAZGOs (binding, cross-project)

**HALLAZGO-NEW-35**: rnOwner consume `/api/qrDinamico` (sin guión) pero el backend v3 pineó `/api/v3/qr-dynamic/*` (con guión). Requiere refactor de path, no solo URL. Fuera de scope S20.5.

**HALLAZGO-NEW-34**: rnOwner consume endpoints `/financial-summary/resident*` que NO existen en el backend. Contrato TS aspiracional pre-existente. Sprint dedicado (S20+).

### Pendiente para S20.5+ (legacy URLs sin v3 pineado)

Estas URLs no tienen equivalente v3 (S20 no las pineó como canónicas), quedan legacy:
- `/api/login` (auth)
- `/api/cloudinary-upload` (storage)
- `/api/notif` (notifications)
- `/api/translate` (i18n)

### Validación

- `pnpm vitest --run src/modulos/Surveys/__tests__/useMySurveys.test.ts`: **4/4 verde** ✅
- `pnpm tsc --noEmit`: sin errores nuevos en archivos modificados (los errores pre-existentes en `reportPresets.test.ts` no son de mi scope)

### Cross-IA

- **Sprint cross-IA ahora full ownership Mavis** (Mario 2026-07-19): Claude Code no toca Condaty por ahora.
- **rnOwner / rnGuard**: no requieren cambios en este sprint. HALLAZGO-NEW-34 (FinancialSummary) y HALLAZGO-NEW-35 (QrDinamico path) son sprints dedicados.

### Out of scope

- **S20+ (HALLAZGO-NEW-34)**: implementar `/financial-summary/resident` y `/resident/arrears` con shape aspiracional de rnOwner
- **S20+ (HALLAZGO-NEW-35)**: refactor path `/api/qrDinamico` → `/api/v3/qr-dynamic/*` en rnOwner
- **S20.5+**: migrar `/api/login`, `/api/cloudinary-upload`, `/api/notif`, `/api/translate` cuando S20+ los pineé como v3
