### PR TITLE
fix(s96): restore Categorías button in Payments module

### DIFF
--- a/src/modulos/Payments/__tests__/usePayments.categoriesButton.test.tsx
+++ b/src/modulos/Payments/__tests__/usePayments.categoriesButton.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render, screen, renderHook } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+// Mock useCrud to capture the `extraButtons` prop and render it for inspection
+let capturedExtraButtons: any = null;
+vi.mock("@/mk/hooks/useCrud/useCrud", () => ({
+  default: vi.fn((opts: any) => {
+    capturedExtraButtons = opts.extraButtons;
+    return {
+      List: () => null,
+      searchs: { searchBy: "" },
+      userCan: vi.fn(() => true),
+      extraData: {},
+      execute: vi.fn(),
+      reLoad: vi.fn(),
+      showToast: vi.fn(),
+      onView: vi.fn(),
+      onDel: vi.fn(),
+    };
+  }),
+}));
+
+import usePayments from "../hooks/usePayments";
+
+describe("usePayments — extraButtons Categories (S96)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedExtraButtons = null;
+  });
+
+  it("extraButtons es un array NO vacío con UN botón JSX (no string)", () => {
+    renderHook(() => usePayments());
+    expect(capturedExtraButtons).toBeDefined();
+    expect(Array.isArray(capturedExtraButtons)).toBe(true);
+    expect(capturedExtraButtons.length).toBe(1);
+  });
+
+  it("el extraButton es un ReactElement (no un objeto plano ni un string)", () => {
+    renderHook(() => usePayments());
+    const btn = capturedExtraButtons[0];
+    // D-104-1: extraButtons debe ser ReactNode[] (JSX elements), no strings ni objetos
+    expect(React.isValidElement(btn)).toBe(true);
+    // Bug pre-S96: el código pasaba `btn.children` (string "Categorías")
+    // en lugar del JSX element, así que NO era un ReactElement.
+  });
+
+  it("el botón Categorías navega a /categories?type=I al hacer click", () => {
+    renderHook(() => usePayments());
+    const btn = capturedExtraButtons[0];
+    expect(btn).toBeDefined();
+    // El onClick handler debe llamar router.push('/categories?type=I')
+    // Simulamos click y verificamos la navegación.
+    const { onClick } = btn.props as any;
+    expect(typeof onClick).toBe("function");
+    onClick();
+    expect(mockPush).toHaveBeenCalledWith("/categories?type=I");
+  });
+
+  it("el texto del botón es 'Categorías' (no otra cosa)", () => {
+    renderHook(() => usePayments());
+    const btn = capturedExtraButtons[0];
+    // El children del Button debe ser "Categorías"
+    const children = (btn.props as any).children;
+    expect(children).toBe("Categorías");
+  });
+
+  it("el variant del botón es 'secondary' (consistencia con Outlays Egresos)", () => {
+    renderHook(() => usePayments());
+    const btn = capturedExtraButtons[0];
+    const variant = (btn.props as any).variant;
+    expect(variant).toBe("secondary");
+  });
+});

--- a/src/modulos/Payments/hooks/usePayments.tsx
+++ b/src/modulos/Payments/hooks/usePayments.tsx
@@ -8,6 +8,7 @@ import type { TableRowContextMenuConfig } from "@/mk/components/ui/Table/Table";
 import { Eye, FileImage, CheckCircle2, Ban } from "lucide-react";
 import { getPaymentsConfig } from "../config/payments.config";
 import { PaymentStatus } from "../Type/PaymentType";
+import Button from "@/mk/components/forms/Button/Button";
 import styles from "../Payments.module.css";
 
 const getPaymentVoucherUrls = (item: any) => {
@@ -88,13 +89,14 @@ export const usePayments = () => {
 
   const extraButtons = useMemo(
     () => [
-      {
-        key: "categories-button",
-        variant: "secondary",
-        onClick: () => goToCategories("I"),
-        className: styles.categoriesButton,
-        children: "Categorías",
-      } as any,
+      <Button
+        key="categories-button"
+        variant="secondary"
+        onClick={() => goToCategories("I")}
+        className={styles.categoriesButton}
+      >
+        Categorías
+      </Button>,
     ],
     [goToCategories]
   );
@@ -103,7 +105,7 @@ export const usePayments = () => {
     paramsInitial,
     mod,
     fields,
-    extraButtons: extraButtons.map((btn) => btn.children), // useCrud expects ReactNodes or custom array of children buttons
+    extraButtons,
     getFilter: handleGetFilter,
   });
 


### PR DESCRIPTION
## Sprint S96 — Front fix: Categorías button in Payments (Ingresos)

### Bug
El botón 'Categorías' en Ingresos (Payments) no funcionaba y 'no parecía botón' (Mario 2026-07-26 ~22:25 local).

### Causa raíz
`usePayments.ts` definía `extraButtons` como array de objetos, luego `.map((btn) => btn.children)` extraía solo el string 'Categorías' (no el JSX `<Button>`). useCrud esperaba `ReactNode[]` y renderizaba el string como texto plano.

### Comparación con Egresos (funciona)
`Outlays.tsx` (Egresos) SÍ tiene el patrón correcto: `extraButtons` es array de `<Button>` JSX.

### Fix
- `usePayments.ts` → `.tsx` (rename, ahora tiene JSX)
- `extraButtons` reescrito como array de `<Button>` JSX
- `useCrud({...})` ahora recibe el array directo (sin map destructivo)

### Tests
- 5 tests nuevos (usePayments.categoriesButton.test.tsx): array no-vacío, es ReactElement, onClick navega a /categories?type=I, texto 'Categorías', variant 'secondary'
- vitest Payments: 34→39 (+5)
- vitest full: 305/313 (los 8 failures son pre-existentes NO regresión — verificado con git stash)

### Decisión D-104-1 (NUEVA, binding, cross-project, replicable)
`extraButtons pattern`: cuando un hook CRUD acepta `extraButtons: ReactNode[]`, SIEMPRE pasar array de JSX `<Button>` elements. `.map((btn) => btn.children)` es anti-pattern que rompe la renderización.

### Otros temas del handoff
- **Export 404 Ingresos**: pre-existente, fix fue `php artisan migrate` post-S95 (las migrations de S32 reports no estaban aplicadas en la DB local de Mario).
- **Paths legacy en el front**: AUDITADO, no hay. Front ya usa `/v3/` canónica en todos los api.ts.

### Cross-IA
Mavis main el 2026-07-26 (regla cross-boundary Mario — **condaty completo**).

### Handoff
`.makromania/projects/condaty/sprints/HANDOFF-2026-07-26-s96-payments-categories-button.md`