### PR TITLE
fix(s75.5): Binnacle modulo path migration a v3/guardnews (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Binnacle/Binnacle.tsx
+++ b/src/modulos/Binnacle/Binnacle.tsx
@@ -98,7 +98,7 @@ const Binnacle = () => {
   ];
 
   const mod = {
-    modulo: "guardnews",
+    modulo: "v3/guardnews",
     singular: "Bitácora",
     plural: "Bitácoras",
     permiso: "guardlogs",


### PR DESCRIPTION
# S75.5: Binnacle modulo path migration a v3/guardnews (HALLAZGO-NEW-64 caveat)

## Resumen

S75 pineó migration backend de `GuardNewController` a `app/Modules/HomeOwner/Controllers/` (PR #160 MERGED). Path legacy `/api/guardnews` ya no existe. S75.5 migra el path del modulo en `Binnacle.tsx` (único consumer frontend).

## Cambios

- **src/modulos/Binnacle/Binnacle.tsx** (modified): `modulo: 'guardnews'` → `modulo: 'v3/guardnews'`. 1 file, +1/-1.

## Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S75.5: `modulo: 'guardnews'` → `GET/POST/etc` a `/api/guardnews` (legacy, ahora 404).
- Post-S75.5: `modulo: 'v3/guardnews'` → `GET/POST/etc` a `/api/v3/guardnews` (canónico v3).

Cero regresión: el `useCrud` auto-deriva la base URL con `/${modulo}`, solo cambia el path prefix. Tests pinean shape idéntico (list/create/show/update/delete con fullType=L/BIN).

- Backend path /api/guardnews: NO pineado más (404).
- Backend path /api/v3/guardnews: idéntico al legacy.
- 1 consumer frontend (Binnacle.tsx) pineá v3.

## Refs

- S75 PR #160 MERGED
- S75 HANDOFF
- Regla Mario 2026-07-23 (branches+PRs always)
- HALLAZGO-NEW-64 (base controller `_export` flow)

🤖 Generated with [Mavis](https://github.com/mariogfos)
