### PR TITLE
fix(s79.5): Condominios modulo path migration a v3/clients (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Condominios/Condominios.tsx
+++ b/src/modulos/Condominios/Condominios.tsx
@@ -15,7 +15,7 @@ const paramsInitial = {
   searchBy: "",
 };
 const mod: ModCrudType = {
-  modulo: "clients",
+  modulo: "v3/clients",
   singular: "condominios",
   plural: "condominios",
   permiso: "condominios",


### PR DESCRIPTION
# S79.5 — Condominios modulo path migration a v3/clients (HALLAZGO-NEW-64 caveat)

## Contexto

S79 (PR #164) migró `ClientController` al módulo v3 (`/api/v3/clients`). El consumer admin `src/modulos/Condominios/Condominios.tsx` aún apunta a `modulo: "clients"` (legacy `/api/clients` ya comentado en `routes/api.php`).

S79.5 cierra el caveat con branch + PR (regla Mario 2026-07-23).

## Cambio

- `src/modulos/Condominios/Condominios.tsx:18`: `modulo: "clients"` → `modulo: "v3/clients"`.

## Compatibilidad

- Pre-S79.5: `useCrud` con `modulo: "clients"` → pegaba a `/api/clients` (legacy, ahora comentado).
- Post-S79.5: `useCrud` con `modulo: "v3/clients"` → pega a `/api/v3/clients` (S79 canónico).
- Mismo shape, mismo flow (list + delete-client + apiResource).

## Patrón replicado

S72.5/S73.5/S74.5/S75.5/S76.5/S78.5/S79.5 (regla Mario 2026-07-23 binding, cross-project).

Refs: S79 (PR #164), HALLAZGO-NEW-64, regla Mario 2026-07-23.