### PR TITLE
fix(s81.5): Documents modulo path migration a v3/documents (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Documents/Documents.tsx
+++ b/src/modulos/Documents/Documents.tsx
@@ -18,7 +18,7 @@ const Documents = () => {
   const { setStore } = useAuth();
 
   const mod = {
-    modulo: "documents",
+    modulo: "v3/documents",
     singular: "documento",
     plural: "documentos",
     permiso: "documents",


### PR DESCRIPTION
# S81.5 — Documents modulo path migration a v3/documents (HALLAZGO-NEW-64 caveat)

## Contexto

S81 (PR #166) migró `DocumentController` al módulo v3 (`/api/v3/documents`). El consumer admin `src/modulos/Documents/Documents.tsx` aún apunta a `modulo: "documents"` (legacy `/api/documents` ya comentado en `routes/api.php`).

S81.5 cierra el caveat con branch + PR (regla Mario 2026-07-23).

## Cambio

- `src/modulos/Documents/Documents.tsx:21`: `modulo: "documents"` → `modulo: "v3/documents"`.

## Compatibilidad

- Pre-S81.5: `useCrud` con `modulo: "documents"` → pegaba a `/api/documents` (legacy, ahora comentado).
- Post-S81.5: `useCrud` con `modulo: "v3/documents"` → pega a `/api/v3/documents` (S81 canónico).
- Mismo shape, mismo flow (upload-file + apiResource).

## Patrón replicado

S72.5/S73.5/S74.5/S75.5/S76.5/S78.5/S79.5/S80.5/S81.5 (regla Mario 2026-07-23 binding, cross-project).

Refs: S81 (PR #166), HALLAZGO-NEW-64, regla Mario 2026-07-23.