### PR TITLE
fix(s65.5): Invitations mod.exportAsync slot frontend (D-38-5 round 16)

### DIFF
--- a/src/modulos/Activities/QrTab/QrTab.tsx
+++ b/src/modulos/Activities/QrTab/QrTab.tsx
@@ -30,7 +30,13 @@ const QRTab: React.FC<QRTabProps> = ({ paramsInitial, onRowClick }) => {
       plural: "Invitaciones QR",
       filter: true,
       permiso: "",
-      export: true,
+      // S65.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+      export: false,
+      exportAsync: {
+        type: "invitations",
+        format: "pdf",
+        label: "Exportar PDF",
+      },
       extraData: false,
       hideActions: {
         


### PR DESCRIPTION
# S65.5 — Invitations mod.exportAsync slot frontend (D-38-5 round 16)

> **HALLAZGO-NEW-61 cleanup #8/8 frontend (cierre total del track legacy export async)**.
> El módulo `Activities/QrTab/QrTab.tsx` pineá `modulo: "invitations"` y
> `export: true` legacy. Migrado al slot async S36.5.

## Contexto

- **Sprint**: S65.5 (frontend companion de S65 backend)
- **Sprint anterior**: S64.5 (PR #616 MERGED — Others mod.exportAsync)
- **Branch**: `fix/s65.5-invitations-mod-export-async` (desde `6c3dacf9`)
- **HALLAZGO-NEW-61 cierre total 8/8 frontend**: 7 migrations + 4 NO-OPs
  + **S65.5** + 3 cierres pendientes cero (NO-OP por ausencia de módulo).

## Cambio frontend (1 file, +7/-1)

### `src/modulos/Activities/QrTab/QrTab.tsx`

```diff
  const modQR: ModCrudType = useMemo(() => {
    return {
      modulo: "invitations",
      singular: "Invitación",
      plural: "Invitaciones QR",
      filter: true,
      permiso: "",
-     export: true,
+     // S65.5 (HALLAZGO-NEW-61): migrado al slot async S36.5.
+     export: false,
+     exportAsync: {
+       type: "invitations",
+       format: "pdf",
+       label: "Exportar PDF",
+     },
      extraData: false,
```

## Decisiones binding (D-65.5-x)

- **D-65.5-1** (S36.5 reusable, binding cross-project): `mod.exportAsync`
  slot auto-detectado por `useCrud`. `searchBy` + `filterBy` (con
  `date_event:week|lweek|month|lmonth`) se auto-pasan del store al Report.
- **D-65.5-2** (R-PKG-016 + DM-2, binding cross-project): kill legacy
  `export: true` + delegate a `mod.exportAsync`. NO thin wrapper deprecated.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S65.5: el botón "Exportar" del módulo QR triggereaba el flow
  legacy `?_export=pdf` (Dompdf sync, 4 cols con `visit_id` UUID raw bug).
- Post-S65.5: el botón "Exportar" triggerea el flow async canónico
  `POST /api/v3/reports/invitations/export` con `format=pdf` + 4 cols
  canónicas (incluye D-65-9 fix: `visit_name` en lugar de `visit_id` UUID).

## HALLAZGO-NEW-61 — CIERRE TOTAL 8/8 frontend 🎯

Track legacy export async frontend cerrado completamente:

| Sprint | Módulo | PR frontend | Notas |
|---|---|---|---|
| S36.5 | Accesses | #599 | pre-merged |
| S41 | BankAccounts | #604 | |
| S43 | Outlays | #605 | |
| S45 | Areas | #606 | |
| S47.5 | DebtDpto | #607 | 3 tabs |
| S48-T05 | DebtGroups | #608 | |
| S52.5 | Users | #609 | |
| S54.5 | Binnacle | #610 | |
| S55.5 | Alerts | #611 | |
| S56.5 | AccessTab | (NO-OP) | D-56.5-2 |
| S57.5 | Documents | #612 | |
| S58.5 | Defaulters | (NO-OP) | D-58.5-1 |
| S59.5 | BankEntity | (NO-OP) | D-59.5-1 |
| S60.5 | Homeowner | (NO-OP) | D-60.5-1 |
| S61.5 | Owners | #613 | |
| S62.5 | Reservations | #614 | |
| S63.5 | Budgets | #615 | |
| S64.5 | Others | #616 | |
| **S65.5** | **Invitations** | **#617 (este)** | **D-65.5-1/2** |

**7 migrations + 4 NO-OPs = 11 PRs frontend MERGED. 0 frontend modules
con `export: true` legacy pendientes.**

Refs: S64.5 PR #616 (post-merge HEAD `6c3dacf9`).
Autor: Mavis <Mavis@makromania.local>.
