### PR TITLE
fix(s78.5): Contents modulo path migration a v3/contents (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Contents/Contents.tsx
+++ b/src/modulos/Contents/Contents.tsx
@@ -131,7 +131,7 @@ const Contents = () => {
   };
 
   const mod: ModCrudType = {
-    modulo: "contents",
+    modulo: "v3/contents",
     singular: "publicación",
     plural: "",
     permiso: "contents",


### PR DESCRIPTION
# S78.5 — Contents modulo path migration a v3/contents (HALLAZGO-NEW-64 caveat)

## Contexto

S78 (PR #163) migró `ContentController` al módulo v3 (`/api/v3/contents`). El consumer admin `src/modulos/Contents/Contents.tsx` aún apunta a `modulo: "contents"` (legacy `/api/contents` ya comentado en `routes/api.php`).

S78.5 cierra el caveat con branch + PR (regla Mario 2026-07-23).

## Cambio

- `src/modulos/Contents/Contents.tsx:134`: `modulo: "contents"` → `modulo: "v3/contents"`.

## Compatibilidad

- Pre-S78.5: `useCrud` con `modulo: "contents"` → pegaba a `/api/contents` (legacy, ahora comentado).
- Post-S78.5: `useCrud` con `modulo: "v3/contents"` → pega a `/api/v3/contents` (S78 canónico).
- Mismo shape, mismo flow de like / comments / images.

## Patrón replicado

S72.5/S73.5/S74.5/S75.5/S76.5/S78.5 (regla Mario 2026-07-23 binding, cross-project).

Refs: S78 (PR #163), HALLAZGO-NEW-64, regla Mario 2026-07-23.