### PR TITLE
S37.5 — payments.config exportAsync slot (frontend S37)

### DIFF
--- a/src/modulos/Payments/config/__tests__/payments.config.test.ts
+++ b/src/modulos/Payments/config/__tests__/payments.config.test.ts
@@ -1,5 +1,6 @@
 /**
  * S-D: payments.config.tsx — form method select options must use numeric PaymentMethod ids
+ *      + S37.5: mod.exportAsync slot para migrar al flow async XLSX
  *
  * RED: fails while the form select uses string ids ('T'/'E'/'C').
  * GREEN: after replacing with FORM_PAYMENT_METHODS (numeric PaymentMethod ids).
@@ -10,6 +11,7 @@ import {
   METHOD_MAP,
   PaymentMethod,
 } from "@/modulos/Payments/Type/PaymentType";
+import { getPaymentsConfig } from "@/modulos/Payments/config/payments.config";
 
 describe("payments.config — FORM_PAYMENT_METHODS are numeric (S-D)", () => {
   it("all form method option ids are numbers, not strings", () => {
@@ -71,5 +73,41 @@ describe("payments.config — renderMethodCell uses numeric METHOD_MAP (S-D)", (
 
   it("string 'T' does NOT resolve (stale code guard)", () => {
     expect(METHOD_MAP["T"]).toBeUndefined();
+  });
+});
+
+describe("payments.config — mod.exportAsync slot (S37.5)", () => {
+  // S37.5: pinea el slot exportAsync (S36.5) en payments.config.tsx para
+  // migrar al flow async XLSX (S32 + S37 PaymentsReportType). El viewer
+  // reportPreset sigue disponible BC para preview + PDF.
+
+  it("pinea mod.exportAsync.type = 'payments' (matchea ReportTypeRegistry)", () => {
+    const { mod } = getPaymentsConfig("text-overflow", "text-right", "text-center");
+    expect(mod.exportAsync).toBeDefined();
+    expect(mod.exportAsync?.type).toBe("payments");
+  });
+
+  it("pinea mod.exportAsync.format = 'excel' (ExcelGenerator path, S37)", () => {
+    const { mod } = getPaymentsConfig("text-overflow", "text-right", "text-center");
+    expect(mod.exportAsync?.format).toBe("excel");
+  });
+
+  it("pinea mod.exportAsync.label = 'Exportar XLSX'", () => {
+    const { mod } = getPaymentsConfig("text-overflow", "text-right", "text-center");
+    expect(mod.exportAsync?.label).toBe("Exportar XLSX");
+  });
+
+  it("mod.export = false → deshabilita IconExport legacy (override)", () => {
+    // S36.5 D-36.5-3: si pinean AMBOS export: true Y exportAsync,
+    // el async override el legacy. Pineando export: false dejamos
+    // claro: solo async.
+    const { mod } = getPaymentsConfig("text-overflow", "text-right", "text-center");
+    expect(mod.export).toBe(false);
+  });
+
+  it("mantiene mod.reportPreset = 'payments-income' (viewer BC)", () => {
+    // BC: el viewer sigue disponible para preview + PDF.
+    const { mod } = getPaymentsConfig("text-overflow", "text-right", "text-center");
+    expect(mod.reportPreset).toBe("payments-income");
   });
 });

--- a/src/modulos/Payments/config/payments.config.tsx
+++ b/src/modulos/Payments/config/payments.config.tsx
@@ -150,7 +150,24 @@ export const getPaymentsConfig = (
       del: true,
     },
     filter: true,
-    export: true,
+    // S37.5: pineamos mod.exportAsync (slot reusable de S36.5) para
+    // migrar el módulo Payments al flow async XLSX (S32 + S37).
+    // - export: false → deshabilita IconExport legacy (el viewer
+    //   reportPreset sigue disponible BC para preview + PDF).
+    // - exportAsync.type: "payments" → matchea el PaymentsReportType
+    //   pineado en S37 (ReportTypeRegistry).
+    // - format: "excel" → ExcelGenerator chunked (S37 D-37-1).
+    // - auto-pasa filterBy+searchBy del store actual (useCrud S36.5).
+    // El flow async NO pinea startDate/endDate porque el filter del
+    // módulo Payments usa `filterBy: "paid_at:m"` (periodo), no
+    // date range custom. Si se requiere date range, S38+ agrega
+    // `extraParams: { start_date, end_date }` via UI.
+    export: false,
+    exportAsync: {
+      type: "payments",
+      format: "excel",
+      label: "Exportar XLSX",
+    },
     titleAdd: "Nuevo",
     titleDel: "Anular",
     saveMsg: {


### PR DESCRIPTION
## S37.5 — payments.config exportAsync slot (frontend S37)

Cierra la integración frontend del módulo Payments al flow async XLSX. Backend pineado en S32 + S37 (PR #120 + #124). Slot `mod.exportAsync` reusable introducido en S36.5 (PR #599).

### Cambios pineados

**`payments.config.tsx` (+19 líneas)**:
- `mod.export: false` (reemplaza el IconExport legacy)
- `mod.exportAsync: { type: "payments", format: "excel", label: "Exportar XLSX" }`
- Mantiene `mod.reportPreset: "payments-income"` BC → el viewer (preview + PDF) sigue funcionando

**`payments.config.test.ts` (+38 líneas, 5 tests nuevos)**:
- `mod.exportAsync.type === "payments"` (matchea ReportTypeRegistry)
- `mod.exportAsync.format === "excel"` (ExcelGenerator path, S37)
- `mod.exportAsync.label === "Exportar XLSX"`
- `mod.export === false` (override del IconExport legacy)
- `mod.reportPreset === "payments-income"` (BC viewer)

### Compatibilidad

- **Backend Payments (S37 MERGED)**: `POST /api/v3/reports/payments/export` con `format=xlsx` + `params: {start_date, end_date}` → XLSX async.
- **Multi-tenant**: `clientId` string UUID en todo el flow (HALLAZGO-NEW-51, R-FIN-008).
- **Otros módulos frontend**: `mod.export: true` legacy sigue funcionando (D-36.5-3).
- **Viewer** (`reportPreset: "payments-income"`): BC, sigue abierto desde el botón "Exportar reporte" legacy (que ahora NO se renderea porque `mod.export: false`). El viewer se accede vía navegación directa.

### HALLAZGO-NEW-56 — patrón reusable XLSX (binding, cross-project)

- Cualquier módulo con XLSX pinea `exportAsync: { format: "excel" }` (mismo patrón que S36.5 Accesses + S37.5 Payments).
- El slot `exportAsync` es SSoT para migrar módulos al flow async.
- BC: `mod.export: true` legacy sigue funcionando en otros módulos (D-36.5-3).
- S38+ (Defaulter, Dpto, Assembly, BankAccounts) usan el mismo slot.

### Decisiones binding (D-37.5-x)

- **D-37.5-1**: `payments.config` pinea `mod.export: false` + `mod.exportAsync`. NO pinea `extraParams` porque el filter del módulo usa `filterBy` (no date range custom). Si se requiere date range, S38+ agrega via UI.
- **D-37.5-2**: Mantener `mod.reportPreset: "payments-income"` BC. El viewer sigue disponible para preview + PDF (flow legacy del viewer).
- **D-37.5-3**: El slot `mod.exportAsync` es SSoT para todos los módulos XLSX. Cualquier módulo que pinee `format: "excel"` automáticamente va por el `ExcelGenerator` (S37 D-37-1) → `PaymentsReportType` (S37) en el backend.

### Test results

- **5 tests nuevos S37.5**: 5/5 verde
- **16 tests** del config file `payments.config.test.ts`: 16/16 verde
- **Suite full**: 288/291 passed. 3 failures pre-existentes en `Assemblies` (NO son regresiones, ya fallaban en dev puro post-S33).
- **TypeScript**: 0 errores nuevos.

### Archivos

- `src/modulos/Payments/config/payments.config.tsx` (modificado)
- `src/modulos/Payments/config/__tests__/payments.config.test.ts` (modificado, +5 tests)

Refs: PR #124 mariogfos/condaty2025-api (S37 backend MERGED), PR #599 (S36.5 frontend).
