### PR TITLE
S47.5 — DebtDpto mod.exportAsync en 3 tabs (NORMAL + FORGIVENESS + EXPENSE)

### DIFF
--- a/src/modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx
+++ b/src/modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx
@@ -35,7 +35,25 @@ const Forgiveness = ({
     sumarize: true,
     extraData: true,
     loadView: { fullType: 'DET', type: 5 },
-    export: true,
+    // S47.5: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+    // - export: false → kill legacy GET /api/v3/debt-dptos?_export=pdf.
+    // - exportAsync: {...} → slot async que useCrud auto-renderea via
+    //   AsyncExportButton (S36.5 pattern, idéntico a S41 BankAccounts,
+    //   S43 Outlays, S45 Areas).
+    // - type: "debt-dptos" → matchea el DebtDptoReportType pineado en
+    //   S47 backend (ReportTypeRegistry.auto-discovery, 11 tipos).
+    // - extraParams.type: 5 (FORGIVENESS) → branch FORGIVENESS del
+    //   ReportType (8 cols: dpto_nro, titular, due_at_date1, status_texto,
+    //   categoria_padre_nombre, forgiveness_cobrar_cur, forgiveness_amount_cur,
+    //   total_sum_cur).
+    // - format: "pdf" (S47 pineá PDF only, no XLSX — D-47-3).
+    export: false,
+    exportAsync: {
+      type: 'debt-dptos',
+      format: 'pdf',
+      label: 'Exportar PDF',
+      extraParams: { type: 5 },
+    },
     titleDel: "Anular",
 
     hideActions: { add: false, edit: true, del: true },

--- a/src/modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx
@@ -226,7 +226,24 @@ const IndividualDebts: React.FC<IndividualDebtsProps> = ({
     modulo: 'v3/debt-dptos',
     singular: 'Deuda',
     plural: '',
-    export: true,
+    // S47.5: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+    // - export: false → kill legacy GET /api/v3/debt-dptos?_export=pdf.
+    // - exportAsync: {...} → slot async que useCrud auto-renderea via
+    //   AsyncExportButton (S36.5 pattern, idéntico a S41 BankAccounts,
+    //   S43 Outlays, S45 Areas).
+    // - type: "debt-dptos" → matchea el DebtDptoReportType pineado en
+    //   S47 backend (ReportTypeRegistry.auto-discovery, 11 tipos).
+    // - extraParams.type: 0 (NORMAL) → branch NORMAL/SHARED/ALL del
+    //   ReportType (6 cols: unit, subcategory, type, status, due_at,
+    //   balance_due_cur). Para AllDebts (sin type) sería 0 también.
+    // - format: "pdf" (S47 pineá PDF only, no XLSX — D-47-3).
+    export: false,
+    exportAsync: {
+      type: 'debt-dptos',
+      format: 'pdf',
+      label: 'Exportar PDF',
+      extraParams: { type: 0 },
+    },
     filter: true,
     permiso: 'expense',
     extraData: true,

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
@@ -249,7 +249,28 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
     modulo: "v3/debt-dptos",
     singular: "Detalle",
     plural: "Detalles",
-    export: true,
+    // S47.5: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+    // - export: false → kill legacy GET /api/v3/debt-dptos?_export=pdf.
+    // - exportAsync: {...} → slot async que useCrud auto-renderea via
+    //   AsyncExportButton (S36.5 pattern, idéntico a S41 BankAccounts,
+    //   S43 Outlays, S45 Areas).
+    // - type: "debt-dptos" → matchea el DebtDptoReportType pineado en
+    //   S47 backend (ReportTypeRegistry.auto-discovery, 11 tipos).
+    // - extraParams.type: 1 (EXPENSE) + debt_id dinámico → branch EXPENSE
+    //   del ReportType (8 cols: unidad, fecha_pago_date3, fecha_plazo_date3,
+    //   estado, monto_cur, multa_cur, mv_cur, total_sum_cur).
+    //   El debtId es un PROP del componente (SharedDebts → DetailSharedDebts
+    //   navega con el debt_id específico de la shared debt seleccionada).
+    //   Como el mod se declara en el render, extraParams lee `debtId` del
+    //   closure del componente — funciona en cada render.
+    // - format: "pdf" (S47 pineá PDF only, no XLSX — D-47-3).
+    export: false,
+    exportAsync: {
+      type: "debt-dptos",
+      format: "pdf",
+      label: "Exportar PDF",
+      extraParams: { type: 1, debt_id: debtId },
+    },
     filter: false,
     permiso: "expense",
     extraData: true,


### PR DESCRIPTION
## S47.5 — DebtDpto mod.exportAsync en 3 tabs (NORMAL + FORGIVENESS + EXPENSE)

**Rama**: `fix/s47.5-debtdpto-mod-export-async` → `dev`
**Sprint**: S47.5 (frontend single-task)
**Sprint anterior**: S47 backend (PR #132 MERGED — DebtDptoReportType)
**Track**: NEW-57 DebtDpto async export (binding, cross-project)

### Logros

- **3 tabs frontend migrados al flow async PDF** (mod.exportAsync, S36.5 pattern).
- **NO factory pattern** (D-45-3): los 3 mods tienen closures internas o referencias externas → cambio mínimo inline.
- **0 regresiones**: tsc 69 errores baseline === 69 con cambio. Vitest 307/308 (1 fail pre-existente Surveys InstantDB appId, validado con git stash).
- 3 files changed, +59/-3 líneas.

### Archivos

- **`src/modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx`** (+19/-1): kill `export: true` + `exportAsync: { type: 'debt-dptos', format: 'pdf', label: 'Exportar PDF', extraParams: { type: 0 } }`. Branch NORMAL.
- **`src/modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx`** (+20/-1): idem con `extraParams: { type: 5 }`. Branch FORGIVENESS.
- **`src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx`** (+23/-1): idem con `extraParams: { type: 1, debt_id: debtId }` (debtId es prop dinámico). Branch EXPENSE.

### Compatibilidad (R-PKG-016)

- `POST /api/v3/reports/debt-dptos/export` con `format=pdf` y `params={type: 0|1|5, debt_id?}` (S47 backend, ya MERGED en #132).
- `GET /api/v3/debt-dptos?_export=pdf` legacy → JSON normal (sigue hasta S48 cleanup D-38-5 round 3).

### Test results

- `tsc --noEmit`: 69 errores baseline === 69 con cambio (0 regresiones).
- `vitest run`: 307/308 tests verde (4.6s). 1 fail pre-existente en `Surveys.test.tsx` (InstantDB appId inválido — fuera de scope S47.5). Validado con `git stash` + re-run baseline.

### Decisiones

- **D-47.5-1** (D-45-3, binding): los 3 mods de DebtDpto NO usan factory pattern porque tienen:
  - `IndividualDebts`: `renderView` con closure `(props) => <RenderView ... user={user} ... />` que captura `user` del closure del componente.
  - `Forgiveness`: `renderForm: RenderForm` + `renderView: RenderView` (referencias externas a componentes importados).
  - `DetailSharedDebts`: `renderView` con closure `(props) => <RenderView ... />` que captura props.
  
  Factory pattern rompería las closures. Cambio mínimo inline es la opción correcta.

- **D-47.5-2** (binding, S36.5 reusable): el slot `mod.exportAsync.extraParams` es `Record<string, any>` estático, pero se RE-evalúa en cada render del componente padre (el mod se declara en el render). Eso permite que `DetailSharedDebts` pase `debt_id: debtId` dinámico al extraParams.

### Pendiente S48

1. **S48 (D-38-5 round 3 cleanup + DebtGroupReportType backend)**:
   - Backend: `DebtGroupReportType` canónico (no confundir con DebtDpto, es `debt-groups`).
   - Cleanup: kill `_export` blocks en `DebtDptoController` (líneas 575/621/628) + `DebtGroupController` (líneas 298/840) + `DptoController` legacy.
   - Frontend: pinear `mod.exportAsync` en `SharedDebts` (pineá `modulo: "debt-groups"`).
2. **HALLAZGO-NEW-43 root cause**: 12+ DebtGroupController*Test failures + 1 error ReservationMaintenanceTest, pre-existentes en dev puro.
3. **Cierre HALLAZGO-NEW-09 items 4-5**: `CACHE_MK=1` en `.env` prod, `CACHE_STORE=redis/memcached`.
4. **S25+ migraciones** (MasiveController, NotificationController, AbilityController) — scope mayor.

Refs: HALLAZGO-NEW-57, HALLAZGO-NEW-43. S47.5 frontend single-task.
