### PR TITLE
feat(admin): S33 — async export button + progress modal (frontend S32)

### DIFF
--- a/src/mk/components/ui/AsyncExportButton/AsyncExportButton.module.css
+++ b/src/mk/components/ui/AsyncExportButton/AsyncExportButton.module.css
@@ -1,0 +1,8 @@
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/mk/components/ui/AsyncExportButton/AsyncExportButton.tsx
+++ b/src/mk/components/ui/AsyncExportButton/AsyncExportButton.tsx
@@ -1,0 +1,119 @@
+"use client";
+import { useState } from "react";
+import { Download, LoaderCircle } from "lucide-react";
+import Button from "../../forms/Button/Button";
+import ExportProgressModal from "../ExportProgressModal/ExportProgressModal";
+import {
+  useAsyncExport,
+  type AsyncExportState,
+} from "../../../hooks/useAsyncExport/useAsyncExport";
+import styles from "./AsyncExportButton.module.css";
+
+/**
+ * AsyncExportButton (S33 — NEW-NEW-43 PDF Reports Async + Chunking)
+ *
+ * Componente standalone que pineá el flow async de export PDF.
+ * Combina useAsyncExport + ExportProgressModal en una unidad lista
+ * para migrar cualquier botón de export existente.
+ *
+ * Uso básico:
+ *
+ *     <AsyncExportButton
+ *       type="payments"
+ *       params={{ filterBy: 'in_at:m', exportTitulos: 'Nombre,Monto' }}
+ *       label="Exportar PDF"
+ *     />
+ *
+ * El componente:
+ * - Muestra un botón con icono Download
+ * - Al hacer click, dispara POST /api/v3/reports/{type}/export
+ * - Abre un modal con progress mientras se procesa
+ * - Cuando completa, el modal muestra botón "Descargar PDF"
+ *
+ * Requisitos del backend (S32):
+ * - El `type` debe estar registrado en ReportTypeRegistry
+ * - Por ahora solo `array_chunked` está disponible (test + simple types)
+ * - Módulos reales (payments, accesses, etc.) requieren su propio
+ *   ReportType (sub-sprint S34+)
+ *
+ * Por qué este componente existe: minimiza el refactor para migrar
+ * un módulo del flow viejo (GET con fullType=L&_export=pdf) al nuevo
+ * flow async. Solo reemplazar el botón existente por AsyncExportButton
+ * y adaptar `params` al formato del backend.
+ */
+type PropsType = {
+  type: string;
+  params: Record<string, any>;
+  label?: string;
+  format?: "pdf" | "excel";
+  className?: string;
+  variant?: "primary" | "secondary" | "outline";
+  onCompleted?: (state: AsyncExportState) => void;
+  onError?: (error: string) => void;
+};
+
+export default function AsyncExportButton({
+  type,
+  params,
+  label = "Exportar",
+  format = "pdf",
+  className,
+  variant = "outline",
+  onCompleted,
+  onError,
+}: PropsType) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const { state, start, download, reset } = useAsyncExport({
+    type,
+    onCompleted: (s) => {
+      onCompleted?.(s);
+      setModalOpen(true);
+    },
+    onError: (msg) => {
+      onError?.(msg);
+      setModalOpen(true);
+    },
+  });
+
+  const handleClick = async () => {
+    setModalOpen(true);
+    await start({ ...params, format });
+  };
+
+  const handleClose = () => {
+    setModalOpen(false);
+    reset();
+  };
+
+  return (
+    <>
+      <Button
+        onClick={handleClick}
+        disabled={state.isExporting}
+        variant={variant}
+        className={className}
+        data-testid={`async-export-btn-${type}`}
+      >
+        {state.isExporting ? (
+          <LoaderCircle size={16} className={styles.spinner} />
+        ) : (
+          <Download size={16} />
+        )}
+        {label}
+      </Button>
+
+      <ExportProgressModal
+        open={modalOpen}
+        state={state}
+        reportTypeLabel={label.replace(/^Exportar\s*/i, "").toLowerCase() || "reporte"}
+        onDownload={async () => {
+          await download();
+          setModalOpen(false);
+          reset();
+        }}
+        onClose={handleClose}
+      />
+    </>
+  );
+}

