### PR TITLE
fix(s62.5): Reservations mod.exportAsync slot frontend

### DIFF
--- a/src/modulos/Reservas/Reserva.tsx
+++ b/src/modulos/Reservas/Reserva.tsx
@@ -38,7 +38,22 @@ const mod = {
   renderView: (props: any) => <ReservationDetailModal {...props} />,
   //loadView: { fullType: "DET" },
   filter: true,
-  export: true,
+  // S62.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+  // - export: false → kill legacy IconExport (D-38-5 round 13 frontend).
+  // - exportAsync: { type: "reservations", ... } → slot async que useCrud
+  //   auto-renderea via AsyncExportButton. Matchea el ReservationReportType
+  //   pineado en S62 backend (ReportTypeRegistry.auto-discovery).
+  // - format: "pdf" → ReportGenerator chunked (S32). XLSX también soportado
+  //   (S62 pineá excelRowProvider).
+  // - auto-pasa filterBy (date_at d/ld/w/lw/m/lm/y/ly + status_reservation +
+  //   area_id) + searchBy del store actual (useCrud S36.5 D-36.5-2).
+  // Patrón idéntico a S52.5 + S54.5 + S55.5 + S57.5 + S61.5.
+  export: false,
+  exportAsync: {
+    type: "reservations",
+    format: "pdf",
+    label: "Exportar PDF",
+  },
   titleAdd: "Nueva",
 };
 


### PR DESCRIPTION
# fix(s62.5): Reservations mod.exportAsync slot frontend (D-38-5 round 13)

## Resumen

HALLAZGO-NEW-61 frontend: `Reserva.tsx` (módulo de Reservas) pineá `export: true` legacy (NO `mod.exportAsync`). El IconExport legacy llamaba a `GET /api/v3/reservations?_export=pdf` (vía `useCrud.onExport`) y el `ReservationController` renderizaba Dompdf en el request HTTP. Riesgo: listados grandes (>200 reservas) caían en timeout 60s PHP-FPM.

S62.5 pinea el slot async S36.5 (patrón idéntico a S52.5 Users + S54.5 Binnacle + S55.5 Alerts + S57.5 Documents + S61.5 Owners).

## Cambios

```
src/modulos/Reservas/Reserva.tsx | 17 ++++++++++++++++-
1 file changed, 16 insertions(+), 1 deletion(-)
```

```diff
   filter: true,
-  export: true,
+  // S62.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+  export: false,
+  exportAsync: {
+    type: "reservations",
+    format: "pdf",
+    label: "Exportar PDF",
+  },
```

## Decisiones binding (D-62.5-x)

- **D-62.5-1** (S36.5 reusable, binding cross-project): `mod.exportAsync` slot auto-detectado por `useCrud`. `searchBy` + `filterBy` (con `date_at d/ld/w/lw/m/lm/y/ly` + `status_reservation` + `area_id`) se auto-pasan del store al Report.
- **D-62.5-2** (R-PKG-016 + DM-2, binding cross-project): kill legacy `export: true` + delegate a `mod.exportAsync`. NO thin wrapper deprecated.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Endpoint legacy `GET /api/v3/reservations?fullType=L&_export=pdf` sigue funcionando (lista normal post-S62 backend cleanup).
- Flow async canónico: `POST /api/v3/reports/reservations/export` con `format=pdf|xlsx`. Render en queue worker (S32), Dompdf pagination automática.

## Tests

- **0 nuevos errores tsc** en `Reserva.tsx`.

## Refs

- Handoff: `.makromania/projects/condaty/sprints/HANDOFF-2026-07-22-s62-reservation-async-export.md` (incluye S62 backend + S62.5 frontend)
- HALLAZGO-NEW-61 (pineado en MEMORY.md)
- S62 backend (PR pendiente)
- S61.5 (PR #613 MERGED — Owners frontend, mismo patrón)
- S36.5 (slot `mod.exportAsync` reusable, PR #599 MERGED)
- D-38-5 round 13 frontend
