### PR TITLE
feat(admin): S54.5 — Binnacle mod.exportAsync slot (frontend async export)

### DIFF
--- a/src/modulos/Binnacle/Binnacle.tsx
+++ b/src/modulos/Binnacle/Binnacle.tsx
@@ -107,7 +107,24 @@ const Binnacle = () => {
     hideActions: { edit: true, del: true, add: true },
     renderView: (props: any) => <RenderView {...props} />,
     loadView: { fullType: "DET" },
-    export: true,
+    // S54.5: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+    // - export: false → kill legacy IconExport.
+    // - exportAsync: { type: "guard-news", ... } → slot async que useCrud
+    //   auto-renderea via AsyncExportButton (S36.5 pattern, idéntico a
+    //   S52.5 Users + S41 BankAccounts + S47.5 DebtDpto + S48-T05 SharedDebts).
+    // - type: "guard-news" → matchea el GuardNewReportType pineado en S54
+    //   backend (ReportTypeRegistry.auto-discovery).
+    // - format: "pdf" → ReportGenerator chunked (S32). XLSX también soportado
+    //   (S54 pineá excelRowProvider).
+    // - auto-pasa searchBy + filterBy del store actual al Report.
+    // Factory NO aplicada (D-45-3, binding): Binnacle pineá renderView
+    // inline. Cambio mínimo inline es la opción correcta.
+    export: false,
+    exportAsync: {
+      type: "guard-news",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
   };
 
   const paramsInitial = {


### PR DESCRIPTION
# S54.5 — Binnacle mod.exportAsync slot (frontend async export)

## TL;DR

Frontend sync con S54 backend (GuardNewReportType). Mismo patrón S52.5 (Users).

**Branch**: `fix/s54.5-binnacle-mod-export-async`
**Base**: `dev` (post-merge S52.5 #609, HEAD `f34482fd`)
**Sprint anterior backend**: S54 (PR #140 OPEN — GuardNewReportType)
**Commit**: (pendiente)

## Logros

- `Binnacle.tsx` migrado al flow async PDF (S36.5 reusable slot).
- Kill legacy `IconExport` (D-38-5 round 5+ frontend).
- 0 nuevos errores tsc en `Binnacle.tsx` (69 errores pre-existentes en otros files no relacionados con S54.5).

## Cambios (1 file, +24/-1)

`src/modulos/Binnacle/Binnacle.tsx`:

```ts
// Antes (legacy IconExport)
export: true,

// Después (async slot)
export: false,
exportAsync: {
  type: "guard-news",
  format: "pdf",
  label: "Exportar PDF",
},
```

## Decisiones binding (D-54.5-x)

- **D-54.5-1** (D-45-3, binding): Factory NO aplicada. `Binnacle.tsx` pineá `renderView: (props: any) => <RenderView {...props} />` (closure inline). Cambio mínimo inline.
- **D-54.5-2** (S36.5 reusable, binding): `mod.exportAsync` slot auto-detectado por `useCrud`. `searchBy` + `filterBy` (con `created_at` d/ld/w/lw/m/lm/y/ly o rango) se auto-pasan del store al Report.
- **D-54.5-3** (R-PKG-016 + DM-2, binding): kill legacy `export: true` + delegate a `mod.exportAsync`. NO thin wrapper deprecated.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Endpoint legacy `GET /api/v3/guardnews?fullType=L` sigue funcionando.
- `modulo: "guardnews"` (sin `v3/`) preserva la ruta legacy pre-S20. **NOTA**: inconsistencia pre-existente (otros mods pinean `v3/<x>`) — fuera de scope S54.5. **S25+ post si Mario quiere migrar**.
- Flow async: `POST /api/v3/reports/guard-news/export` con `format=pdf|xlsx`. Render en queue worker (S32), Dompdf paginá automáticamente.

## Pendiente S55+ (cola vieja, replicable S54 pattern)

- S55 = AlertController async export
- S56 = AccessController async export
- S57 = DocumentController async export
- 3 sprints más cierran el track de export legacy completamente.

## Refs cross-sprint

- S54 backend PR #140 (OPEN) — `GuardNewReportType` async PDF + XLSX
- S52.5 frontend PR #609 (MERGED) — `Users` mod.exportAsync (mismo patrón)
- S36.5 frontend pattern — `mod.exportAsync` slot reusable
- D-45-3 binding — factory NO aplica si mod pineá closures internas
- D-54-3 binding — ReportType con `ClientTrait` pineá `withoutGlobalScope` + `where` explícito
