### PR TITLE
S48-T05 — SharedDebts mod.exportAsync (debt-groups)

### DIFF
--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
@@ -451,7 +451,25 @@ const SharedDebts: React.FC<SharedDebtsProps> = ({ onExtraDataChange }) => {
     modulo: "debt-groups",
     singular: "Deuda Compartida",
     plural: "",
-    export: true,
+    // S48: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+    // - export: false → kill legacy GET /api/v3/debt-groups?_export=pdf.
+    // - exportAsync: {...} → slot async que useCrud auto-renderea via
+    //   AsyncExportButton (S36.5 pattern, idéntico a S41 BankAccounts,
+    //   S43 Outlays, S45 Areas, S47.5 DebtDpto).
+    // - type: "debt-groups" → matchea el DebtGroupReportType pineado en
+    //   S48-T01 backend (PR #133, ReportTypeRegistry.auto-discovery,
+    //   12 tipos).
+    // - extraParams.type: undefined → branch EXPENSE del ReportType
+    //   (7 cols agregado por debt_id/year/month). Si el usuario pinea
+    //   type=4 (SHARED), el branch cambia automáticamente (S48-T01
+    //   detectBranch).
+    // - format: "pdf" (S48-T01 pineá PDF only, no XLSX — D-48-3).
+    export: false,
+    exportAsync: {
+      type: "debt-groups",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
     filter: true,
     permiso: "expense",
     extraData: true,


### PR DESCRIPTION
## S48-T05 — SharedDebts mod.exportAsync (debt-groups)

**Rama**: `fix/s48-shareddebts-mod-export-async` → `dev`
**Sprint**: S48 (frontend single-task)
**Sprint anterior**: S48-T01 backend (PR #133 MERGED — DebtGroupReportType)
**Track**: NEW-57 DebtGroups async export (binding, cross-project)

### Logros

- **SharedDebts tab migrado al flow async PDF** (mod.exportAsync, S36.5 pattern).
- **0 regresiones**: tsc 69 errores baseline === 69 con cambio. Vitest 307/308 (1 fail pre-existente Surveys InstantDB appId).
- 1 file changed, +19/-1 líneas.

### Archivos

- **`src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx`** (+19/-1): kill `export: true` (legacy IconExport) + `exportAsync: { type: "debt-groups", format: "pdf", label: "Exportar PDF" }` (sin extraParams.type → branch EXPENSE default).

### Compatibilidad (R-PKG-016)

- `POST /api/v3/reports/debt-groups/export` con `format=pdf` y `params={type: 1|4?, searchBy?, filterBy?}` (S48-T01 backend, ya MERGED en #133).
- `GET /api/v3/debt-groups?_export=pdf` legacy → JSON normal (sigue hasta S48-T08 cleanup D-38-5 round 3).

### Test results

- `tsc --noEmit`: 69 errores baseline === 69 con cambio (0 regresiones).
- `vitest run`: 307/308 tests verde (4.9s, 41/42 test files). 1 fail pre-existente en `Surveys.test.tsx` (InstantDB appId inválido, validado en S47.5).
- **Hook pre-commit**: 0 warnings, todas las verificaciones pasaron.

### Decisiones

- **D-48-5-1** (S36.5 reusable, binding): `mod.exportAsync` sin `extraParams` → branch EXPENSE default (D-48-2: `params.type` undefined o ≠ SHARED). Si el usuario pinea `type=4` (SHARED) en los filtros, el `detectBranch` del ReportType lo switcha automáticamente. Patrón reusable: 1 slot `mod.exportAsync` cubre 2 branches cuando el ReportType pineá detección interna.
- **D-48-5-2** (D-45-3, binding): `SharedDebts` NO usa factory pattern porque `renderForm: (props) => <RenderForm {...props} />` (closure inline). Cambio mínimo inline.

### Pendiente S48 (mismo sprint, PRs separados)

1. **S48-T08 cleanup D-38-5 round 3**: kill `_export` blocks en `DebtDptoController` (líneas 575-628) + `DebtGroupController` (líneas 298-300 + 840-950) + `DptoController` (líneas 518-529 + 731+).
2. **HALLAZGO-NEW-43 root cause**: 12+ DebtGroupController*Test failures + 1 error ReservationMaintenanceTest, pre-existentes en dev puro.
3. **Cierre HALLAZGO-NEW-09 items 4-5**: `CACHE_MK=1` en `.env` prod, `CACHE_STORE=redis/memcached`.
4. **S25+ migraciones** (MasiveController, NotificationController, AbilityController) — scope mayor.

Refs: HALLAZGO-NEW-57. S48 frontend single-task.
