### PR TITLE
fix(s80.5): Areas modulo path migration a v3/areas (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Areas/Areas.tsx
+++ b/src/modulos/Areas/Areas.tsx
@@ -36,7 +36,7 @@ const Areas = () => {
   // El cambio es el mínimo: solo `export: true` → `export: false +
   // exportAsync: {...}`. La lógica de renderView/renderForm queda intacta.
   const mod = {
-    modulo: "areas",
+    modulo: "v3/areas",
     singular: "área social",
     plural: "áreas sociales",
     permiso: "areas",


### PR DESCRIPTION
# S80.5 — Areas modulo path migration a v3/areas (HALLAZGO-NEW-64 caveat)

## Contexto

S80 (PR #165) migró `AreaController` al módulo v3 (`/api/v3/areas`). El consumer admin `src/modulos/Areas/Areas.tsx` aún apunta a `modulo: "areas"` (legacy `/api/areas` ya comentado en `routes/api.php`).

S80.5 cierra el caveat con branch + PR (regla Mario 2026-07-23).

## Cambio

- `src/modulos/Areas/Areas.tsx:39`: `modulo: "areas"` → `modulo: "v3/areas"`.

## Compatibilidad

- Pre-S80.5: `useCrud` con `modulo: "areas"` → pegaba a `/api/areas` (legacy, ahora comentado).
- Post-S80.5: `useCrud` con `modulo: "v3/areas"` → pega a `/api/v3/areas` (S80 canónico).
- Mismo shape, mismo flow (statusArea + apiResource).

## Patrón replicado

S72.5/S73.5/S74.5/S75.5/S76.5/S78.5/S79.5/S80.5 (regla Mario 2026-07-23 binding, cross-project).

Refs: S80 (PR #165), HALLAZGO-NEW-64, regla Mario 2026-07-23.