### PR TITLE
fix(s64.5): Others mod.exportAsync slot frontend

### DIFF
--- a/src/modulos/Activities/PedidosTab/PedidosTab.tsx
+++ b/src/modulos/Activities/PedidosTab/PedidosTab.tsx
@@ -94,7 +94,19 @@ const PedidosTab: React.FC<PedidosTabProps> = ({ paramsInitial }) => {
       filter: true,
       permiso: "",
       extraData: false,
-      export: true,
+      // S64.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+      // - export: false → kill legacy IconExport (D-38-5 round 15 frontend).
+      // - exportAsync: { type: "others", ... } → slot async.
+      // - matchea el OtherReportType pineado en S64 backend.
+      // - auto-pasa filterBy (in_at:week|lweek|month|lmonth) + searchBy del
+      //   store actual (useCrud S36.5 D-36.5-2).
+      // Patrón idéntico a S52.5 + S54.5 + S55.5 + S57.5 + S61.5 + S62.5 + S63.5.
+      export: false,
+      exportAsync: {
+        type: "others",
+        format: "pdf",
+        label: "Exportar PDF",
+      },
       hideActions: {
         add: true,
         edit: true,


### PR DESCRIPTION
# fix(s64.5): Others mod.exportAsync slot frontend (D-38-5 round 15)

## Resumen

HALLAZGO-NEW-61 frontend: `PedidosTab.tsx` (módulo de Otros / Pedidos) pineá `export: true` legacy (NO `mod.exportAsync`). El IconExport legacy llamaba a `GET /api/v3/others?_export=pdf` (vía `useCrud.onExport`) y el `OtherController` renderizaba Dompdf en el request HTTP. Riesgo: listados grandes (>500 others) caían en timeout 60s PHP-FPM.

S64.5 pinea el slot async S36.5 (patrón idéntico a S52.5 Users + S54.5 Binnacle + S55.5 Alerts + S57.5 Documents + S61.5 Owners + S62.5 Reservations + S63.5 Budgets).

## Cambios

```
src/modulos/Activities/PedidosTab/PedidosTab.tsx | 14 ++++++++++++--
1 file changed, 13 insertions(+), 1 deletion(-)
```

```diff
       filter: true,
       permiso: "",
       extraData: false,
-      export: true,
+      // S64.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+      export: false,
+      exportAsync: {
+        type: "others",
+        format: "pdf",
+        label: "Exportar PDF",
+      },
```

## Decisiones binding (D-64.5-x)

- **D-64.5-1** (S36.5 reusable, binding cross-project): `mod.exportAsync` slot auto-detectado por `useCrud`. `searchBy` + `filterBy` (con `in_at:week|lweek|month|lmonth`) se auto-pasan del store al Report.
- **D-64.5-2** (R-PKG-016 + DM-2, binding cross-project): kill legacy `export: true` + delegate a `mod.exportAsync`. NO thin wrapper deprecated.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Endpoint legacy `GET /api/v3/others?fullType=L&_export=pdf` sigue funcionando (lista normal post-S64 backend cleanup).
- Flow async canónico: `POST /api/v3/reports/others/export` con `format=pdf|xlsx`. Render en queue worker (S32), Dompdf pagination automática.

## Tests

- **0 nuevos errores tsc** en `PedidosTab.tsx`.

## Refs

- Handoff: `.makromania/projects/condaty/sprints/HANDOFF-2026-07-22-s64-other-async-export.md` (incluye S64 backend + S64.5 frontend)
- HALLAZGO-NEW-61 (pineado en MEMORY.md)
- S64 backend (PR pendiente)
- S63.5 (PR #615 MERGED — Budgets frontend, mismo patrón)
- S36.5 (slot `mod.exportAsync` reusable, PR #599 MERGED)
- D-38-5 round 15 frontend
