### PR TITLE
fix(s73.5): Invitations modulo path migration a v3/campaigns (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Invitations/Invitations.tsx
+++ b/src/modulos/Invitations/Invitations.tsx
@@ -14,7 +14,7 @@ const paramsInitial = {
   searchBy: "",
 };
 const mod: ModCrudType = {
-  modulo: "campaigns",
+  modulo: "v3/campaigns",
   singular: "campaña",
   plural: "campañas",
   permiso: "campanas",


### PR DESCRIPTION
# S73.5: Invitations modulo path migration a v3/campaigns (HALLAZGO-NEW-64 caveat)

## Resumen

S73 pineó migration backend de `CampaignController` a `app/Modules/Campaigns/Controllers/` (PR #158 MERGED). Path legacy `/api/campaigns` ya no existe (controller borrado). S73.5 migra el path del modulo en `Invitations.tsx` (único consumer frontend).

## Cambios

- **src/modulos/Invitations/Invitations.tsx** (modified): `modulo: 'campaigns'` → `modulo: 'v3/campaigns'`. 1 file, +1/-1.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S73.5: `modulo: 'campaigns'` → `GET/POST/etc` a `/api/campaigns` (legacy, ahora 404).
- Post-S73.5: `modulo: 'v3/campaigns'` → `GET/POST/etc` a `/api/v3/campaigns` (canónico v3).

Cero regresión: el `useCrud` auto-deriva la base URL con `/${modulo}`, solo cambia el path prefix. Tests pinean shape idéntico (list/create/show/update/delete con fullType=L).

- Backend path /api/campaigns: NO pineado más (404).
- Backend path /api/v3/campaigns: idéntico al legacy (mismo controller, mismo shape).
- 1 consumer frontend (Invitations.tsx) pineá v3.

## Notas

- 0 consumers frontend para `shifts` (mobile-only, rnGuard consume via API directa).
- Branch + PR (regla Mario 2026-07-23 aplicada, S72.5 pattern replicado).

## Refs

- S73 PR #158 MERGED
- S73 HANDOFF
- Regla Mario 2026-07-23 (branches+PRs always)
- HALLAZGO-NEW-64 (base controller `_export` flow)

🤖 Generated with [Mavis](https://github.com/mariogfos)
