### PR TITLE
fix(s84.5): Users + Superadmins modulo path migration a v3/users (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Superadmins/Superadmins.tsx
+++ b/src/modulos/Superadmins/Superadmins.tsx
@@ -21,7 +21,7 @@ const Superadmins = () => {
   const { user } = useAuth();
 
   const mod: ModCrudType = {
-    modulo: "users",
+    modulo: "v3/users",
     singular: "superadmin",
     plural: "superadmins",
     permiso: "superadmins",

--- a/src/modulos/Users/Users.tsx
+++ b/src/modulos/Users/Users.tsx
@@ -26,7 +26,7 @@ const paramsInitial = {
 const Users = () => {
   const { user, userCan } = useAuth();
   const mod: ModCrudType = {
-    modulo: "users",
+    modulo: "v3/users",
     singular: "personal",
     plural: "personal administrativo",
     filter: true,


### PR DESCRIPTION
## S84.5: Users + Superadmins modulo path migration a v3/users (HALLAZGO-NEW-64 caveat)

**Sprint**: S84.5 (frontend HALLAZGO-NEW-64 caveat fix)
**Tipo**: frontend fix
**Sprint backend**: S84 ([PR #169](https://github.com/mariogfos/condaty2025-api/pull/169) pendiente merge)
**Autor**: Mavis <Mavis@makromania.local>

### Logros

- `src/modulos/Users/Users.tsx:29`: `modulo: 'users'` → `modulo: 'v3/users'`
- `src/modulos/Superadmins/Superadmins.tsx:24`: `modulo: 'users'` → `modulo: 'v3/users'`
- Branch + PR per regla Mario 2026-07-23 (binding, cross-project)
- Patrón S72.5/S73.5/S74.5/S75.5/S76.5/S78.5/S79.5/S80.5/S81.5/S83.5 replicado

### Cambios frontend (2 files, +2/-2)

- `src/modulos/Users/Users.tsx:29`: `modulo: 'users'` → `modulo: 'v3/users'`
- `src/modulos/Superadmins/Superadmins.tsx:24`: `modulo: 'users'` → `modulo: 'v3/users'`

### S84 (MME) backend

S84 (D-38-5 round 5+ MME migration): `UserController` migrado a `app/Modules/Users/Controllers/UserController.php` con routes en `app/Modules/Users/Routes/api.php` (carga auto desde `AppServiceProvider`).

Endpoints migrados:
- `GET/POST /api/adm-login` (login)
- `POST /api/adm-getpinreset`, `adm-setpassreset`, `adm-validatepin`, `adm-resetpassci`
- `POST /api/adm-register`, `adm-logout`, `adm-iam`, `adm-getpin`, `adm-setemail`, `adm-setpass`, `adm-import`, `adm-sessions`
- `DELETE /api/delete-user/{id}` (deleteUser)
- `POST /api/trust-device` (trustDevice)
- `REST /api/users` (apiResource → `/api/v3/users`)

### HALLAZGO-NEW-64 caveat (binding, cross-project)

Pre-merge catch: detecté 2 consumers admin con `modulo: 'users'`:

1. **Users.tsx** — modulo "personal administrativo" (lista full con join a client_users + roles)
2. **Superadmins.tsx** — modulo "superadmins" (lista FOS-only con fosrole_id NOT NULL + trustedDevices count)

Ambos consumen el **mismo resource `users`** (mismas URLs `/api/users` o `/api/v3/users`) pero con `fullType` y filtros diferentes. La URL del backend `/api/v3/users` retorna los mismos datos para ambos — el filtrado es frontend-side (el backend lee `fullType=L/FOS/CHAT/BOT/DET/EXIST/EXTRA`).

### Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S84.5: `modulo: 'users'` → apunta a `/api/users` (legacy, aún activo)
- Post-S84.5: `modulo: 'v3/users'` → apunta a `/api/v3/users` (nuevo módulo)
- Legacy `/api/users` sigue activo. No se rompe nada.

### Refs

S84 (PR #169 backend), S83.5 (Alerts), S82 (ClientConfig mobile-only, no .5), S81.5 (Documents), S80.5 (Areas), S79.5 (Condominios), S78.5 (Contents), S76.5 (Guards), S75.5 (Binnacle), S74.5 (Events), S73.5 (Invitations), S72.5 (UnitsTypes — primer .5 con regla 2026-07-23), HALLAZGO-NEW-64, regla Mario 2026-07-23.
