### PR TITLE
feat(admin): S55.5 — Alerts mod.exportAsync slot (frontend async export)

### DIFF
--- a/src/modulos/Alerts/Alerts.tsx
+++ b/src/modulos/Alerts/Alerts.tsx
@@ -66,7 +66,24 @@ const Alerts = () => {
     permiso: "alerts",
     extraData: true,
     hideActions: { edit: true, del: true, add: true },
-    export: true,
+    // S55.5: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+    // - export: false → kill legacy IconExport.
+    // - exportAsync: { type: "alerts", ... } → slot async que useCrud
+    //   auto-renderea via AsyncExportButton (S36.5 pattern, idéntico a
+    //   S52.5 Users + S54.5 Binnacle + S41 BankAccounts).
+    // - type: "alerts" → matchea el AlertReportType pineado en S55 backend
+    //   (ReportTypeRegistry.auto-discovery).
+    // - format: "pdf" → ReportGenerator chunked (S32). XLSX también soportado
+    //   (S55 pineá excelRowProvider).
+    // - auto-pasa searchBy + filterBy del store actual al Report.
+    // Factory NO aplicada (D-45-3, binding): Alerts pineá renderView con
+    // reLoad closure inline. Cambio mínimo inline es la opción correcta.
+    export: false,
+    exportAsync: {
+      type: "alerts",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
     filter: true,
     renderView: (props: {
       open: boolean;


### PR DESCRIPTION
# S55.5 — Alerts mod.exportAsync slot (frontend async export)

## TL;DR

Frontend sync con S55 backend (AlertReportType). Mismo patrón S52.5 (Users) + S54.5 (Binnacle).

**Branch**: `fix/s55.5-alerts-mod-export-async`
**Base**: `dev` (post-merge S52.5 #609, HEAD `f34482fd`)
**Sprint anterior backend**: S55 (PR #141 OPEN — AlertReportType)
**Commit**: (pendiente)

## Logros

- `Alerts.tsx` migrado al flow async PDF (S36.5 reusable slot).
- Kill legacy `IconExport` (D-38-5 round 6 frontend).
- 0 nuevos errores tsc en `Alerts.tsx` (69 errores pre-existentes en otros files no relacionados con S55.5).

## Cambios (1 file, +24/-1)

`src/modulos/Alerts/Alerts.tsx`:

```ts
// Antes (legacy IconExport)
export: true,

// Después (async slot)
export: false,
exportAsync: {
  type: "alerts",
  format: "pdf",
  label: "Exportar PDF",
},
```

## Decisiones binding (D-55.5-x)

- **D-55.5-1** (D-45-3, binding): Factory NO aplicada. `Alerts.tsx` pineá `renderView: (props) => <RenderView {...props} reLoad={() => reLoad()} />` (closure inline con `reLoad`). Cambio mínimo inline.
- **D-55.5-2** (S36.5 reusable, binding): `mod.exportAsync` slot auto-detectado por `useCrud`. `searchBy` + `filterBy` se auto-pasan del store al Report.
- **D-55.5-3** (R-PKG-016 + DM-2, binding): kill legacy `export: true` + delegate a `mod.exportAsync`. NO thin wrapper deprecated.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Endpoint legacy `GET /api/v3/alerts?fullType=L` sigue funcionando.
- Flow async: `POST /api/v3/reports/alerts/export` con `format=pdf|xlsx`. Render en queue worker (S32), Dompdf paginá automáticamente.

## Pendiente S56+ (cola vieja, replicable S55 pattern)

- S56 = AccessController async export
- S57 = DocumentController async export
- 2 sprints más cierran el track de export legacy completamente.

## Refs cross-sprint

- S55 backend PR #141 (OPEN) — `AlertReportType` async PDF + XLSX
- S52.5 frontend PR #609 (MERGED) — `Users` mod.exportAsync (mismo patrón)
- S54.5 frontend PR #610 (OPEN) — `Binnacle` mod.exportAsync (mismo patrón)
- S36.5 frontend pattern — `mod.exportAsync` slot reusable
- D-45-3 binding — factory NO aplica si mod pineá closures internas
- D-55-3 binding — ReportType con `ClientTrait` + `SoftDeletes` pineá `withoutGlobalScope` + `where` + `whereNull deleted_at` explícitos
- D-55-5 binding — switch `if (!_export)` legacy → async flow
