### PR TITLE
fix(s76.5): Guards modulo path migration a v3/guards (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Guards/Guards.tsx
+++ b/src/modulos/Guards/Guards.tsx
@@ -26,7 +26,7 @@ const paramsInitial = {
 const Guards = () => {
   const { userCan } = useAuth();
   const mod: ModCrudType = {
-    modulo: "guards",
+    modulo: "v3/guards",
     singular: "guardia",
     plural: "Guardias",
     filter: true,


### PR DESCRIPTION
# S76.5 — Guards modulo path migration a v3/guards (HALLAZGO-NEW-64 caveat)

## Contexto

S76 (PR #161) migró `GuardController` al módulo v3 (`/api/v3/guards`). El consumer admin `src/modulos/Guards/Guards.tsx` aún apunta a `modulo: "guards"` (legacy `/api/guards` ya comentado en `routes/api.php`).

S76.5 cierra el caveat con branch + PR (regla Mario 2026-07-23) — NO push directo a dev.

## Cambio

- `src/modulos/Guards/Guards.tsx:29`: `modulo: "guards"` → `modulo: "v3/guards"`.

## Compatibilidad

- Pre-S76.5: `useCrud` con `modulo: "guards"` → pegaba a `/api/guards` (legacy, ahora comentado).
- Post-S76.5: `useCrud` con `modulo: "v3/guards"` → pega a `/api/v3/guards` (S76 canónico).
- Mismo shape, mismo async export flow (`exportAsync.type: "guards"` S66 canónico).

## Patrón replicado

S72.5/S73.5/S74.5/S75.5/S76.5 (regla Mario 2026-07-23 binding, cross-project): cada sprint MME migration debe pinear su consumer frontend pre-merge catch.

Refs: S76 (PR #161), HALLAZGO-NEW-64, regla Mario 2026-07-23.