### PR TITLE
fix(s74.5): EventsAdmin modulo path migration a v3/events (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Events/EventsAdmin/EventsAdmin.tsx
+++ b/src/modulos/Events/EventsAdmin/EventsAdmin.tsx
@@ -46,7 +46,7 @@ const paramsInitial = {
 const EventsAdmin = () => {
   // const { user } = useAuth();
   const mod: ModCrudType = {
-    modulo: "events",
+    modulo: "v3/events",
     singular: "evento",
     plural: "Eventos",
     permiso: "events",


### PR DESCRIPTION
# S74.5: EventsAdmin modulo path migration a v3/events (HALLAZGO-NEW-64 caveat)

## Resumen

S74 pineó migration backend de `EventController` a `app/Modules/Events/Controllers/` (PR #159 MERGED). Path legacy `/api/events` ya no existe (controller borrado). S74.5 migra el path del modulo en `EventsAdmin.tsx` (único consumer frontend).

## Cambios

- **src/modulos/Events/EventsAdmin/EventsAdmin.tsx** (modified): `modulo: 'events'` → `modulo: 'v3/events'`. 1 file, +1/-1.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S74.5: `modulo: 'events'` → `GET/POST/etc` a `/api/events` (legacy, ahora 404).
- Post-S74.5: `modulo: 'v3/events'` → `GET/POST/etc` a `/api/v3/events` (canónico v3).

Cero regresión: el `useCrud` auto-deriva la base URL con `/${modulo}`, solo cambia el path prefix. Tests pinean shape idéntico (list/create/show/update/delete con fullType=L).

- Backend path /api/events: NO pineado más (404).
- Backend path /api/v3/events: idéntico al legacy (mismo controller, mismo shape).
- 1 consumer frontend (EventsAdmin.tsx) pineá v3.

## Notas

- Branch + PR (regla Mario 2026-07-23 aplicada, S72.5/S73.5 pattern replicado).

## Refs

- S74 PR #159 MERGED
- S74 HANDOFF
- Regla Mario 2026-07-23 (branches+PRs always)
- HALLAZGO-NEW-64 (base controller `_export` flow)

🤖 Generated with [Mavis](https://github.com/mariogfos)
