### PR TITLE
fix(s85.5): Dptos modulo path migration a v3/dptos (HALLAZGO-NEW-64 caveat)

### DIFF
--- a/src/modulos/Dptos/Dptos.tsx
+++ b/src/modulos/Dptos/Dptos.tsx
@@ -108,7 +108,7 @@ const Dptos = () => {
   }, []);
 
   const mod: ModCrudType = {
-    modulo: "dptos",
+    modulo: "v3/dptos",
     singular: "",
     plural: "",
     filter: true,


### PR DESCRIPTION
## S85.5: Dptos modulo path migration a v3/dptos (HALLAZGO-NEW-64 caveat)

**Sprint**: S85.5 (frontend HALLAZGO-NEW-64 caveat fix)
**Tipo**: frontend fix
**Sprint backend**: S85 ([PR #170](https://github.com/mariogfos/condaty2025-api/pull/170) pendiente merge)
**Autor**: Mavis <Mavis@makromania.local>

### Logros

- `src/modulos/Dptos/Dptos.tsx:111`: `modulo: 'dptos'` → `modulo: 'v3/dptos'`
- Branch + PR per regla Mario 2026-07-23 (binding, cross-project)
- Patrón S72.5/S73.5/S74.5/S75.5/S76.5/S78.5/S79.5/S80.5/S81.5/S83.5/S84.5 replicado

### Cambios frontend (1 file, +1/-1)

- `src/modulos/Dptos/Dptos.tsx:111`: `modulo: 'dptos'` → `modulo: 'v3/dptos'`

### S85 (MME) backend

S85 (D-38-5 round 5+ MME migration): `DptoController` (1343 LOC, xlarge — **el MÁS grande del refactor**) migrado a `app/Modules/HomeOwner/Controllers/DptoController.php` con routes en `app/Modules/HomeOwner/Routes/api.php` (carga auto desde `AppServiceProvider`).

Endpoints migrados:
- `REST /api/v3/dptos` (apiResource → 5 routes)
- `POST /api/v3/dptos-change-titular` (changeTitular)
- `POST /api/v3/dptos-change-manager` (changeManager)
- `POST /api/v3/dptos-remove-titular` (removeTitular)
- `POST /api/v3/dptos-change-owner` (changeOwner)
- `POST /api/v3/dptos-release-owner` (releaseOwner)
- `POST /api/v3/dptos-process-excel-references` (processExcelReferences)

### HALLAZGO-NEW-64 caveat (binding, cross-project)

Pre-merge catch: detecté **1 consumer admin** con `modulo: 'dptos'`:

1. **Dptos.tsx** — modulo "unidades" (lista full con join a homeowners + tenants + types + field_values + dpto_owners + deuda).

Dptos.tsx es el **ÚNICO consumer admin** del resource dptos (no hay duplicados como en S84 Users/Superadmins).

### Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S85.5: `modulo: 'dptos'` → apunta a `/api/dptos` (legacy, aún activo)
- Post-S85.5: `modulo: 'v3/dptos'` → apunta a `/api/v3/dptos` (nuevo módulo)
- Legacy `/api/dptos` sigue activo. No se rompe nada.

### Refs

S85 (PR #170 backend), S84.5 (Users + Superadmins), S83.5 (Alerts), S82 (ClientConfig mobile-only, no .5), S81.5 (Documents), S80.5 (Areas), S79.5 (Condominios), S78.5 (Contents), S76.5 (Guards), S75.5 (Binnacle), S74.5 (Events), S73.5 (Invitations), S72.5 (UnitsTypes — primer .5 con regla 2026-07-23), HALLAZGO-NEW-64, regla Mario 2026-07-23.