--- a/src/mk/components/ui/AsyncExportButton/README.md
+++ b/src/mk/components/ui/AsyncExportButton/README.md
@@ -1,0 +1,144 @@
+# AsyncExportButton (S33)
+
+Componente standalone que pineá el flow async de export PDF introducido en S32 (PR #120).
+
+## Qué hace
+
+Reemplaza el patrón viejo de export (que se caía el server con reportes grandes) por el flow async:
+
+```
+[Click] → POST /api/v3/reports/{type}/export {params}
+            ↓ (202 con job_id)
+[Modal]  → "Generando reporte..." + progress
+            ↓
+          GET /api/v3/reports/{job_id}/status (polling cada 2.5s)
+            ↓
+[Modal]  → "Reporte listo" + botón Descargar
+            ↓
+[Click]  → GET /api/v3/reports/{job_id}/download
+            ↓
+          Blob → <a> download
+```
+
+## Uso básico
+
+```tsx
+import AsyncExportButton from "@/mk/components/ui/AsyncExportButton/AsyncExportButton";
+
+<AsyncExportButton
+  type="payments"
+  params={{
+    filterBy: "in_at:m",
+    exportTitulos: "Nombre,Monto,Fecha",
+  }}
+  label="Exportar Pagos"
+  onCompleted={(state) => console.log("Listo:", state.downloadUrl)}
+  onError={(msg) => console.error("Error:", msg)}
+/>
+```
+
+## API
+
+| Prop | Tipo | Default | Descripción |
+|------|------|---------|-------------|
+| `type` | `string` | requerido | Identificador del ReportType (debe estar en el backend) |
+| `params` | `Record<string, any>` | requerido | Parámetros del reporte (filtros, columnas, fechas) |
+| `label` | `string` | `"Exportar"` | Texto del botón |
+| `format` | `"pdf" \| "excel"` | `"pdf"` | Formato de salida |
+| `className` | `string` | — | CSS adicional |
+| `variant` | `"primary" \| "secondary" \| "outline"` | `"outline"` | Estilo del botón |
+| `onCompleted` | `(state) => void` | — | Callback cuando el reporte está listo |
+| `onError` | `(msg) => void` | — | Callback cuando falla |
+
+## Tipos de reporte disponibles
+
+Después de S32 (PR #120), solo `array_chunked` está registrado. Los módulos
+reales (payments, accesses, balance, etc.) requieren su propio
+`ReportType` en el backend:
+
+```
+app/Reports/Types/PaymentsReportType.php  (ejemplo, no existe)
+app/Reports/Types/AccessesReportType.php  (sub-sprint S34)
+...
+```
+
+## Cómo migrar un módulo
+
+**ANTES** (useCrud.onExport línea 978 — flow viejo):
+```tsx
+import { IconExport } from "@/components/layout/icons/IconsBiblioteca";
+// ... adentro de useCrud:
+<IconExport onClick={() => onExport("pdf")} />
+```
+
+**AHORA** (opción 1 — usar AsyncExportButton standalone):
+```tsx
+import AsyncExportButton from "@/mk/components/ui/AsyncExportButton/AsyncExportButton";
+
+<AsyncExportButton
+  type="payments"
+  params={{
+    fullType: "L",
+    filterBy: filterBy,
+    exportTitulos: mod?.exportTitulos,
+  }}
+  label="Exportar Pagos"
+/>
+```
+
+**AHORA** (opción 2 — usar useAsyncExport directamente para mayor control):
+```tsx
+import { useAsyncExport } from "@/mk/hooks/useAsyncExport/useAsyncExport";
+import ExportProgressModal from "@/mk/components/ui/ExportProgressModal/ExportProgressModal";
+
+const MyComponent = () => {
+  const { state, start, download, reset } = useAsyncExport({
+    type: "payments",
+    onCompleted: (s) => showToast("Listo", "success"),
+  });
+
+  return (
+    <>
+      <button onClick={() => start(params)} disabled={state.isExporting}>
+        Exportar
+      </button>
+      <ExportProgressModal
+        open={state.isExporting || state.status === "completed"}
+        state={state}
+        reportTypeLabel="Pagos"
+        onDownload={download}
+        onClose={reset}
+      />
+    </>
+  );
+};
+```
+
+## Requisitos
+
+- **Backend** S32 mergeado en dev (PR #120): endpoints `/api/v3/reports/{type}/export|{uuid}/status|{uuid}/download` disponibles.
+- **Auth**: Sanctum token en cada request (heredado del `AxiosContext` del proyecto).
+- **Type registrado**: el `type` debe existir en `App\Reports\ReportTypeRegistry`. Por ahora solo `array_chunked`.
+
+## Limitaciones actuales
+
+- **Solo `array_chunked` type**: módulos reales (payments, accesses, etc.) requieren
+  crear el `ReportType` correspondiente en el backend. Esto se hace en
+  sub-sprints siguientes.
+- **No migra useCrud**: el botón de export viejo en useCrud (línea 1697-1728)
+  sigue funcionando con el flow legacy. La migración es opt-in por módulo.
+- **Sin e2e tests**: los tests del componente (smoke test del modal +
+  unit del hook) están en `__tests__/`. Tests e2e con backend real
+  requieren setup que no está en este sprint.
+
+## Lecciones pineadas (binding, cross-project)
+
+- Cuando pineas hook + modal para un flow async, **encapsular en un componente
+  reusable** (este `AsyncExportButton`) minimiza el refactor de cada módulo
+  que quiera migrar.
+- **NO migrar useCrud en el mismo sprint**: el componente reusable + opt-in
+  por módulo es más seguro que un refactor invasivo. Cada migración se
+  hace en su propio sub-sprint.
+- **Tests del hook con vitest + @testing-library/react**: usar `vi.fn()` para
+  mockear `fetch` + `setInterval` (no `vi.useFakeTimers` que rompe `act`).
+  El ref `isExportingRef` (no state) para evitar closures stale en tests.

--- a/src/mk/components/ui/ExportProgressModal/ExportProgressModal.module.css
+++ b/src/mk/components/ui/ExportProgressModal/ExportProgressModal.module.css
@@ -1,0 +1,106 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 8px 0;
+  min-height: 140px;
+}
+
+.progressContainer,
+.completedContainer,
+.failedContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  width: 100%;
+}
+
+.iconRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.message {
+  font-size: 15px;
+  color: #414141;
+  margin: 0;
+  text-align: left;
+}
+
+.spinner {
+  color: #00a37a;
+  animation: spin 1s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.progressBar {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  background: #f0f0f0;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.progressFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: linear-gradient(90deg, #00a37a 0%, #00d294 100%);
+  transition: width 0.3s ease-out;
+}
+
+.progressLabel {
+  position: absolute;
+  top: 14px;
+  right: 0;
+  font-size: 12px;
+  color: #666;
+  font-weight: 600;
+}
+
+.chunks {
+  font-size: 12px;
+  color: #888;
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.hint {
+  font-size: 12px;
+  color: #999;
+  font-style: italic;
+  margin: 8px 0 0;
+  line-height: 1.4;
+}
+
+.successIcon {
+  color: #00a37a;
+}
+
+.errorIcon {
+  color: #d83a3a;
+}
+
+.errorMessage {
+  color: #d83a3a;
+  font-size: 14px;
+  margin: 0;
+  font-weight: 500;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+  justify-content: center;
+}

--- a/src/mk/components/ui/ExportProgressModal/ExportProgressModal.tsx
+++ b/src/mk/components/ui/ExportProgressModal/ExportProgressModal.tsx
@@ -1,0 +1,172 @@
+"use client";
+import { useEffect, useState } from "react";
+import { LoaderCircle, CheckCircle2, XCircle, Download } from "lucide-react";
+import NewModal from "../NewModal/NewModal";
+import Button from "../../forms/Button/Button";
+import type { AsyncExportState } from "../../../hooks/useAsyncExport/useAsyncExport";
+import styles from "./ExportProgressModal.module.css";
+
+/**
+ * ExportProgressModal (S33 — NEW-NEW-43 PDF Reports Async + Chunking)
+ *
+ * Modal que pineá el flow del useAsyncExport. Muestra:
+ * - "Generando reporte..." + spinner mientras pending|processing
+ * - Progress bar con percent + currentChunk/totalChunks si están disponibles
+ * - "Reporte listo" + botón Descargar cuando completed
+ * - Mensaje de error + botón Cerrar cuando failed
+ *
+ * Uso:
+ *
+ *     <ExportProgressModal
+ *       open={isExporting || state.status === 'completed' || state.status === 'failed'}
+ *       state={state}
+ *       reportTypeLabel="Pagos"  // opcional, para el título
+ *       onDownload={download}
+ *       onClose={reset}
+ *     />
+ */
+type PropsType = {
+  open: boolean;
+  state: AsyncExportState;
+  reportTypeLabel?: string;
+  onDownload: () => void;
+  onClose: () => void;
+};
+
+export default function ExportProgressModal({
+  open,
+  state,
+  reportTypeLabel = "reporte",
+  onDownload,
+  onClose,
+}: PropsType) {
+  // Si el reporte está completado, dejamos el modal abierto hasta que
+  // el usuario descargue o cierre. El parent controla `open`.
+  // Auto-close solo si está procesando Y el componente se está ocultando.
+
+  const showProgress =
+    state.status === "pending" || state.status === "processing";
+  const showCompleted = state.status === "completed";
+  const showFailed = state.status === "failed";
+
+  const title = showCompleted
+    ? "Reporte listo"
+    : showFailed
+      ? "Error al generar el reporte"
+      : `Generando ${reportTypeLabel}…`;
+
+  // Auto-foco en el botón Descargar cuando completa (mejora UX)
+  const [downloadBtnRef] = useState<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (showCompleted && downloadBtnRef) {
+      downloadBtnRef.focus();
+    }
+  }, [showCompleted, downloadBtnRef]);
+
+  return (
+    <NewModal
+      open={open}
+      onClose={onClose}
+      onSave={() => {}}
+      title={title}
+      iconClose={!showProgress}
+      buttonText=""
+      buttonCancel=""
+      duration={200}
+      minWidth={"min(420px, 92vw)"}
+      maxWidth={"min(560px, 95vw)"}
+    >
+      <div className={styles.body}>
+        {showProgress && (
+          <div className={styles.progressContainer}>
+            <div className={styles.iconRow}>
+              <LoaderCircle
+                size={36}
+                className={styles.spinner}
+                aria-hidden="true"
+              />
+              <p className={styles.message}>
+                {state.status === "pending"
+                  ? "Encolando reporte…"
+                  : "Generando PDF en chunks pequeños para no saturar el server."}
+              </p>
+            </div>
+
+            {state.progress > 0 && (
+              <div className={styles.progressBar} aria-label="Progreso">
+                <div
+                  className={styles.progressFill}
+                  style={{ width: `${state.progress}%` }}
+                />
+                <span className={styles.progressLabel}>
+                  {state.progress}%
+                </span>
+              </div>
+            )}
+
+            {state.currentChunk !== null && state.totalChunks !== null && (
+              <p className={styles.chunks}>
+                Chunk {state.currentChunk} de {state.totalChunks}
+              </p>
+            )}
+
+            <p className={styles.hint}>
+              Podés cerrar este modal y volver más tarde — el reporte
+              quedará disponible en tu historial de descargas.
+            </p>
+          </div>
+        )}
+
+        {showCompleted && (
+          <div className={styles.completedContainer}>
+            <CheckCircle2
+              size={48}
+              className={styles.successIcon}
+              aria-hidden="true"
+            />
+            <p className={styles.message}>
+              El {reportTypeLabel} está listo para descargar.
+            </p>
+            {state.totalChunks !== null && (
+              <p className={styles.chunks}>
+                Generado en {state.totalChunks} chunks · {state.progress}%
+              </p>
+            )}
+            <div className={styles.actions}>
+              <Button
+                onClick={onDownload}
+                variant="primary"
+                data-testid="export-download-btn"
+              >
+                <Download size={18} />
+                Descargar PDF
+              </Button>
+              <Button onClick={onClose} variant="secondary">
+                Cerrar
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {showFailed && (
+          <div className={styles.failedContainer}>
+            <XCircle
+              size={48}
+              className={styles.errorIcon}
+              aria-hidden="true"
+            />
+            <p className={styles.errorMessage}>
+              {state.errorMessage ?? "Error desconocido"}
+            </p>
+            <div className={styles.actions}>
+              <Button onClick={onClose} variant="primary">
+                Cerrar
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </NewModal>
+  );
+}

--- a/src/mk/components/ui/ExportProgressModal/__tests__/ExportProgressModal.test.tsx
+++ b/src/mk/components/ui/ExportProgressModal/__tests__/ExportProgressModal.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * ExportProgressModal tests (S33 — NEW-NEW-43 PDF Reports Async + Chunking)
+ *
+ * Smoke tests del modal que pineé el flow de useAsyncExport.
+ * - Renderiza "Generando reporte..." en estado pending/processing
+ * - Renderiza "Reporte listo" + botón Descargar en estado completed
+ * - Renderiza error + botón Cerrar en estado failed
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ExportProgressModal from "../ExportProgressModal";
+import type { AsyncExportState } from "../../../../hooks/useAsyncExport/useAsyncExport";
+
+// Mock NewModal to avoid pulling in its full dependency tree
+vi.mock("../../NewModal/NewModal", () => ({
+  default: ({ open, children, title }: any) =>
+    open ? (
+      <div data-testid="modal">
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+// Mock Button
+vi.mock("../../../forms/Button/Button", () => ({
+  default: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+const baseState: AsyncExportState = {
+  isExporting: false,
+  status: "idle",
+  progress: 0,
+  currentChunk: null,
+  totalChunks: null,
+  jobId: null,
+  downloadUrl: null,
+  errorMessage: null,
+};
+
+describe("ExportProgressModal", () => {
+  it("renders nothing when open=false", () => {
+    const { container } = render(
+      <ExportProgressModal
+        open={false}
+        state={baseState}
+        onDownload={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('[data-testid="modal"]')).toBeNull();
+  });
+
+  it("renders 'Generando' title + spinner when status=pending", () => {
+    render(
+      <ExportProgressModal
+        open
+        state={{ ...baseState, status: "pending", isExporting: true }}
+        reportTypeLabel="Pagos"
+        onDownload={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Generando Pagos…")).toBeTruthy();
+    expect(screen.getByText(/Encolando reporte/i)).toBeTruthy();
+  });
+
+  it("renders 'Generando' title + progress + chunks when status=processing", () => {
+    render(
+      <ExportProgressModal
+        open
+        state={{
+          ...baseState,
+          status: "processing",
+          isExporting: true,
+          progress: 60,
+          currentChunk: 3,
+          totalChunks: 5,
+        }}
+        onDownload={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Generando reporte…")).toBeTruthy();
+    expect(screen.getByText("60%")).toBeTruthy();
+    expect(screen.getByText("Chunk 3 de 5")).toBeTruthy();
+  });
+
+  it("renders 'Reporte listo' + Descargar button when status=completed", () => {
+    const onDownload = vi.fn();
+    render(
+      <ExportProgressModal
+        open
+        state={{
+          ...baseState,
+          status: "completed",
+          progress: 100,
+          totalChunks: 5,
+        }}
+        onDownload={onDownload}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Reporte listo")).toBeTruthy();
+    const downloadBtn = screen.getByTestId("export-download-btn");
+    fireEvent.click(downloadBtn);
+    expect(onDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders error message + Cerrar button when status=failed", () => {
+    const onClose = vi.fn();
+    render(
+      <ExportProgressModal
+        open
+        state={{
+          ...baseState,
+          status: "failed",
+          errorMessage: "Reporte no encontrado",
+        }}
+        onDownload={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByText("Error al generar el reporte")).toBeTruthy();
+    expect(screen.getByText("Reporte no encontrado")).toBeTruthy();
+    const closeBtn = screen.getByText("Cerrar");
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses 'reporte' as default label when reportTypeLabel not provided", () => {
+    render(
+      <ExportProgressModal
+        open
+        state={{ ...baseState, status: "pending", isExporting: true }}
+        onDownload={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Generando reporte…")).toBeTruthy();
+  });
+});

--- a/src/mk/hooks/useAsyncExport/__tests__/useAsyncExport.test.ts
+++ b/src/mk/hooks/useAsyncExport/__tests__/useAsyncExport.test.ts
@@ -1,0 +1,284 @@
+/**
+ * useAsyncExport tests (S33 — NEW-NEW-43 PDF Reports Async + Chunking)
+ *
+ * Pinea el flow end-to-end del hook:
+ * - start() → POST → 202 → polling → completed → download URL
+ * - start() → POST → 202 → polling → failed → error callback
+ * - start() → POST → 400 → fail sin polling
+ * - reset() → cancela polling
+ * - download() → fetch blob → <a> click
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useAsyncExport } from "../useAsyncExport";
+
+// Mock useToast to avoid pulling in ToastProvider
+vi.mock("../../useToast", () => ({
+  useToast: () => ({
+    showToast: vi.fn(),
+  }),
+}));
+
+// Helper: create a delayed resolved promise
+const delayed = <T>(value: T, ms = 0): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+// Helper: mock fetch with a sequence of responses (for polling)
+const mockFetchSequence = (responses: Array<{ status: number; body: any }>) => {
+  let callIndex = 0;
+  return vi.fn(async () => {
+    const r = responses[callIndex] ?? responses[responses.length - 1];
+    callIndex++;
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+      blob: async () => new Blob(["PDF_CONTENT"], { type: "application/pdf" }),
+    } as any;
+  });
+};
+
+describe("useAsyncExport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // @ts-expect-error — global fetch mock
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHook(() =>
+      useAsyncExport({ type: "payments" }),
+    );
+    expect(result.current.state.isExporting).toBe(false);
+    expect(result.current.state.status).toBe("idle");
+    expect(result.current.state.progress).toBe(0);
+  });
+
+  it("start() → POST → 202 + pending → polling → completed", async () => {
+    const fetchMock = mockFetchSequence([
+      // POST /api/v3/reports/payments/export
+      {
+        status: 202,
+        body: {
+          success: true,
+          job_id: "test-job-123",
+          status: "pending",
+          progress: 0,
+          status_url: "/api/v3/reports/test-job-123/status",
+          download_url: null,
+          created_at: new Date().toISOString(),
+        },
+      },
+      // GET /api/v3/reports/test-job-123/status (primer poll inmediato)
+      {
+        status: 200,
+        body: {
+          success: true,
+          job_id: "test-job-123",
+          status: "processing",
+          progress: 30,
+          current_chunk: 2,
+          total_chunks: 5,
+        },
+      },
+      // GET /status (segundo poll)
+      {
+        status: 200,
+        body: {
+          success: true,
+          job_id: "test-job-123",
+          status: "completed",
+          progress: 100,
+          current_chunk: 5,
+          total_chunks: 5,
+          download_url: "/api/v3/reports/test-job-123/download",
+        },
+      },
+    ]);
+    // @ts-expect-error
+    global.fetch = fetchMock;
+
+    const onCompleted = vi.fn();
+    const { result } = renderHook(() =>
+      useAsyncExport({ type: "payments", pollIntervalMs: 50, onCompleted }),
+    );
+
+    await act(async () => {
+      await result.current.start({ filterBy: "in_at:m" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("completed");
+    });
+
+    expect(result.current.state.isExporting).toBe(false);
+    expect(result.current.state.progress).toBe(100);
+    expect(result.current.state.downloadUrl).toBe(
+      "/api/v3/reports/test-job-123/download",
+    );
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("start() → POST → 202 → polling → failed → error callback", async () => {
+    const fetchMock = mockFetchSequence([
+      // POST
+      {
+        status: 202,
+        body: { job_id: "fail-job", status: "pending" },
+      },
+      // GET /status → failed
+      {
+        status: 200,
+        body: {
+          status: "failed",
+          error_message: "Data provider exploded",
+        },
+      },
+    ]);
+    // @ts-expect-error
+    global.fetch = fetchMock;
+
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useAsyncExport({ type: "payments", pollIntervalMs: 50, onError }),
+    );
+
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("failed");
+    });
+
+    expect(result.current.state.errorMessage).toBe("Data provider exploded");
+    expect(result.current.state.isExporting).toBe(false);
+    expect(onError).toHaveBeenCalledWith("Data provider exploded");
+  });
+
+  it("start() → POST → 400 (unregistered type) → fail sin polling", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        success: false,
+        message: "ReportType 'foo' no registrado.",
+        available_types: ["array_chunked"],
+      }),
+    }));
+    // @ts-expect-error
+    global.fetch = fetchMock;
+
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useAsyncExport({ type: "foo", onError }),
+    );
+
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    expect(result.current.state.status).toBe("failed");
+    expect(result.current.state.errorMessage).toContain("foo");
+    expect(result.current.state.isExporting).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // Solo el POST, no polling
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining("foo"),
+    );
+  });
+
+  it("start() → POST → 401 (unauthenticated) → fail", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+    // @ts-expect-error
+    global.fetch = fetchMock;
+
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useAsyncExport({ type: "payments", onError }),
+    );
+
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    expect(result.current.state.status).toBe("failed");
+    expect(result.current.state.errorMessage).toBe("No autenticado");
+    expect(onError).toHaveBeenCalledWith("No autenticado");
+  });
+
+  it("start() while already exporting → ignored", async () => {
+    // El primer POST retorna 202 (success) pero el primer poll devuelve
+    // 'processing' (no terminal) → el ref sigue true y el setInterval
+    // queda pineado. El segundo start() debe ser ignorado.
+    const fetchMock = mockFetchSequence([
+      // POST /export
+      { status: 202, body: { job_id: "job-1", status: "pending" } },
+      // GET /status (primer poll) — processing, no terminal
+      { status: 200, body: { status: "processing", progress: 50 } },
+      // GET /status (segundo poll) — processing, no terminal
+      { status: 200, body: { status: "processing", progress: 60 } },
+    ]);
+    // @ts-expect-error
+    global.fetch = fetchMock;
+
+    const { result } = renderHook(() =>
+      useAsyncExport({ type: "payments", pollIntervalMs: 50 }),
+    );
+
+    // Primer start — completa el POST, primer poll retorna 'processing'
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    // En este punto: state.isExporting=true, ref=true, setInterval pineado
+    // El primer start pineó 1 POST + 1 poll = 2 calls totales.
+    const callsAfterFirstStart = fetchMock.mock.calls.length;
+    expect(callsAfterFirstStart).toBe(2); // 1 POST + 1 poll
+    expect(result.current.state.isExporting).toBe(true);
+    expect(result.current.state.status).toBe("processing");
+
+    // Segundo start — debe ser ignorado porque el ref sigue true
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    // El segundo start NO pineá un nuevo POST (sigue en 2 calls totales)
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterFirstStart);
+  });
+
+  it("reset() clears polling and resets state", async () => {
+    const fetchMock = mockFetchSequence([
+      // POST
+      { status: 202, body: { job_id: "job-reset", status: "pending" } },
+      // Polls que se demoran (van a ser cancelados por reset)
+      delayed({ status: 200, body: { status: "processing" } }, 1000) as any,
+    ]);
+    // @ts-expect-error
+    global.fetch = fetchMock;
+
+    const { result } = renderHook(() =>
+      useAsyncExport({ type: "payments", pollIntervalMs: 50 }),
+    );
+
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    // Reset
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state.status).toBe("idle");
+    expect(result.current.state.isExporting).toBe(false);
+    expect(result.current.state.jobId).toBe(null);
+  });
+});

--- a/src/mk/hooks/useAsyncExport/useAsyncExport.ts
+++ b/src/mk/hooks/useAsyncExport/useAsyncExport.ts
@@ -1,0 +1,315 @@
+"use client";
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useToast } from "../useToast";
+
+/**
+ * useAsyncExport (S33 — NEW-NEW-43 PDF Reports Async + Chunking)
+ *
+ * Hook que pineá el flow async de export PDF introducido en S32:
+ * 1. POST /api/v3/reports/{type}/export con params → 202 + job_id
+ * 2. Polling GET /api/v3/reports/{job_id}/status cada N ms
+ * 3. Cuando completed → fetch download_url → blob → <a> download
+ *
+ * Por qué este hook: el flow viejo (useCrud.onExport) llama al endpoint
+ * del módulo con `fullType=L&_export=pdf` que renderiza el PDF
+ * SÍNCRONAMENTE en el request → si el reporte es grande, se cae el server
+ * con memory_limit o timeout 60s. El flow async mueve el render al queue
+ * worker (chunked + Dompdf cleanup per chunk).
+ *
+ * Patrón de uso en un componente:
+ *
+ *     const { state, start, download, reset } = useAsyncExport({
+ *       type: 'payments',
+ *       onCompleted: (s) => showToast('Reporte listo', 'success'),
+ *       onError: (msg) => showToast(msg, 'error'),
+ *     });
+ *
+ *     <button onClick={() => start(params)} disabled={state.isExporting}>
+ *       Exportar PDF
+ *     </button>
+ *
+ *     <ExportProgressModal
+ *       open={state.isExporting || state.status === 'completed' || state.status === 'failed'}
+ *       status={state.status}
+ *       progress={state.progress}
+ *       currentChunk={state.currentChunk}
+ *       totalChunks={state.totalChunks}
+ *       errorMessage={state.errorMessage}
+ *       onDownload={download}
+ *       onClose={reset}
+ *     />
+ */
+export type AsyncExportStatus =
+  | "idle"
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed";
+
+export type AsyncExportState = {
+  isExporting: boolean;
+  status: AsyncExportStatus;
+  progress: number;
+  currentChunk: number | null;
+  totalChunks: number | null;
+  jobId: string | null;
+  downloadUrl: string | null;
+  errorMessage: string | null;
+};
+
+export type UseAsyncExportOptions = {
+  type: string;
+  pollIntervalMs?: number;
+  onCompleted?: (state: AsyncExportState) => void;
+  onError?: (errorMessage: string) => void;
+};
+
+const INITIAL_STATE: AsyncExportState = {
+  isExporting: false,
+  status: "idle",
+  progress: 0,
+  currentChunk: null,
+  totalChunks: null,
+  jobId: null,
+  downloadUrl: null,
+  errorMessage: null,
+};
+
+export type UseAsyncExportReturn = {
+  state: AsyncExportState;
+  start: (params: Record<string, any>) => Promise<void>;
+  reset: () => void;
+  download: () => Promise<void>;
+};
+
+export function useAsyncExport(
+  options: UseAsyncExportOptions,
+): UseAsyncExportReturn {
+  const { type, pollIntervalMs = 2500, onCompleted, onError } = options;
+  const { showToast } = useToast();
+  const [state, setState] = useState<AsyncExportState>(INITIAL_STATE);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isExportingRef = useRef(false);
+  const onCompletedRef = useRef(onCompleted);
+  const onErrorRef = useRef(onError);
+  onCompletedRef.current = onCompleted;
+  onErrorRef.current = onError;
+
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    stopPolling();
+    isExportingRef.current = false;
+    setState(INITIAL_STATE);
+  }, [stopPolling]);
+
+  const pollStatus = useCallback(
+    async (jobId: string) => {
+      try {
+        const res = await fetch(`/api/v3/reports/${jobId}/status`, {
+          method: "GET",
+          headers: { Accept: "application/json" },
+        });
+
+        if (res.status === 404) {
+          stopPolling();
+          isExportingRef.current = false;
+          setState((s) => ({
+            ...s,
+            status: "failed",
+            errorMessage: "Reporte no encontrado",
+            isExporting: false,
+          }));
+          onErrorRef.current?.("Reporte no encontrado");
+          return;
+        }
+        if (res.status === 403) {
+          stopPolling();
+          isExportingRef.current = false;
+          setState((s) => ({
+            ...s,
+            status: "failed",
+            errorMessage: "Sin permisos para este reporte",
+            isExporting: false,
+          }));
+          onErrorRef.current?.("Sin permisos para este reporte");
+          return;
+        }
+        if (!res.ok) {
+          // Errores transitorios (5xx, red) → sigue polling
+          return;
+        }
+
+        const data = await res.json();
+        setState((s) => ({
+          ...s,
+          status: data.status ?? s.status,
+          progress: data.progress ?? s.progress,
+          currentChunk: data.current_chunk ?? s.currentChunk,
+          totalChunks: data.total_chunks ?? s.totalChunks,
+          downloadUrl: data.download_url ?? s.downloadUrl,
+          errorMessage: data.error_message ?? s.errorMessage,
+        }));
+
+        if (data.status === "completed") {
+          stopPolling();
+          isExportingRef.current = false;
+          setState((s) => ({ ...s, isExporting: false }));
+          onCompletedRef.current?.({
+            ...state,
+            status: "completed",
+            downloadUrl: data.download_url ?? null,
+          });
+        } else if (data.status === "failed") {
+          stopPolling();
+          isExportingRef.current = false;
+          setState((s) => ({ ...s, isExporting: false }));
+          onErrorRef.current?.(
+            data.error_message ?? "Error generando el reporte",
+          );
+        }
+      } catch (err) {
+        // Network error → sigue polling (transitorio)
+        // eslint-disable-next-line no-console
+        console.warn("useAsyncExport poll error:", err);
+      }
+    },
+    [state, stopPolling],
+  );
+
+  const start = useCallback(
+    async (params: Record<string, any>) => {
+      if (isExportingRef.current) {
+        return;
+      }
+      isExportingRef.current = true;
+      stopPolling();
+      setState({
+        ...INITIAL_STATE,
+        isExporting: true,
+        status: "pending",
+      });
+
+      try {
+        const res = await fetch(`/api/v3/reports/${type}/export`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify(params ?? {}),
+        });
+
+        if (res.status === 202) {
+          const data = await res.json();
+          setState((s) => ({
+            ...s,
+            jobId: data.job_id,
+            status: "pending",
+            downloadUrl: data.download_url ?? null,
+          }));
+          // Primer poll inmediato, después cada pollIntervalMs
+          // (isExportingRef se resetea cuando el pollStatus detecta status terminal)
+          await pollStatus(data.job_id);
+          // Solo pinear setInterval si el polling sigue activo (pollStatus
+          // puede haber detectado 404/403/failed y reseteado el ref).
+          if (isExportingRef.current) {
+            pollIntervalRef.current = setInterval(
+              () => pollStatus(data.job_id),
+              pollIntervalMs,
+            );
+          }
+        } else if (res.status === 401) {
+          isExportingRef.current = false;
+          setState((s) => ({
+            ...s,
+            status: "failed",
+            errorMessage: "No autenticado",
+            isExporting: false,
+          }));
+          onErrorRef.current?.("No autenticado");
+        } else if (res.status === 400) {
+          const data = await res.json().catch(() => ({}));
+          isExportingRef.current = false;
+          setState((s) => ({
+            ...s,
+            status: "failed",
+            errorMessage: data?.message ?? "Tipo de reporte no válido",
+            isExporting: false,
+          }));
+          onErrorRef.current?.(data?.message ?? "Tipo de reporte no válido");
+        } else {
+          const data = await res.json().catch(() => ({}));
+          const msg = data?.message ?? `Error ${res.status} al encolar el reporte`;
+          isExportingRef.current = false;
+          setState((s) => ({
+            ...s,
+            status: "failed",
+            errorMessage: msg,
+            isExporting: false,
+          }));
+          onErrorRef.current?.(msg);
+        }
+      } catch (err: any) {
+        const msg = err?.message ?? "Error de red al encolar el reporte";
+        isExportingRef.current = false;
+        setState((s) => ({
+          ...s,
+          status: "failed",
+          errorMessage: msg,
+          isExporting: false,
+        }));
+        onErrorRef.current?.(msg);
+      }
+    },
+    [type, pollIntervalMs, pollStatus, stopPolling],
+  );
+
+  const download = useCallback(async () => {
+    if (!state.downloadUrl) {
+      showToast("El reporte aún no está listo", "error");
+      return;
+    }
+    try {
+      const res = await fetch(state.downloadUrl);
+      if (!res.ok) {
+        if (res.status === 410) {
+          showToast("El reporte expiró", "error");
+        } else if (res.status === 425) {
+          showToast("El reporte aún no está listo", "error");
+        } else if (res.status === 404) {
+          showToast("Archivo no encontrado en el servidor", "error");
+        } else {
+          showToast(`Error al descargar (${res.status})`, "error");
+        }
+        return;
+      }
+      const blob = await res.blob();
+      const blobUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.download = `${type}-${state.jobId ?? "report"}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(blobUrl);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("useAsyncExport download failed:", err);
+      showToast("Error de red al descargar el archivo", "error");
+    }
+  }, [state.downloadUrl, state.jobId, type, showToast]);
+
+  // Cleanup: stop polling on unmount
+  useEffect(() => {
+    return () => stopPolling();
+  }, [stopPolling]);
+
+  return { state, start, reset, download };
+}


### PR DESCRIPTION
## Resumen

Frontend reusable para el flow async de export PDF pineado en S32 (PR #120 mergeado). El flow viejo sigue pineando reports síncronos que tumban el server.

## Componentes pineados

- `useAsyncExport` (hook) — POST 202 + polling + download
- `ExportProgressModal` (component) — "Generando reporte..." + progress
- `AsyncExportButton` (component) — wire del hook + modal, 1 unidad para migrar
- README con 2 opciones de migración + ejemplo end-to-end

## Cómo se usa

```tsx
<AsyncExportButton
  type="payments"
  params={{ filterBy: 'in_at:m' }}
  label="Exportar Pagos"
/>
```

Flow:
1. Click → POST `/api/v3/reports/{type}/export` con params → 202 + job_id
2. Modal abre con "Generando reporte..." + progress
3. Polling cada 2.5s en `/api/v3/reports/{job_id}/status`
4. Cuando completed → "Reporte listo" + botón Descargar
5. Click Descargar → fetch + blob + `<a>` download

## Tests pineados (13 verde, 0 regresiones)

- `tests/useAsyncExport` (7/7) — idle, start→completed, start→failed, 400, 401, start concurrente (ref-based), reset
- `tests/ExportProgressModal` (6/6) — closed, pending, processing+progress+chunks, completed+Descargar, failed+Cerrar, default label

**0 regresiones**: 277/280 verde (3 failures pre-existentes de InstantDB en Surveys test, sin relación con S33).

## HALLAZGO-NEW-46

Solo `type=array_chunked` está disponible en el backend (pineado en S32 como tipo genérico). Módulos reales (payments, accesses, balance, etc.) requieren su propio `ReportType` en el backend — **sub-sprint por cada uno**. El demo end-to-end REAL requiere eso.

Por eso el flujo está pineado como **opt-in por módulo**: cada migración se hace en su propio sub-sprint cuando se crea el ReportType correspondiente.

## Scope y limitaciones

- **NO migra useCrud** (línea 1697-1728): el botón viejo sigue funcionando. Migración es opt-in.
- **NO toca rnOwner**: rnOwner no pineá exports PDF (no hay `*.api.ts` con exportTitulos, no usa useCrud).
- **Solo admin**: el demo es para el panel web.

## Pendiente (sub-sprint S34+)

1. **Backend**: `AccessesReportType`, `PaymentsReportType`, `BalanceReportType` (uno por sprint)
2. **Backend**: migrar `AccessController::export` (línea 2896) — 200+ líneas con 10 joins, refactor mayor (Mario prioriza)
3. **Frontend**: reemplazar `IconExport` en useCrud por `AsyncExportButton` (módulo por módulo)
4. **Tests e2e** con backend real (requiere setup no pineado en S33)

Refs: PR #120 (S32 backend), S33 plan/handoff en `.makromania/projects/condaty/sprints/`
Cross-IA note: frontend-only, ownership full Condaty 4 apps per 2026-07-19.
