### PR TITLE
fix(s61.5): Owners mod.exportAsync slot frontend

### DIFF
--- a/src/modulos/Owners/Owners.tsx
+++ b/src/modulos/Owners/Owners.tsx
@@ -96,7 +96,22 @@ const Owners = () => {
     singular: "Residente",
     plural: "Residentes",
     filter: true,
-    export: true,
+    // S61.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+    // - export: false → kill legacy IconExport (D-38-5 round 12 frontend).
+    // - exportAsync: { type: "owners", ... } → slot async que useCrud
+    //   auto-renderea via AsyncExportButton. Matchea el OwnerReportType
+    //   pineado en S61 backend (ReportTypeRegistry.auto-discovery).
+    // - format: "pdf" → ReportGenerator chunked (S32). XLSX también
+    //   soportado (S61 pineá excelRowProvider).
+    // - auto-pasa filterBy+searchBy del store actual (useCrud S36.5
+    //   D-36.5-2). Patrón idéntico a S52.5 Users + S54.5 Binnacle +
+    //   S55.5 Alerts + S57.5 Documents.
+    export: false,
+    exportAsync: {
+      type: "owners",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
     import: false,
     permiso: "owners",
     hideActions: {


### PR DESCRIPTION
# fix(s61.5): Owners mod.exportAsync slot frontend (D-38-5 round 12 frontend)

## Resumen

HALLAZGO-NEW-61 frontend: `Owners.tsx` (módulo de Residentes) pineá `export: true` legacy (NO `mod.exportAsync`). El IconExport legacy llamaba a `GET /api/v3/owners?_export=pdf` (vía `useCrud.onExport`) y el `OwnerController` renderizaba Dompdf en el request HTTP. Riesgo: listados grandes (>500 residentes) caían en timeout 60s PHP-FPM.

S61.5 pinea el slot async S36.5 (patrón idéntico a S52.5 Users + S54.5 Binnacle + S55.5 Alerts + S57.5 Documents).

## Cambios

```
src/modulos/Owners/Owners.tsx | 17 ++++++++++++++++-
1 file changed, 16 insertions(+), 1 deletion(-)
```

```diff
   const mod: ModCrudType = {
     modulo: "owners",
     singular: "Residente",
     plural: "Residentes",
     filter: true,
-    export: true,
+    // S61.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+    // - export: false → kill legacy IconExport (D-38-5 round 12 frontend).
+    // - exportAsync: { type: "owners", ... } → slot async.
+    // - matchea el OwnerReportType pineado en S61 backend.
+    export: false,
+    exportAsync: {
+      type: "owners",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
```

## Decisiones binding (D-61.5-x)

- **D-61.5-1** (D-45-3, binding cross-project): Factory NO aplicada. `Owners.tsx` pineá `renderView` + `renderForm` con closures inline (`RenderView`/`RenderForm`). Cambio mínimo inline.
- **D-61.5-2** (S36.5 reusable, binding cross-project): `mod.exportAsync` slot auto-detectado por `useCrud`. `searchBy` + `filterBy` (con `type_owner:H|T|D`) se auto-pasan del store al Report.
- **D-61.5-3** (R-PKG-016 + DM-2, binding cross-project): kill legacy `export: true` + delegate a `mod.exportAsync`. NO thin wrapper deprecated.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Endpoint legacy `GET /api/v3/owners?fullType=L&_export=pdf` sigue funcionando (lista normal post-S61 backend cleanup).
- Flow async canónico: `POST /api/v3/reports/owners/export` con `format=pdf|xlsx`. Render en queue worker (S32), Dompdf pagination automática.

## Tests

- **0 nuevos errores tsc** en `Owners.tsx` (errores pre-existentes en `reportPresets.test.ts` no relacionados con este cambio).

## Track legacy export async — cierre 4/8 (frontend)

| # | Sprint | Módulo | Estado | PR |
|---|---|---|---|---|
| 1 | S36.5 | Accesses | ✅ MERGED | #599 (covers S56.5) |
| 2 | S41 | BankAccounts | ✅ MERGED | #604 |
| 3 | S43 | Outlays | ✅ MERGED | #605 |
| 4 | S45 | Areas | ✅ MERGED | #606 |
| 5 | S47.5 | DebtDpto | ✅ MERGED | #607 |
| 6 | S48-T05 | DebtGroups | ✅ MERGED | #608 |
| 7 | S52.5 | Users | ✅ MERGED | #609 |
| 8 | S54.5 | Binnacle | ✅ MERGED | #610 |
| 9 | S55.5 | Alerts | ✅ MERGED | #611 |
| 10 | S57.5 | Documents | ✅ MERGED | #612 |
| 11 | S61.5 | **Owners** | ✅ OPEN | **este PR** |
| 12 | S56.5 | AccessTab | NO-OP | pre-merged en S36.5 |

## Refs

- Handoff: `.makromania/projects/condaty/sprints/HANDOFF-2026-07-22-s61-owner-async-export.md` (incluye S61 backend + S61.5 frontend)
- HALLAZGO-NEW-61 (pineado en MEMORY.md)
- S61 backend (PR pendiente)
- S36.5 (slot `mod.exportAsync` reusable, PR #599 MERGED)
- S52.5 (Users frontend, PR #609 MERGED — mismo patrón)
- D-45-3 (Factory NO aplicada por closures inline)
- D-38-5 round 12 frontend
