### PR TITLE
fix(s86.5): remove partial-payments submenu (HALLAZGO-NEW-65 — unificación ingresos)

### DIFF
--- a/src/components/MainMenu/mainMenuConfig.ts
+++ b/src/components/MainMenu/mainMenuConfig.ts
@@ -83,11 +83,6 @@ export const menuConfig: MenuConfigItem[] = [
         labelKey: "bankAccounts",
         perm: "bank_accounts",
       },
-      {
-        href: "/partial-payments",
-        labelKey: "partialPayments",
-        perm: "bank_accounts",
-      },
       // {
       //   href: "/bank-provider-tester",
       //   labelKey: "bankTester",


### PR DESCRIPTION
## S86.5: Remove partial-payments submenu (HALLAZGO-NEW-65 — unificación ingresos)

**Sprint**: S86.5 (frontend cleanup post-payment flow unification)
**Tipo**: frontend cleanup
**Sprint backend**: S86 ([PR #171](https://github.com/mariogfos/condaty2025-api/pull/171) pendiente merge)
**Autor**: Mavis <Mavis@makromania.local>

### Logros

- `src/app/partial-payments/page.tsx` **borrado** (era placeholder que devolvía `null`).
- `src/components/MainMenu/mainMenuConfig.ts`: item `partialPayments` eliminado del dropdown `Finanzas`. Solo queda el submenu `Ingresos` (que apunta a `/payments` → `/api/v3/payments`) como Mario pidió.
- Branch + PR per regla Mario 2026-07-23 (binding, cross-project).
- i18n keys (`partialPayments` en es/pt/en) pineados en `messages.ts` por convención — quedan huérfanos pero no afectan funcionalidad. Se pueden limpiar en sprint aparte si se quiere.

### Cambios frontend (1 file modified + 1 file deleted, -10 LOC)

- `D src/app/partial-payments/page.tsx` (5 líneas eliminadas, devolvía `null`).
- `M src/components/MainMenu/mainMenuConfig.ts` (5 líneas eliminadas, item del menu).

### HALLAZGO-NEW-65 (binding, cross-project, 2026-07-24)

Menú Finanzas admin tenía 2 submenús que se solapaban funcionalmente:
1. **Ingresos** (`/payments` → `/api/v3/payments`) — flujo unificado canónico.
2. **Pagos parciales** (`/partial-payments` → placeholder que devolvía `null`) — legacy.

Mario pidió que solo quede **Ingresos** porque el flujo unificado (S86 backend) ya cubre ambos casos (pago total + pago parcial) con cascade automática + flag `create_expense` inline + `DIRECT_INCOME` sin deudas.

**Patrón replicable**: cuando un módulo legacy queda pineado como placeholder (return null), evaluar si eliminarlo del menu + ruta. Frontend: `src/app/<legacy>/page.tsx` + `mainMenuConfig.ts`. Backend: `app/Http/Controllers/<Legacy>Controller.php` + `routes/api.php`.

### Compatibilidad (R-PKG-016, ZERO BC break)

- Pre-S86.5: submenú "Pagos parciales" visible en menu Finanzas (no funcionaba — devolvía null).
- Post-S86.5: solo submenú "Ingresos" visible. Menos confusión, mismo flujo.

### Refs

S86 (PR #171 backend), S85 Dpto MME, S83-S84 Phase 3 MME, S68 MasiveController refactor, regla Mario 2026-07-23.
