### PR TITLE
feat(admin): S52.5 — Users mod.exportAsync slot (frontend async export)

### DIFF
--- a/src/modulos/Users/Users.tsx
+++ b/src/modulos/Users/Users.tsx
@@ -31,7 +31,26 @@ const Users = () => {
     plural: "personal administrativo",
     filter: true,
     permiso: "users",
-    export: true,
+    // S52.5: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+    // - export: false → kill legacy IconExport.
+    // - exportAsync: { type: "users", ... } → slot async que useCrud auto-renderea
+    //   via AsyncExportButton (S36.5 pattern, idéntico a S41 BankAccounts +
+    //   S47.5 DebtDpto + S48-T05 SharedDebts).
+    // - type: "users" → matchea el UserReportType pineado en S52 backend
+    //   (ReportTypeRegistry.auto-discovery).
+    // - format: "pdf" → ReportGenerator chunked (S32). XLSX también soportado
+    //   (S52 pineá excelRowProvider).
+    // - auto-pasa searchBy del store actual (useCrud S36.5 D-36.5-2).
+    // - filterBy (pipe-separated role_id) también se pasa via params del Report.
+    // Factory NO aplicada (D-45-3, binding): Users pineá renderView + renderDel
+    // con closures internas (capturan reLoad + userCan). Factory rompería
+    // esas refs. Cambio mínimo inline es la opción correcta.
+    export: false,
+    exportAsync: {
+      type: "users",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
     titleAdd: "Nuevo",
     // import: true,
     // search: { hide: true },


### PR DESCRIPTION
# S52.5 — Users mod.exportAsync slot (frontend async export)

## TL;DR

Frontend sync con S52 backend (UserReportType). Mismo patrón S41 (BankAccounts) + S47.5 (DebtDpto) + S48-T05 (SharedDebts).

**Branch**: `fix/s52.5-users-mod-export-async`
**Base**: `dev` (post-merge S48-T05 #608)
**Sprint anterior backend**: S52 (PR #138 MERGED — UserReportType)
**Commit**: (pendiente)

## Logros

- `Users.tsx` migrado al flow async PDF (S36.5 reusable slot).
- Kill legacy `IconExport` (D-38-5 round 4 frontend).
- 0 nuevos errores tsc en `Users.tsx` (errores pre-existentes en otros files no relacionados con S52.5).

## Cambios (1 file, +20/-1)

`src/modulos/Users/Users.tsx`:

```ts
// Antes (S41-style legacy)
export: true,

// Después (S52.5 async)
export: false,
exportAsync: {
  type: "users",
  format: "pdf",
  label: "Exportar PDF",
},
```

## Decisiones binding (D-52.5-x)

- **D-52.5-1** (D-45-3, binding): Factory NO aplicada. `Users.tsx` pineá `renderView` + `renderDel` con closures internas (capturan `reLoad` + `userCan`). Factory rompería esas refs. Cambio mínimo inline es la opción correcta.
- **D-52.5-2** (S36.5 reusable, binding): `mod.exportAsync` slot auto-detectado por `useCrud` que pineá `AsyncExportButton`. `searchBy` + `filterBy` se auto-pasan del store al Report (D-36.5-2).

## Compatibilidad (R-PKG-016, ZERO BC break)

- Endpoint legacy `GET /api/v3/users` sigue funcionando.
- `modulo: "users"` (sin `v3/`) preserva la ruta legacy. **NOTA**: los otros mods (BankAccounts, Outlays, Defaulters) pinean `modulo: "v3/..."` (con v3). Esto es una inconsistencia pre-existente en `Users.tsx` (ruta legacy pre-S20) — fuera de scope S52.5. **S25+ post si Mario quiere migrar**.
- Flow async: `POST /api/v3/reports/users/export` con `format=pdf|xlsx`. Render en queue worker (S32), Dompdf paginá automáticamente.

## Pendiente S53+ (cola vieja, replicable S52 pattern)

- S53 = GuardController async export
- S54 = AlertController async export
- S55 = AccessController async export
- S56 = DocumentController async export
- 4 sprints más para cerrar el track de export legacy completamente.

## Refs cross-sprint

- S52 backend PR #138 (MERGED) — `UserReportType` async PDF + XLSX
- S36.5 frontend pattern — `mod.exportAsync` slot reusable
- D-45-3 binding — factory NO aplica si mod pineá closures internas
