### PR TITLE
fix(s72.5): UnitsTypes modulo path migration a v3 (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/UnitTypes/UnitsTypes.tsx
+++ b/src/modulos/UnitTypes/UnitsTypes.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/mk/contexts/AuthProvider";
 import RenderView from "./RenderView/RenderView";
 
 const mod = {
-  modulo: "types",
+  modulo: "v3/types",
   singular: "Tipo de unidad",
   plural: "Tipos de unidades",
   onHideActions: (item: any) => {


### PR DESCRIPTION
# S72.5: UnitsTypes modulo path migration a v3 (HALLAZGO-NEW-64 caveat)

## Resumen

S72 pineó migration backend de `TypeController` a `app/Modules/Types/Controllers/` (PR #157 MERGED). Path legacy `/api/types` ya no existe (controller borrado). S72.5 migra el path del modulo en `UnitsTypes.tsx` (único consumer frontend).

**Nota cross-team**: S72.5 marca el **PRIMER sprint .5 con branch + PR** (nueva regla de Mario del 2026-07-23: "en adelante debes trabajar en ramas y con pr, para mas seguridad"). Anteriormente los .5 frontend (S66.5, S67.5, S70.5, S71.5) fueron push directo a dev. A partir de S72.5 todos los .5 frontend también pasan por branch + PR para auditabilidad.

## Cambios

- **src/modulos/UnitTypes/UnitsTypes.tsx** (modified): `modulo: 'types'` → `modulo: 'v3/types'`. 1 file, +1/-1.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S72.5: `modulo: 'types'` → `GET/POST/etc` a `/api/types` (legacy, ahora 404).
- Post-S72.5: `modulo: 'v3/types'` → `GET/POST/etc` a `/api/v3/types` (canónico v3).

Cero regresión: el `useCrud` auto-deriva la base URL con `/${modulo}`, solo cambia el path prefix. Tests pinean shape idéntico (list/create/show/update/delete con fullType=L).

- Backend path /api/types: NO pineado más (404).
- Backend path /api/v3/types: idéntico al legacy (mismo controller, mismo shape).
- 1 consumer frontend (UnitsTypes.tsx) pineá v3.

## Refs

- S72 PR #157 MERGED
- S72 HANDOFF
- Regla Mario 2026-07-23: branches+PRs always (incluso para .5 frontend)
- HALLAZGO-NEW-64 (base controller `_export` flow)

🤖 Generated with [Mavis](https://github.com/mariogfos)
