### PR TITLE
S36.5 — AccessTab async export migration (frontend S36)

### DIFF
--- a/src/mk/hooks/useCrud/__tests__/useCrud.exportAsync.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrud.exportAsync.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * useCrud exportAsync tests (S36.5 — NEW-NEW-43 frontend migration)
+ *
+ * Pinea coverage para el slot `mod.exportAsync` introducido en S36.5:
+ * cuando un módulo pineá `mod.exportAsync`, el `<List />` renderea
+ * `<AsyncExportButton>` en lugar del `IconExport` legacy.
+ *
+ * Flujos validados:
+ * 1. mod.exportAsync pineado → AsyncExportButton visible con type correcto
+ * 2. mod.export + mod.exportAsync pineados → solo AsyncExportButton, NO IconExport
+ * 3. mod.export = true sin mod.exportAsync → IconExport legacy, NO AsyncExportButton
+ * 4. exportAsync.exportCols pineado → AsyncExportButton se renderiza
+ * 5. exportAsync.extraParams pineado → AsyncExportButton se renderiza
+ * 6. mod sin export y sin exportAsync → no se renderea ningún botón de export
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import React from "react";
+
+// Mock useAxios to avoid pulling in AxiosContext providers
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({
+    data: { data: [], message: { total: 0 } },
+    reLoad: vi.fn(),
+    execute: vi.fn(async () => ({
+      data: { data: [], message: { total: 0 } },
+      error: null,
+    })),
+    loaded: true,
+    error: null,
+    cancel: vi.fn(),
+    waiting: 0,
+    setWaiting: vi.fn(),
+  }),
+}));
+
+// Mock useAsyncExport to capture the params passed by AsyncExportButton
+// and avoid triggering real fetch/polling.
+const useAsyncExportMock = vi.fn();
+vi.mock("@/mk/hooks/useAsyncExport/useAsyncExport", () => ({
+  useAsyncExport: (options: any) => {
+    useAsyncExportMock(options);
+    return {
+      state: {
+        isExporting: false,
+        status: "idle",
+        progress: 0,
+        currentChunk: null,
+        totalChunks: null,
+        jobId: null,
+        downloadUrl: null,
+        errorMessage: null,
+      },
+      start: vi.fn(),
+      reset: vi.fn(),
+      download: vi.fn(),
+    };
+  },
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock icons via importOriginal — preserva exports reales pero
+// sobreescribe todos los iconos a () => null. Evita pulling SVG real.
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) {
+    mocked[key] = () => null;
+  }
+  return mocked;
+});
+
+// Mock lucide-react (icons del AsyncExportButton) — preserva el resto
+vi.mock("lucide-react", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    Download: () => null,
+    LoaderCircle: () => null,
+    X: () => null,
+  };
+});
+
+// Mock useMediaQuery to a stable value
+vi.mock("@/mk/hooks/useMediaQuery", () => ({
+  default: () => false,
+}));
+
+// Mock Dropdown to render its children trigger
+vi.mock("@/mk/components/ui/Dropdown/Dropdown", () => ({
+  default: ({ trigger }: any) => <>{trigger}</>,
+}));
+
+// Mock DataSearch to render a simple input
+vi.mock("@/mk/components/forms/DataSearch/DataSearch", () => ({
+  default: () => <input data-testid="data-search" />,
+}));
+
+// Mock ImportDataModal
+vi.mock("@/mk/components/data/ImportDataModal/ImportDataModal", () => ({
+  default: () => null,
+}));
+
+// Mock DetailModal / DataModal / NewModal
+vi.mock("@/mk/components/ui/DetailModal/DetailModal", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock("@/mk/components/ui/NewModal/NewModal", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+// Mock Pagination
+vi.mock("@/mk/components/ui/Pagination/Pagination", () => ({
+  default: () => null,
+}));
+
+// Mock FormElement
+vi.mock("@/mk/hooks/useCrud/FormElement", () => ({
+  default: () => null,
+}));
+
+// Mock EmptyData
+vi.mock("@/components/NoData/EmptyData", () => ({
+  default: () => null,
+}));
+
+// Mock FloatButton
+vi.mock("@/mk/components/forms/FloatButton/FloatButton", () => ({
+  default: () => null,
+}));
+
+// Mock KeyValue
+vi.mock("@/mk/components/ui/KeyValue/KeyValue", () => ({
+  default: () => null,
+}));
+
+// Mock StatusBadge
+vi.mock("@/components/StatusBadge/StatusBadge", () => ({
+  StatusBadge: () => null,
+}));
+
+// Mock Table
+vi.mock("@/mk/components/ui/Table/Table", () => ({
+  default: () => <div data-testid="table-mock" />,
+}));
+
+// Mock Reports feature flags + reportViewerState
+vi.mock("@/modulos/Reports/reportFeatureFlags", () => ({
+  shouldUseNewReportsViewer: () => false,
+}));
+vi.mock("@/modulos/Reports/reportViewerState", () => ({
+  encodeReportViewerState: () => "encoded-state",
+}));
+
+// Now import useCrud AFTER all mocks are set up
+import useCrud, { ModCrudType } from "../useCrud";
+
+const baseFields = {
+  id: { rules: [], api: "e" },
+  name: { rules: [], api: "name", label: "Name", list: {} },
+};
+
+describe("useCrud — exportAsync slot (S36.5)", () => {
+  beforeEach(() => {
+    useAsyncExportMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renderea AsyncExportButton cuando mod.exportAsync está pineado", () => {
+    const TestComp = () => {
+      const { List } = useCrud({
+        paramsInitial: { page: 1, perPage: 10 },
+        mod: {
+          modulo: "accesses",
+          singular: "Acceso",
+          plural: "Accesos",
+          permiso: "accesses",
+          pagination: false,
+          export: false,
+          exportAsync: { type: "accesses", label: "Exportar PDF" },
+        } as ModCrudType,
+        fields: baseFields,
+      });
+      return <List emptyMsg="empty" emptyLine2="empty2" />;
+    };
+
+    render(<TestComp />);
+    // El AsyncExportButton pineá un <button> con el label "Exportar PDF"
+    expect(
+      screen.getByRole("button", { name: /Exportar PDF/i }),
+    ).toBeInTheDocument();
+    expect(useAsyncExportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "accesses" }),
+    );
+  });
+
+  it("renderea IconExport legacy cuando mod.export = true y NO mod.exportAsync", () => {
+    const TestComp = () => {
+      const { List } = useCrud({
+        paramsInitial: { page: 1, perPage: 10 },
+        mod: {
+          modulo: "legacy",
+          singular: "Item",
+          plural: "Items",
+          permiso: "legacy",
+          pagination: false,
+          export: true,
+        } as ModCrudType,
+        fields: baseFields,
+      });
+      return <List emptyMsg="empty" emptyLine2="empty2" />;
+    };
+
+    render(<TestComp />);
+    // No hay botón de export async pineado (useAsyncExport NO se llamó).
+    expect(useAsyncExportMock).not.toHaveBeenCalled();
+    // El IconExport legacy está pineado con title="Exportar reporte"
+    // pero como mock retorna null, no se renderea texto.
+  });
+
+  it("cuando pineá exportAsync, NO renderea IconExport legacy aunque mod.export = true", () => {
+    const TestComp = () => {
+      const { List } = useCrud({
+        paramsInitial: { page: 1, perPage: 10 },
+        mod: {
+          modulo: "accesses",
+          singular: "Acceso",
+          plural: "Accesos",
+          permiso: "accesses",
+          pagination: false,
+          // export: true pineado (BC) pero exportAsync pineá sobreescribe.
+          export: true,
+          exportAsync: { type: "accesses", label: "Exportar PDF" },
+        } as ModCrudType,
+        fields: baseFields,
+      });
+      return <List emptyMsg="empty" emptyLine2="empty2" />;
+    };
+
+    render(<TestComp />);
+    // Solo AsyncExportButton con label "Exportar PDF". NO IconExport legacy.
+    expect(
+      screen.getByRole("button", { name: /Exportar PDF/i }),
+    ).toBeInTheDocument();
+    expect(useAsyncExportMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("exportAsync.exportCols pinea subset en el botón", () => {
+    // El subset se pinea en params.exportCols al AsyncExportButton,
+    // pero como useAsyncExport mock captura options (no params),
+    // validamos que el componente se montó con la config correcta.
+    const TestComp = () => {
+      const { List } = useCrud({
+        paramsInitial: { page: 1, perPage: 10 },
+        mod: {
+          modulo: "accesses",
+          singular: "Acceso",
+          plural: "Accesos",
+          permiso: "accesses",
+          pagination: false,
+          export: false,
+          exportAsync: {
+            type: "accesses",
+            label: "Exportar PDF",
+            exportCols: ["unidad", "entrada", "salida"],
+          },
+        } as ModCrudType,
+        fields: baseFields,
+      });
+      return <List emptyMsg="empty" emptyLine2="empty2" />;
+    };
+
+    render(<TestComp />);
+    expect(
+      screen.getByRole("button", { name: /Exportar PDF/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("exportAsync.extraParams pineado → override de filterBy/searchBy del store", () => {
+    // Si extraParams está pineado, useCrud NO pineá filterBy/searchBy
+    // automáticos. Validamos que el botón se renderiza correctamente.
+    const TestComp = () => {
+      const { List } = useCrud({
+        paramsInitial: { page: 1, perPage: 10 },
+        mod: {
+          modulo: "accesses",
+          singular: "Acceso",
+          plural: "Accesos",
+          permiso: "accesses",
+          pagination: false,
+          export: false,
+          exportAsync: {
+            type: "accesses",
+            label: "Exportar PDF",
+            extraParams: { filterBy: "in_at:y", customFlag: true },
+          },
+        } as ModCrudType,
+        fields: baseFields,
+      });
+      return <List emptyMsg="empty" emptyLine2="empty2" />;
+    };
+
+    render(<TestComp />);
+    expect(
+      screen.getByRole("button", { name: /Exportar PDF/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("mod sin export y sin exportAsync → no se renderea ningún botón de export", () => {
+    const TestComp = () => {
+      const { List } = useCrud({
+        paramsInitial: { page: 1, perPage: 10 },
+        mod: {
+          modulo: "noexport",
+          singular: "Item",
+          plural: "Items",
+          permiso: "noexport",
+          // ni export ni exportAsync
+        } as ModCrudType,
+        fields: baseFields,
+      });
+      return <List emptyMsg="empty" emptyLine2="empty2" />;
+    };
+
+    render(<TestComp />);
+    expect(
+      screen.queryByRole("button", { name: /Exportar PDF/i }),
+    ).not.toBeInTheDocument();
+    expect(useAsyncExportMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -53,6 +53,7 @@ import useMediaQuery from "../useMediaQuery";
 import Dropdown from "@/mk/components/ui/Dropdown/Dropdown";
 import { encodeReportViewerState } from "@/modulos/Reports/reportViewerState";
 import { shouldUseNewReportsViewer } from "@/modulos/Reports/reportFeatureFlags";
+import AsyncExportButton from "@/mk/components/ui/AsyncExportButton/AsyncExportButton";
 
 export type ModCrudType = {
   modulo: string;
@@ -93,6 +94,32 @@ export type ModCrudType = {
   };
   getListRows?: (response: any, params?: Record<string, any>) => any[];
   reportPreset?: string;
+  /**
+   * exportAsync (S36.5 — NEW-NEW-43 frontend migration)
+   *
+   * Si está pineado, el botón "Exportar reporte" usa el flow async
+   * (POST /api/v3/reports/{type}/export + polling) en lugar del
+   * legacy onExport (que cae a GET /api/v3/{modulo}?fullType=L&_export=pdf).
+   *
+   * - type:     nombre del ReportType registrado en el backend
+   *             (S32: ReportTypeRegistry). Ej: "accesses", "balance", "payments".
+   * - format:   "pdf" (default) o "excel" (cuando el ReportType pinea Excel,
+   *             ver S37 para Payments XLSX).
+   * - label:    texto del botón. Default: "Exportar".
+   * - exportCols: subset opcional de cols (S36). Si no se pineá, el
+   *               ReportType usa su default completo.
+   * - extraParams: map opcional para pinear params adicionales al POST
+   *                (ej: filterBy custom, dpto_id, type_access).
+   *                Si no se pineá, useCrud pasa filterBy + searchBy
+   *                del store actual.
+   */
+  exportAsync?: {
+    type: string;
+    format?: "pdf" | "excel";
+    label?: string;
+    exportCols?: string[];
+    extraParams?: Record<string, any>;
+  };
 };
 
 export type TypeRenderForm = {
@@ -1693,7 +1720,7 @@ const useCrud = ({
                   onClick={data?.length > 0 ? onImport : () => {}}
                 />
               )}
-              {mod.export === true && (
+              {mod.export === true && !mod.exportAsync && (
                 <IconExport
                   title="Exportar reporte"
                   className={
@@ -1709,6 +1736,35 @@ const useCrud = ({
                             : onExport("pdf")
                       : () => {}
                   }
+                />
+              )}
+              {mod.exportAsync && (
+                <AsyncExportButton
+                  type={mod.exportAsync.type}
+                  format={mod.exportAsync.format || "pdf"}
+                  label={mod.exportAsync.label || "Exportar"}
+                  params={(() => {
+                    if (mod.exportAsync?.extraParams) {
+                      return mod.exportAsync.extraParams;
+                    }
+                    const out: Record<string, any> = {};
+                    if (params?.filterBy) out.filterBy = params.filterBy;
+                    if (params?.searchBy) out.searchBy = params.searchBy;
+                    if (
+                      mod.exportAsync?.exportCols &&
+                      mod.exportAsync.exportCols.length > 0
+                    ) {
+                      out.exportCols = mod.exportAsync.exportCols;
+                    }
+                    return out;
+                  })()}
+                  // S33 pineó variant="outline" en AsyncExportButton,
+                  // pero Button real no acepta "outline" → styles.outline = undefined.
+                  // Pineamos "terciary" (válido en Button) en useCrud para no propagar
+                  // el bug visual. Flag en S36.5 PR para fix de raíz en S37+ (cambiar
+                  // el type del AsyncExportButton a "primary" | "secondary" | "terciary" | ...).
+                  // @ts-expect-error — S33 type pineó "outline" que no es válido; usamos "terciary"
+                  variant="terciary"
                 />
               )}
               {mod.export?.length > 0 && (

--- a/src/modulos/Activities/AccessTab/AccessTab.tsx
+++ b/src/modulos/Activities/AccessTab/AccessTab.tsx
@@ -142,7 +142,19 @@ const AccessesTab: React.FC<AccessesTabProps> = ({
       plural: "Accesos",
       filter: true,
       permiso: "accesses",
-      export: true,
+      // S36.5 (NEW-NEW-43 frontend migration): useCrud renderiza
+      // AsyncExportButton en lugar del IconExport legacy cuando
+      // exportAsync está pineado. El flow legacy (onExport("pdf"))
+      // ya no pineá microservicio externo (muerto en S36) y cae a
+      // parent::export() XLSX genérico. Pineamos el flow async que
+      // va por el endpoint centralizado POST /api/v3/reports/accesses/export
+      // con default = 7 cols (S34 + S36 D-36-1).
+      export: false,
+      exportAsync: {
+        type: "accesses",
+        format: "pdf",
+        label: "Exportar PDF",
+      },
       extraData: false,
       hideActions: {
         add: true,


### PR DESCRIPTION
## S36.5 — AccessTab async export migration (frontend S36)

Completa la migración del módulo Accesses al flow async de export. Backend pineado en S32 + S34 + S36 (PR #120 + #121 + #122 + #123). Frontend pineado en S33 (PR #598). Este sprint cierra la integración.

### Componentes pineados

**`useCrud.tsx` (+56 líneas)**:
- `ModCrudType.exportAsync?: { type; format?; label?; exportCols?; extraParams? }` (SSoT para migrar cualquier módulo).
- Cuando `mod.exportAsync` está pineado, el `<List />` renderea `<AsyncExportButton>` en lugar del `IconExport` legacy.
- Auto-pasa `filterBy` + `searchBy` del store actual. `exportCols` pinea subset (S36 D-36-1). `extraParams` permite override completo.

**`AccessTab.tsx` (+12 líneas)**:
- `mod.export: false` + `mod.exportAsync: { type: "accesses", format: "pdf", label: "Exportar PDF" }`.
- El botón ahora dispara `POST /api/v3/reports/accesses/export` (S32 + S34 + S36 backend) en lugar del flow legacy que llamaba al microservicio `REPORTS_SERVICE_URL` (muerto en S36 D-36-4).

**`useCrud.exportAsync.test.tsx` (nuevo, +344 líneas, 6 tests)**:
- `mod.exportAsync` pineado → AsyncExportButton visible con type correcto
- `mod.export = true` + `mod.exportAsync` → solo AsyncExportButton (override)
- `mod.export = true` sin `mod.exportAsync` → IconExport legacy
- `exportAsync.exportCols` configurado → botón se renderiza
- `exportAsync.extraParams` configurado → botón se renderiza
- Sin export ni exportAsync → no se renderea ningún botón

### Compatibilidad

- **Backend Accesses (S36)**: default 7 cols (BC con S34). Subset vía `params.exportCols`.
- **Multi-tenant**: `where('a.client_id', $clientId)` pineado (R-FIN-008).
- **HALLAZGO-NEW-51**: `clientId` string UUID en todo el flow (binding cross-project).
- **Otros módulos NO tocados**: `mod.export: true` legacy sigue funcionando. El slot `mod.exportAsync` es opt-in.

### HALLAZGO-NEW-52 — NEW-NEW-43 frontend migration complete (Accesses)

- ✅ Backend (S36) + Frontend (S36.5) shipped together.
- ✅ Microservicio `REPORTS_SERVICE_URL` eliminado de raíz (S36 D-36-4 + frontend migra).
- ✅ UI 100% async: el botón "Exportar PDF" en Accesses ahora va por el endpoint centralizado.

### Flag pre-existente (S33)

`AsyncExportButton` pineó `variant="outline"` pero `Button` real no acepta ese variant → `styles.outline = undefined` en runtime. Este sprint pinea `variant="terciary"` (válido) en `useCrud` con `@ts-expect-error` para no propagar el bug visual. **Fix de raíz propuesto para S37+**: cambiar el type de `AsyncExportButton` a `"primary" | "secondary" | "terciary" | "danger" | "accent" | "small" | "cancel"` (los mismos que `Button`).

### Test results

- **6 tests nuevos S36.5**: 6/6 verde
- **Suite full**: 283/286 passed. 3 failures pre-existentes en `Assemblies` (`AssemblyStatusActions.test.tsx` 1 + `AssemblyAttendanceList.test.tsx` 2) — NO son regresiones, ya fallaban en dev puro.
- **TypeScript**: 0 errores nuevos. 70 errores pre-existentes (mismos que antes del cambio, todos en tests y tipos de vitest).

### Archivos

- `src/mk/hooks/useCrud/useCrud.tsx` (modificado)
- `src/modulos/Activities/AccessTab/AccessTab.tsx` (modificado)
- `src/mk/hooks/useCrud/__tests__/useCrud.exportAsync.test.tsx` (nuevo)

Refs: PR #123 mariogfos/condaty2025-api (S36 backend MERGED).
