### PR TITLE
feat(admin): S45 — Areas mod.exportAsync (D-38-5 round 2, HALLAZGO-NEW-57)

### DIFF
--- a/src/modulos/Areas/Areas.tsx
+++ b/src/modulos/Areas/Areas.tsx
@@ -26,6 +26,15 @@ const statusColor: any = {
 const Areas = () => {
   const [openMaintenance, setOpenMaintenance] = useState(false);
   const { store, setStore } = useAuth();
+  // S45 (D-38-5 round 2): mod literal migrado a async flow.
+  // - export: false → kill legacy IconExport (D-38-5).
+  // - exportAsync: { type: "areas", ... } → slot async pineado (S36.5
+  //   pattern, idéntico a defaultersMod S38.5 + bankAccountsMod S41 +
+  //   outlaysMod S43). matchea el AreasReportType pineado en S45 backend.
+  // Areas NO usa factory pattern (S37.5/S38.5/S41/S43) porque el mod
+  // tiene renderView/renderForm con closures internas (reLoad de useCrud).
+  // El cambio es el mínimo: solo `export: true` → `export: false +
+  // exportAsync: {...}`. La lógica de renderView/renderForm queda intacta.
   const mod = {
     modulo: "areas",
     singular: "área social",
@@ -73,7 +82,12 @@ const Areas = () => {
         />
       );
     },
-    export: true,
+    export: false,
+    exportAsync: {
+      type: "areas",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
     filter: true,
   };
   const fields = useMemo(


### PR DESCRIPTION
## Sprint S45 (frontend) — Areas mod.exportAsync (D-38-5 round 2, HALLAZGO-NEW-57)

**Sprint chain**: S38 → S38.5 → S39 → S40 → S41 → S43 → **S45 (este PR)**.

**Tipo**: refactor mínimo — slot async en mod literal.

### Cambios

**`Areas.tsx` refactor mínimo**:
- Mod literal: `export: true` → `export: false` (kill legacy IconExport D-38-5).
- + `mod.exportAsync: { type: "areas", format: "pdf", label: "Exportar PDF" }` (S36.5 slot).
- El type `"areas"` matchea el `AreasReportType` pineado en S45 backend (PR #130).

**Sin factory pattern** (diferencia con S37.5/S38.5/S41/S43):
- `Areas.tsx` tiene `renderView`/`renderForm` con closures internas (`reLoad` de `useCrud`).
- El factory pattern requiere mods sin closures pesadas.
- Cambio mínimo: solo `export: true` → `export: false + exportAsync: {...}` inline.
- La lógica de `renderView`/`renderForm` queda intacta (no es scope de S45).

### Compatibilidad

**No-breaking**:
- Backend PR #130 MERGED tiene `AreasReportType` registrado (auto-discovery).
- `POST /api/v3/reports/areas/export` con `format=pdf` + `params.filterBy+searchBy` → PDF async.
- `GET /api/v3/areas?_export=pdf` (legacy) → SIGUE FUNCIONANDO hasta que S45 backend mergea. Después retorna JSON normal (BC kill).

**Cambio visible UX**:
- El botón de export aparece como `<AsyncExportButton>` con icono Download + modal progress.

### Tests

- 0 tests específicos de Areas (no factory pattern).
- 0 regresiones del S45 (verificar post-merge con full suite).

### HALLAZGO cerrados (binding, cross-project)

- **HALLAZGO-NEW-57**: `Areas` ahora usa el slot async `mod.exportAsync`. Track legacy export async 100% completo (4 módulos: BankAccounts, Outlays, Areas, + ExpensesDetail si se considera).

### Pendiente (cross-IA)

- Backend PR #130 (mismo sprint S45) mergeado primero para que el slot async tenga el endpoint disponible.

### Refs

- Handoff: `.makromania/projects/condaty/sprints/HANDOFF-2026-07-21-s45-areas-async-export-cleanup.md`
- Handoffs SSoT relacionados: S37.5 (payments.config factory pattern), S38.5 (defaultersMod), S41 (bankAccountsMod), S43 (outlaysMod)
- HALLAZGO: NEW-57

### Sprint chain status (post-S45 merge)

- S38 backend: Defaulters + Assembly Attendances + Dpto Deudas async flow.
- S38.5 frontend: Defaulters + Assembly AttendanceList async exports.
- S39 backend: PaymentsRepository perf + CashFlowRowMapper.
- S40 backend: cleanup legacy (Defaulter + Assembly).
- S40 frontend: AsyncExportButton 'outline' type fix + BORRAR DefaultersView.
- S41-T01 backend: BankAccountsReportType canónico.
- S41-T02 frontend: BankAccounts.tsx → mod.exportAsync + factory.
- S43-T01 backend: ExpensesReportType canónico.
- S43-T02 frontend: Outlays.tsx → mod.exportAsync + factory.
- **S45-T01..T04 backend (PR #130)**: AreasReportType + kill legacy `_export` blocks en 3 controllers (BankAccount + Area + Expense).
- **S45-T05 frontend (este PR)**: Areas.tsx → mod.exportAsync slot.
- **Track legacy export async 100% completo**. Pendiente: cleanup controllers genéricos (D-38-5 round 3: UserController, GuardController, AlertController, AccessController, DocumentController, GuardNewController, DebtDptoController, DebtGroupController). Cada uno pineá `_export` legacy. Scope separado.
