### PR TITLE
fix(s63.5): Budgets mod.exportAsync slot frontend

### DIFF
--- a/src/modulos/Budget/Budget/Budget.tsx
+++ b/src/modulos/Budget/Budget/Budget.tsx
@@ -140,7 +140,19 @@ const Budget = () => {
       permiso: "budgets",
       extraData: true,
       filter: true,
-      export: true,
+      // S63.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+      // - export: false → kill legacy IconExport (D-38-5 round 14 frontend).
+      // - exportAsync: { type: "budgets", ... } → slot async.
+      // - matchea el BudgetReportType pineado en S63 backend.
+      // - auto-pasa filterBy (period M|Q|B|Y + status D|P|A|R + category_id)
+      //   + searchBy del store actual (useCrud S36.5 D-36.5-2).
+      // Patrón idéntico a S52.5 + S54.5 + S55.5 + S57.5 + S61.5 + S62.5.
+      export: false,
+      exportAsync: {
+        type: "budgets",
+        format: "pdf",
+        label: "Exportar PDF",
+      },
       titleAdd: "Nuevo",
       saveMsg: {
         add: "Presupuesto creado con éxito",


### PR DESCRIPTION
# fix(s63.5): Budgets mod.exportAsync slot frontend (D-38-5 round 14)

## Resumen

HALLAZGO-NEW-61 frontend: `Budget.tsx` (módulo de Presupuestos) pineá `export: true` legacy (NO `mod.exportAsync`). El IconExport legacy llamaba a `GET /api/v3/budgets?_export=pdf` (vía `useCrud.onExport`) y el `BudgetController` renderizaba Dompdf en el request HTTP. Riesgo: listados grandes (>200 presupuestos) caían en timeout 60s PHP-FPM.

S63.5 pinea el slot async S36.5 (patrón idéntico a S52.5 Users + S54.5 Binnacle + S55.5 Alerts + S57.5 Documents + S61.5 Owners + S62.5 Reservations).

## Cambios

```
src/modulos/Budget/Budget/Budget.tsx | 14 ++++++++++++--
1 file changed, 13 insertions(+), 1 deletion(-)
```

```diff
   filter: true,
-  export: true,
+  // S63.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+  export: false,
+  exportAsync: {
+    type: "budgets",
+    format: "pdf",
+    label: "Exportar PDF",
+  },
```

## Decisiones binding (D-63.5-x)

- **D-63.5-1** (S36.5 reusable, binding cross-project): `mod.exportAsync` slot auto-detectado por `useCrud`. `searchBy` + `filterBy` (con `period M|Q|B|Y` + `status D|P|A|R` + `category_id`) se auto-pasan del store al Report.
- **D-63.5-2** (R-PKG-016 + DM-2, binding cross-project): kill legacy `export: true` + delegate a `mod.exportAsync`. NO thin wrapper deprecated.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Endpoint legacy `GET /api/v3/budgets?fullType=L&_export=pdf` sigue funcionando (lista normal post-S63 backend cleanup).
- Flow async canónico: `POST /api/v3/reports/budgets/export` con `format=pdf|xlsx`. Render en queue worker (S32), Dompdf pagination automática.

## Tests

- **0 nuevos errores tsc** en `Budget.tsx`.

## Refs

- Handoff: `.makromania/projects/condaty/sprints/HANDOFF-2026-07-22-s63-budget-async-export.md` (incluye S63 backend + S63.5 frontend)
- HALLAZGO-NEW-61 (pineado en MEMORY.md)
- S63 backend (PR pendiente)
- S62.5 (PR #614 MERGED — Reservations frontend, mismo patrón)
- S36.5 (slot `mod.exportAsync` reusable, PR #599 MERGED)
- D-38-5 round 14 frontend
