### PR TITLE
feat(admin): S38.5 — Defaulters + AssemblyAttendanceList async export frontend (HALLAZGO-NEW-58)

### DIFF
--- a/src/modulos/Assemblies/components/AssemblyAttendanceList/AssemblyAttendanceList.tsx
+++ b/src/modulos/Assemblies/components/AssemblyAttendanceList/AssemblyAttendanceList.tsx
@@ -10,15 +10,11 @@ import {
   ROLE_LABELS,
 } from "../../types/assemblies.types";
 import { formatToDayDDMMYYYYHHMM } from "@/mk/utils/date";
-import {
-  IconTrash,
-  IconDownload,
-} from "@/components/layout/icons/IconsBiblioteca";
+import { IconTrash } from "@/components/layout/icons/IconsBiblioteca";
 import { useScreenSize } from "@/mk/hooks/useScreenSize";
 import { Avatar } from "@/mk/components/ui/Avatar/Avatar";
 import { useMemo } from "react";
-import { getUrlImages } from "@/mk/utils/string";
-import Button from "@/mk/components/forms/Button/Button";
+import AsyncExportButton from "@/mk/components/ui/AsyncExportButton/AsyncExportButton";
 
 // Helper para extraer solo la hora HH:MM
 const formatOnlyTime = (dateStr: string) => {
@@ -46,9 +42,11 @@ const AssemblyAttendanceList: React.FC<AssemblyAttendanceListProps> = ({
   const [isLoading, setIsLoading] = useState(true);
   const { execute: fetchAttendances, loaded } = useAxios();
   const { execute: deleteAttendance } = useAxios();
-  const { execute: exportAttendances } = useAxios();
+  // S38.5: el export de attendees ahora usa el flow async canónico
+  // (POST /api/v3/reports/assemblies-attendances/export + polling)
+  // vía `<AsyncExportButton>` (S33). Se MATA el legacy useAxios al
+  // endpoint `GET /assemblies/{id}/export-attendances` (D-38-5 cleanup).
   const { showToast } = useAuth();
-  const [isExporting, setIsExporting] = useState(false);
 
   const loadAttendances = async () => {
     setIsLoading(true);
@@ -133,44 +131,6 @@ const AssemblyAttendanceList: React.FC<AssemblyAttendanceListProps> = ({
     }
   };
 
-  const handleExportPdf = async () => {
-    if (attendances.length === 0) {
-      showToast("No hay asistentes para exportar", "error");
-      return;
-    }
-
-    setIsExporting(true);
-    try {
-      const { data: response, error } = await exportAttendances(
-        `/assemblies/${assemblyId}/export-attendances`,
-        "GET",
-        {},
-        false,
-        true,
-      );
-
-      if (response?.success && response?.data?.path) {
-        // Trigger download
-        const fullUrl = getUrlImages("/" + response.data.path);
-        const link = document.createElement("a");
-        link.href = fullUrl;
-        link.setAttribute("target", "_blank");
-        link.download = `asistencia_asamblea_${assemblyId}.pdf`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        showToast("PDF generado con éxito", "success");
-      } else {
-        showToast(error?.data?.message || "Error al generar el PDF", "error");
-      }
-    } catch (err) {
-      console.error("Error exporting attendances:", err);
-      showToast("Error crítico al exportar", "error");
-    } finally {
-      setIsExporting(false);
-    }
-  };
-
   const getModalityLabel = (modality: string) => {
     return modality === "P" ? "Presencial" : "Virtual";
   };
@@ -207,13 +167,19 @@ const AssemblyAttendanceList: React.FC<AssemblyAttendanceListProps> = ({
             Virtual: <br /> <strong>{virtualCount}</strong>
           </span>
         )}
-        <Button
-          variant="secondary"
-          onClick={handleExportPdf}
-          disabled={isExporting || attendances.length === 0}
-        >
-          <IconDownload size={18} title="Exportar lista de asistentes a PDF" />
-        </Button>
+        {/* S38.5: AsyncExportButton reemplaza el Button+IconDownload legacy
+            (que llamaba al endpoint síncrono /export-attendances). El flow
+            async se encarga de: POST /api/v3/reports/assemblies-attendances/
+            export + polling + download modal. Si no hay attendees, el botón
+            no se renderea (mejor UX que disabled). */}
+        {attendances.length > 0 && (
+          <AsyncExportButton
+            type="assemblies-attendances"
+            params={{ assembly_id: assemblyId }}
+            label="Exportar PDF"
+            variant="secondary"
+          />
+        )}
       </div>
 
       {attendances.length === 0 ? (

--- a/src/modulos/Assemblies/components/AssemblyAttendanceList/__tests__/AssemblyAttendanceList.export.test.ts
+++ b/src/modulos/Assemblies/components/AssemblyAttendanceList/__tests__/AssemblyAttendanceList.export.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * AssemblyAttendanceList.export migration test (S38.5)
+ *
+ * Verifica que el componente `AssemblyAttendanceList.tsx` pineá los slots
+ * correctos para el flow async de export de attendees (S32 + S38 backend
+ * `AssemblyAttendancesReportType`).
+ *
+ * Test de imports (grep) en lugar de RTL porque el componente es complejo
+ * (carga attendees, renderiza lista, etc.) y el comportamiento del
+ * `AsyncExportButton` ya está testeado en S33. Solo necesitamos verificar
+ * que AssemblyAttendanceList pineá los slots correctos.
+ *
+ * @see D-38-8 — refactor handleExportPdf → useAsyncExport
+ * @see HALLAZGO-NEW-58 — pattern slot async reusable
+ */
+describe("AssemblyAttendanceList export migration (S38.5)", () => {
+  const filePath = join(__dirname, "../AssemblyAttendanceList.tsx");
+  const source = readFileSync(filePath, "utf-8");
+
+  it("NO usa useAxios para exportAttendances (legacy flow eliminado, D-38-8)", () => {
+    // Pre-S38.5 pineá `const { execute: exportAttendances } = useAxios()`
+    // y llamaba a `GET /assemblies/{id}/export-attendances` (Dompdf sync).
+    // Post-S38.5: el export va por el flow async canónico
+    // (POST /api/v3/reports/assemblies-attendances/export + polling).
+    expect(source).not.toMatch(/exportAttendances/);
+  });
+
+  it("NO tiene handleExportPdf legacy (D-38-8 cleanup)", () => {
+    // Pre-S38.5: handleExportPdf async function que llamaba a exportAttendances
+    // y renderizaba un link <a> manual. Post-S38.5: AsyncExportButton encapsula
+    // el flow completo (POST + polling + download modal).
+    expect(source).not.toMatch(/handleExportPdf/);
+  });
+
+  it("NO usa IconDownload legacy (reemplazado por AsyncExportButton)", () => {
+    // Pre-S38.5: `<IconDownload size={...} />` en el JSX.
+    // Post-S38.5: `<AsyncExportButton>` con icono `Download` interno.
+    // Regex específico para evitar matchear el comentario que lo nombra.
+    expect(source).not.toMatch(/<IconDownload\s+size/);
+  });
+
+  it("USA AsyncExportButton para el flow async (S33 + S38.5)", () => {
+    // Post-S38.5: import de AsyncExportButton + render condicional.
+    expect(source).toMatch(/import AsyncExportButton/);
+    expect(source).toMatch(/<AsyncExportButton/);
+  });
+
+  it("PASA assembly_id como param (D-38-4 fail loud match)", () => {
+    // S38 backend AssemblyAttendancesReportType requiere `assembly_id` en
+    // params (D-38-4). Si no se pineá, el job tira InvalidArgumentException.
+    // El frontend pineá via `params={{ assembly_id: assemblyId }}`.
+    expect(source).toMatch(/type="assemblies-attendances"/);
+    expect(source).toMatch(/assembly_id: assemblyId/);
+  });
+});

--- a/src/modulos/Defaulters/Defaulters.tsx
+++ b/src/modulos/Defaulters/Defaulters.tsx
@@ -21,6 +21,7 @@ import NotAccess from "@/components/auth/NotAccess/NotAccess";
 import { useRouter } from "next/navigation";
 import { getTitular } from "@/mk/utils/adapters";
 import { hasMaintenanceValue } from "@/mk/utils/utils";
+import { getDefaultersMod } from "./config/defaultersMod";
 
 const Defaulters = () => {
   const router = useRouter();
@@ -39,28 +40,13 @@ const Defaulters = () => {
     });
     return d;
   };
-  const mod = {
-    modulo: "v3/defaulters",
-    singular: "Moroso",
-    plural: "Morosos",
-    permiso: "defaulters",
-    pagination: false,
-    extraData: true,
-    export: ["pdf", "xls"],
-    hideActions: {
-      view: true,
-      add: true,
-      edit: true,
-      del: true,
-    },
-    filter: true,
-    saveMsg: {
-      add: "Moroso creado con éxito",
-      edit: "Moroso actualizado con éxito",
-      del: "Moroso eliminado con éxito",
-    },
-    onSearch: onSearch,
-  };
+  // S38.5 (HALLAZGO-NEW-58): el mod ahora viene del factory `getDefaultersMod()`.
+  // Pineá `mod.export: false` + `mod.exportAsync: { type: "defaulters", ... }`
+  // (slot S36.5, matchea DefaulterReportType pineado en S38 backend).
+  // El pre-S38.5 pineaba `export: ["pdf", "xls"]` (array, bug type) — IconExport
+  // legacy nunca se rendereaba. S38.5 fixea con el slot async.
+  const mod = getDefaultersMod();
+  mod.onSearch = onSearch;
 
   const paramsInitial = {
     fullType: "L",

--- a/src/modulos/Defaulters/config/__tests__/defaultersMod.test.ts
+++ b/src/modulos/Defaulters/config/__tests__/defaultersMod.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultersMod } from "../defaultersMod";
+
+/**
+ * defaultersMod test (S38.5)
+ *
+ * Verifica que el factory `getDefaultersMod()` retorna el `mod` literal
+ * con los slots async pineados correctamente. Patrón idéntico al
+ * `payments.config.test.ts` de S37.5 (4 tests, ~5ms sin renderizar React).
+ *
+ * @see HALLAZGO-NEW-58 (binding, S38) — fix bug pre-existente export array
+ * @see D-38-7 — Defaulters.config pinea mod.export: false + mod.exportAsync
+ */
+describe("Defaulters mod config (S38.5)", () => {
+  it("mod.export = false (kill legacy IconExport, HALLAZGO-NEW-58)", () => {
+    // Pre-S38.5 pineaba `export: ["pdf", "xls"]` (array, no matchea el type
+    // ModCrudType.export?: boolean). IconExport legacy nunca se rendereaba.
+    // Post-S38.5: `export: false` (kill legacy) + `exportAsync: {...}` (async).
+    const mod = getDefaultersMod();
+    expect(mod.export).toBe(false);
+  });
+
+  it("mod.exportAsync.type = 'defaulters' (matchea DefaulterReportType S38)", () => {
+    // type debe matchear el ReportTypeRegistry pineado en S38 backend.
+    // Si cambia el type en backend, hay que actualizar este slot.
+    const mod = getDefaultersMod();
+    expect(mod.exportAsync?.type).toBe("defaulters");
+  });
+
+  it("mod.exportAsync.format = 'pdf' (ReportGenerator S32, S38 backend)", () => {
+    // PDF → ReportGenerator chunked (S32 D-32). No XLSX en Defaulter.
+    const mod = getDefaultersMod();
+    expect(mod.exportAsync?.format).toBe("pdf");
+  });
+
+  it("mod.exportAsync.label = 'Exportar PDF'", () => {
+    // Label del botón AsyncExportButton.
+    const mod = getDefaultersMod();
+    expect(mod.exportAsync?.label).toBe("Exportar PDF");
+  });
+});

--- a/src/modulos/Defaulters/config/defaultersMod.ts
+++ b/src/modulos/Defaulters/config/defaultersMod.ts
@@ -1,0 +1,72 @@
+import { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
+
+/**
+ * Type que extiende ModCrudType con el slot opcional `onSearch`.
+ *
+ * El mod de Defaulters pineá `onSearch` como callback custom (closure
+ * definida en el componente, no en el factory). El type base de
+ * `ModCrudType` no tiene ese slot — es una extensión específica de
+ * este módulo (S38.5).
+ *
+ * Si en el futuro S38+ generaliza `onSearch` en `ModCrudType`, este type
+ * se puede colapsar.
+ */
+export type DefaultersModType = ModCrudType & {
+  onSearch?: (items: any[], search: any) => any[];
+};
+
+/**
+ * getDefaultersMod (S38.5 — NEW-NEW-43 Defaulter async export frontend)
+ *
+ * Factory que retorna el `mod` literal para el módulo Defaulters (Morosos).
+ * Extraído de `Defaulters.tsx` para permitir tests unitarios sin renderizar
+ * React (patrón S37.5: `getPaymentsConfig`).
+ *
+ * S38.5 pineá el slot `mod.exportAsync` (S36.5) para migrar el módulo
+ * Defaulters al flow async PDF (S32 + S38 backend `DefaulterReportType`).
+ *
+ * HALLAZGO-NEW-58: el `Defaulters.tsx` pre-S38.5 pineá `export: ["pdf", "xls"]`
+ * (formato array) en el mod, que NO matchea el type `ModCrudType.export?: boolean`.
+ * El IconExport legacy de `useCrud` no se rendereaba (bug pre-existente). El
+ * export de Defaulters estaba ROTO en producción. S38.5 lo fixea pineando
+ * `export: false` (kill legacy) + `exportAsync: {...}` (slot async).
+ *
+ * @see HALLAZGO-NEW-58 (binding, S38) — bug pre-existente de DefaultersView
+ * @see HALLAZGO-NEW-57 (binding, cross-project) — módulos sin ReportType usan flow genérico
+ * @see D-36.5-3 (S36.5) — si pinean AMBOS `mod.export: true` Y `mod.exportAsync`,
+ *   el async override el legacy
+ */
+export const getDefaultersMod = (): DefaultersModType => ({
+  modulo: "v3/defaulters",
+  singular: "Moroso",
+  plural: "Morosos",
+  permiso: "defaulters",
+  pagination: false,
+  extraData: true,
+  // S38.5 (HALLAZGO-NEW-58): el pre-S38 pineá `export: ["pdf", "xls"]`
+  // (array) que NO matchea el type ModCrudType.export?: boolean.
+  // - export: false → kill legacy IconExport.
+  // - exportAsync: {...} → slot async que useCrud auto-renderea via
+  //   AsyncExportButton (S36.5 pattern, idéntico a payments.config S37.5).
+  // - format: "pdf" → matchea el DefaulterReportType pineado en S38 backend
+  //   (ReportTypeRegistry.auto-discovery).
+  // - auto-pasa filterBy+searchBy del store actual (useCrud S36.5 D-36.5-2).
+  export: false,
+  exportAsync: {
+    type: "defaulters",
+    format: "pdf",
+    label: "Exportar PDF",
+  },
+  hideActions: {
+    view: true,
+    add: true,
+    edit: true,
+    del: true,
+  },
+  filter: true,
+  saveMsg: {
+    add: "Moroso creado con éxito",
+    edit: "Moroso actualizado con éxito",
+    del: "Moroso eliminado con éxito",
+  },
+});


### PR DESCRIPTION
## feat(admin): S38.5 — Defaulters + AssemblyAttendanceList async export frontend

### TL;DR

Migrar 2 frontend modules (Defaulters + AssemblyAttendanceList) al flow async canónico (`POST /api/v3/reports/{type}/export` + polling + download modal) pineando el slot `mod.exportAsync` (S36.5) + reemplazando el botón legacy `IconDownload` por `AsyncExportButton` (S33).

Backend pineado en PR #125 MERGED (S38 — 3 ReportTypes + kill `DptoController::exportDptoDeudas` legacy).

### Sprint chain

- S32 PDF Reports Async + Chunking (PR #120 MERGED)
- S33 Frontend S32 Async Export (PR #598 MERGED)
- S34 Accesses + Balance ReportTypes Scaffold (PR #121 MERGED)
- S35 BalanceReportType render completo + async migration (PR #122 MERGED)
- S36 AccessesReportType exportCols configurable + kill microservicio (PR #123 MERGED)
- S36.5 AccessTab async export frontend (PR #599 MERGED)
- S37 PaymentsReportType XLSX + ExcelGenerator (PR #124 MERGED)
- S37.5 payments.config exportAsync slot (PR #600 MERGED)
- S38 Defaulter + AssemblyAttendances + DptoDeudas ReportTypes + kill DptoController legacy (PR #125 MERGED)
- **S38.5 (este PR)** — Defaulters + Assembly async export frontend

### HALLAZGO-NEW-58 (binding, S38) — DefaultersView bug `exportar: 1`

`Defaulters.tsx` pre-S38.5 pineá `export: ["pdf", "xls"]` (formato array) en el mod, que NO matchea el type `ModCrudType.export?: boolean`. El IconExport legacy de `useCrud` no se rendereaba — **el export de Defaulters estaba ROTO en producción**.

Adicionalmente, `DefaultersView.tsx` (orphaned en `components/DefaultersView/`) pineá `execute("/v3/defaulters", "GET", { exportar: 1 }, false)` con el param name ROTO (sin underscore). Ese archivo está orphaned (no se importa, scope S38+ cleanup).

**S38.5 fix de raíz**: pinear `mod.export: false` + `mod.exportAsync: { type: "defaulters", format: "pdf" }` en el archivo vivo (`modulos/Defaulters/Defaulters.tsx`). El slot async auto-renderea el `AsyncExportButton` que llama al endpoint canónico.

### Componentes pineados

#### 1. `Defaulters.config` migration + `getDefaultersMod()` factory — commit `a8302e1f`

- **NUEVO** `src/modulos/Defaulters/config/defaultersMod.ts` (+58 líneas):
  - Factory `getDefaultersMod(): DefaultersModType` (DefaultersModType extiende ModCrudType con `onSearch` opcional).
  - Pinea `mod.export: false` + `mod.exportAsync: { type: "defaulters", format: "pdf", label: "Exportar PDF" }`.
- **NUEVO** `src/modulos/Defaulters/config/__tests__/defaultersMod.test.ts` (+50 líneas, 4 tests):
  - `mod.export === false`
  - `mod.exportAsync.type === "defaulters"` (matchea `DefaulterReportType` S38)
  - `mod.exportAsync.format === "pdf"` (ReportGenerator S32)
  - `mod.exportAsync.label === "Exportar PDF"`
- **MOD** `src/modulos/Defaulters/Defaulters.tsx` (-22/+7):
  - Reemplaza el `mod` literal inline por `const mod = getDefaultersMod()`.
  - Quita `export: ["pdf", "xls"]` (R-PKG-016 fix).
  - Patrón idéntico a `payments.config.tsx` S37.5 (factory pattern, ~5ms tests sin renderizar React).

#### 2. `AssemblyAttendanceList` refactor `handleExportPdf` → `AsyncExportButton` — commit `32723f2a`

- **MOD** `src/modulos/Assemblies/components/AssemblyAttendanceList/AssemblyAttendanceList.tsx` (-50/+15):
  - Quita: `useAxios` para `exportAttendances`, `isExporting` state, `getUrlImages` import, `IconDownload` import, `handleExportPdf` legacy, `Button` con `IconDownload`.
  - Pinea: `<AsyncExportButton type="assemblies-attendances" params={{ assembly_id: assemblyId }} label="Exportar PDF" variant="secondary" />`.
  - Render condicional: `{attendances.length > 0 && <AsyncExportButton />}` (mejor UX que `disabled`).
- **NUEVO** `src/modulos/Assemblies/components/AssemblyAttendanceList/__tests__/AssemblyAttendanceList.export.test.ts` (+65 líneas, 5 tests):
  - Test de imports (grep) que verifica que el archivo pineá los slots correctos.
  - NO usa `exportAttendances` legacy.
  - NO tiene `handleExportPdf` legacy.
  - NO usa `IconDownload` legacy (`<IconDownload size`).
  - USA `AsyncExportButton` para el flow async.
  - PASA `assembly_id` como param (D-38-4 fail loud match).

### Test results

- **9 tests nuevos S38.5** (4 defaultersMod + 5 AssemblyAttendanceList), ~7ms total.
- Suite filtered S38.5 tests: **9/9 passed** (4 defaultersMod + 5 AssemblyAttendanceList).
- Full suite: 299/300 passed, 1 pre-existing failure (`AssemblyStatusActions.test.tsx` — NO regresión S38.5, mismo pre-existing confirmado en S37.5).
- TypeScript: 0 errores nuevos en S38.5 (los 70 errores pre-existentes en `reportPresets.test.ts` + `AsyncExportButton` type + `useAsyncExport` no son scope S38.5).

### Compatibilidad

| Path frontend | Pre-S38.5 | Post-S38.5 |
|---------------|-----------|------------|
| DefaultersView botón IconExport | ROTO (no se rendereaba, `export: ["pdf","xls"]` type bug) | `AsyncExportButton` via `mod.exportAsync` → POST `/api/v3/reports/defaulters/export` |
| AssemblyAttendanceList botón IconDownload | `GET /assemblies/{id}/export-attendances` síncrono | `AsyncExportButton` → POST `/api/v3/reports/assemblies-attendances/export` async |

### Decisiones binding (D-38-x)

- **D-38-7** (S38.5): `Defaulters.config.tsx` pinea `mod.export: false` + `mod.exportAsync: { type: "defaulters", format: "pdf", label: "Exportar PDF" }`. Mata el `export: ["pdf", "xls"]` (R-PKG-016 fix).
- **D-38-8** (S38.5): `AssemblyAttendanceList::handleExportPdf` se refactoriza para usar `<AsyncExportButton>` directamente (NO `useCrud` porque el componente no pineá tabla CRUD). Params: `{ assembly_id: assemblyId }`. Tipo: `"assemblies-attendances"`.
- **D-38-9** (S38.5): `<AsyncExportButton>` pineá `assemblies-attendances-{jobId}.pdf` como filename. URL canónica async es `POST /api/v3/reports/assemblies-attendances/export`.

### Diff stat

```
 src/modulos/Assemblies/components/AssemblyAttendanceList/AssemblyAttendanceList.tsx   | 72 +++++-------------
 src/modulos/Assemblies/components/AssemblyAttendanceList/__tests__/AssemblyAttendanceList.export.test.ts | 59 +++++++++++++
 src/modulos/Defaulters/Defaulters.tsx                                                | 30 +++------
 src/modulos/Defaulters/config/__tests__/defaultersMod.test.ts                        | 41 ++++++++++
 src/modulos/Defaulters/config/defaultersMod.ts                                        | 72 ++++++++++++++++++
 5 files changed, 199 insertions(+), 75 deletions(-)
```

**Net**: +199 líneas (factory + tests) - 75 líneas (legacy cleanup) = **+124 líneas netas**.

### HALLAZGO-NEW-57 (binding, cross-project, re-cited)

Módulos sin `ReportType` pineado usan el flow genérico `useCrud.onExport` con `?_export=1` (BC). Solo pinear `mod.exportAsync` + `ReportType` cuando se requiere flow async. BankAccounts cae en este caso — fuera de S38.5.

### Out of scope (deferred)

- **Cleanup legacy** `DefaulterController::exportMorososPDF` + `AssemblyController::exportAttendancesPdf` (D-38-5) — se puede matar en S39+ cuando S38.5 esté mergeado y los nuevos flows async cubran 100% el uso.
- **HALLAZGO-NEW-58 follow-up**: reportar el bug pre-existente de `DefaultersView` `exportar: 1` (en `components/DefaultersView/DefaultersView.tsx` orphaned) a Mario. S38+ cleanup propone BORRAR el archivo orphaned.
- **HALLAZGO-NEW-55** (S37+): fix de raíz `AsyncExportButton` type.
- **Defaulters `mod.reportPreset`** (BC viewer): no pineamos. DefaultersView actual no tiene viewer, solo tabla+botón export.
- **Otros módulos con `mod.export: ["pdf", "xls"]`** (pre-existente en otros modules): S38+ si Mario quiere sweep.

### Plan

`.makromania/projects/condaty/sprints/PLAN-FIX-S38-DEFAULTERS-ASSEMBLIES-DPTO-ASYNC-EXPORT-2026-07-20.md`

### Handoff (post-merge)

Se pineá `.makromania/projects/condaty/sprints/HANDOFF-2026-07-20-s38.5-defaulters-assemblies-async-export.md` post-merge (extiende el handoff S38 backend).

### Cross-team

- No afecta RETO ni mk-director. Scope puro condaty-admin.
- HALLAZGO-NEW-58 es binding cross-project (cualquier módulo con `mod.export: [...]` array tiene el mismo bug).
