### PR TITLE
fix(s83.5): Alerts modulo path migration a v3/alerts (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Alerts/Alerts.tsx
+++ b/src/modulos/Alerts/Alerts.tsx
@@ -60,7 +60,7 @@ const Alerts = () => {
   }>({});
 
   const mod = {
-    modulo: "alerts",
+    modulo: "v3/alerts",
     singular: "alerta",
     plural: "",
     permiso: "alerts",


### PR DESCRIPTION
# S83.5 — Alerts modulo path migration a v3/alerts (HALLAZGO-NEW-64 caveat)

## Contexto

S83 (PR #168) migró `AlertController` al módulo v3 (`/api/v3/alerts`). El consumer admin `src/modulos/Alerts/Alerts.tsx` aún apunta a `modulo: "alerts"` (legacy `/api/alerts` ya comentado en `routes/api.php`).

S83.5 cierra el caveat con branch + PR (regla Mario 2026-07-23).

## Cambio

- `src/modulos/Alerts/Alerts.tsx:63`: `modulo: "alerts"` → `modulo: "v3/alerts"`.

## Compatibilidad

- Pre-S83.5: `useCrud` con `modulo: "alerts"` → pegaba a `/api/alerts` (legacy, ahora comentado).
- Post-S83.5: `useCrud` con `modulo: "v3/alerts"` → pega a `/api/v3/alerts` (S83 canónico).
- Mismo shape, mismo flow (apiResource + attend custom endpoint).

## Patrón replicado

S72.5/S73.5/S74.5/S75.5/S76.5/S78.5/S79.5/S80.5/S81.5/S83.5 (regla Mario 2026-07-23 binding, cross-project).

Refs: S83 (PR #168), HALLAZGO-NEW-64, regla Mario 2026-07-23.