### PR TITLE
fix(s103): front modulo y URLs legacy → v3/ + VisitReasons dead pin

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 NEXT_PUBLIC_APP_NAME ="Condaty Admin"
 NEXT_PUBLIC_APP_DESCRIPTION ="Admin - Control de Accesos"
 NEXT_PUBLIC_APP_LOGO ="/assets/images/logo/logo.svg"
-NEXT_PUBLIC_API_URL="https://phplaravel-1214481-5270819.cloudwaysapps.com/api"
+NEXT_PUBLIC_API_URL="http://127.0.0.1:8000/api"
 NEXT_PUBLIC_APP_LOGIN_USER ="eMail"
 NEXT_PUBLIC_APP_LOGIN_PASS ="Password"
 NEXT_PUBLIC_AUTH_LOGIN ="/adm-login"

--- a/src/components/ActiveOwner/ActiveOwner.tsx
+++ b/src/components/ActiveOwner/ActiveOwner.tsx
@@ -30,7 +30,7 @@ const ActiveOwner = ({
   // W:En espera
 
   const { data: dptos, execute } = useAxios(
-    "/dptos",
+    "/v3/dptos",
     "GET",
     {
       page: 1,

--- a/src/components/MainMenu/mainMenuConfig.ts
+++ b/src/components/MainMenu/mainMenuConfig.ts
@@ -54,11 +54,10 @@ export const menuConfig: MenuConfigItem[] = [
       { href: "/invitations", perm: "campanas", labelKey: "qrInvitations" },
       { href: "/uploads", perm: "cargamasiva", labelKey: "bulkUpload" },
       { href: "/app-versions", perm: "superadmins", labelKey: "appVersions" },
-      {
-        href: "/visit-reasons",
-        perm: "visit_reasons",
-        labelKey: "Motivos de visitas",
-      },
+      // S103: VisitReasons removido del menú — feature dead (permiso "" en el
+      // módulo + endpoint /api/v3/visit-reasons nunca existió en el back).
+      // La página /visit-reasons queda huérfana (próximo sprint: borrarla junto
+      // al módulo src/modulos/VisitReasons/ si Mario confirma dead permanente).
     ],
   },
   {

--- a/src/modulos/Activities/QrTab/QrTab.tsx
+++ b/src/modulos/Activities/QrTab/QrTab.tsx
@@ -25,7 +25,7 @@ const QRTab: React.FC<QRTabProps> = ({ paramsInitial, onRowClick }) => {
   // Definición del módulo QR
   const modQR: ModCrudType = useMemo(() => {
     return {
-      modulo: "invitations",
+      modulo: "v3/invitations",
       singular: "Invitación",
       plural: "Invitaciones QR",
       filter: true,

--- a/src/modulos/DashDptos/DashDptos.tsx
+++ b/src/modulos/DashDptos/DashDptos.tsx
@@ -58,7 +58,7 @@ const DashDptos = ({ id }: DashDptosProps) => {
     reLoad,
     execute,
     loaded,
-  } = useAxios("/dptos", "GET", {
+  } = useAxios("/v3/dptos", "GET", {
     fullType: "DET",
     dpto_id: id,
     extraData: true,
@@ -134,7 +134,7 @@ const DashDptos = ({ id }: DashDptosProps) => {
       };
 
       const { data: response } = await execute(
-        "/dptos-change-owner",
+        "/v3/dptos-change-owner",
         "POST",
         payload,
       );
@@ -183,7 +183,7 @@ const DashDptos = ({ id }: DashDptosProps) => {
     }
   };
   const onDel = async () => {
-    const { data } = await execute("/dptos/" + datas.data.id, "DELETE");
+    const { data } = await execute("/v3/dptos/" + datas.data.id, "DELETE");
     if (data?.success) {
       showToast("Unidad eliminada", "success");
       router.push("/units");
@@ -233,7 +233,7 @@ const DashDptos = ({ id }: DashDptosProps) => {
         type: currentRemovalType,
       };
 
-      const { data } = await execute("/dptos-release-owner", "POST", payload);
+      const { data } = await execute("/v3/dptos-release-owner", "POST", payload);
 
       if (data?.success) {
         showToast(

--- a/src/modulos/DashDptos/UnitInfo/UnitInfo.tsx
+++ b/src/modulos/DashDptos/UnitInfo/UnitInfo.tsx
@@ -108,7 +108,7 @@ const UnitInfo = ({
     }
 
     try {
-      const { data } = await execute("/dptos-change-titular", "POST", {
+      const { data } = await execute("/v3/dptos-change-titular", "POST", {
         dpto_id: dptoId,
         holder,
       });
@@ -141,7 +141,7 @@ const UnitInfo = ({
     }
 
     try {
-      const { data } = await execute("/dptos-release-owner", "POST", {
+      const { data } = await execute("/v3/dptos-release-owner", "POST", {
         dpto_id: dptoId,
         owner_id: ownerId,
         type: "H",

--- a/src/modulos/HomeOwners/HomeOwners.tsx
+++ b/src/modulos/HomeOwners/HomeOwners.tsx
@@ -78,7 +78,7 @@ const HomeOwners = () => {
   };
 
   const mod: ModCrudType = {
-    modulo: "homeowners",
+    modulo: "v3/homeowners",
     singular: "Propietario",
     plural: "Propietarios",
     permiso: "owners",

--- a/src/modulos/Owners/Owners.tsx
+++ b/src/modulos/Owners/Owners.tsx
@@ -92,7 +92,7 @@ const Owners = () => {
   };
 
   const mod: ModCrudType = {
-    modulo: "owners",
+    modulo: "v3/owners",
     singular: "Residente",
     plural: "Residentes",
     filter: true,

--- a/src/modulos/Reservas/Reserva.tsx
+++ b/src/modulos/Reservas/Reserva.tsx
@@ -28,7 +28,7 @@ import {
 import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
 
 const mod = {
-  modulo: "reservations",
+  modulo: "v3/reservations",
   singular: "reserva",
   plural: "reservas",
   permiso: "reservations",

--- a/src/modulos/Reservas/ReservaPending.tsx
+++ b/src/modulos/Reservas/ReservaPending.tsx
@@ -15,7 +15,7 @@ import { ReservationStatus } from "./constants/reservationConstants";
 
 // --- Definición del Módulo (Ajusta singular/plural si quieres) ---
 const mod = {
-  modulo: "reservations",
+  modulo: "v3/reservations",
   singular: "Reserva Pendiente", // Cambiado para claridad
   plural: "Reservas Pendientes", // Cambiado para claridad
   permiso: "reservations", // Asegúrate que el permiso sea correcto

--- a/src/modulos/Surveys/config/surveys.config.tsx
+++ b/src/modulos/Surveys/config/surveys.config.tsx
@@ -20,7 +20,7 @@ export const getSurveyConfig = (
   onCloseView?: () => void,
 ): { mod: ModCrudType; fields: any } => {
   const mod: ModCrudType = {
-    modulo: "surveys",
+    modulo: "v3/surveys",
     singular: "Encuesta",
     plural: "Encuestas",
     titleAdd: "Crear",

--- a/src/modulos/VisitReasons/VisitReasons.tsx
+++ b/src/modulos/VisitReasons/VisitReasons.tsx
@@ -1,57 +1,21 @@
 "use client";
-import useCrud from "@/mk/hooks/useCrud/useCrud";
+// S103: VisitReasons es feature DEAD — el backend nunca expuso
+// `/api/v3/visit-reasons` (verificado con `php artisan route:list` el 2026-07-27).
+// El módulo tenía `permiso: ""` y siempre mostraba NotAccess; el entry del menú
+// Backoffice se removió en S103 (mainMenuConfig.ts). La página
+// /visit-reasons queda huérfana (próximo sprint: borrarla si Mario confirma).
+//
+// Pin: este placeholder documenta el estado y previene que cualquier reactivador
+// futuro restaure el módulo sin haberse asegurado primero de que el back tiene
+// los endpoints. Para reactivar:
+//   1. Crear `app/Modules/VisitReasons/Controllers/VisitReasonController.php` en
+//      el back y registrarlo en routes/api.php como `/api/v3/visit-reasons`.
+//   2. Restaurar el entry del menú en mainMenuConfig.ts.
+//   3. Reemplazar este componente con la implementación real (useCrud).
 import NotAccess from "@/components/auth/NotAccess/NotAccess";
-import { useEffect, useMemo } from "react";
-import { useAuth } from "@/mk/contexts/AuthProvider";
-
-const mod = {
-  modulo: "visit-reasons",
-  singular: "Motivo de visita",
-  plural: "Motivos de visitas",
-  permiso: "", //"visit_reasons",
-  extraData: false,
-  // renderForm: RenderForm,
-  // renderView: (props: any) => <RenderView {...props} />,
-  loadView: { fullType: "DET" },
-};
-
-const paramsInitial = {
-  perPage: 20,
-  page: 1,
-  fullType: "L",
-  searchBy: "",
-  _debug: 2,
-};
 
 const VisitReasons = () => {
-  const fields = useMemo(() => {
-    return {
-      id: { rules: [], api: "e" },
-      name: {
-        rules: ["required"],
-        api: "ae",
-        label: "Nombre",
-        form: { type: "text" },
-        list: true,
-      },
-    };
-  }, []);
-
-  const { setStore, store } = useAuth();
-
-  useEffect(() => {
-    setStore({ ...store, title: "Motivos de visitas" });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const { userCan, List } = useCrud({
-    paramsInitial,
-    mod,
-    fields,
-  });
-
-  if (!userCan(mod.permiso, "R")) return <NotAccess />;
-  return <List height={"100%"} />;
+  return <NotAccess />;
 };
 
 export default VisitReasons;


### PR DESCRIPTION
# Sprint S103 — Front: modulo + URLs legacy → v3/ + VisitReasons dead pin

## Resumen

S103 cierra el pendiente del audit URLs legacy del front. **7 endpoints del admin pegaban 404 silencioso** porque `useCrud` construía URLs como `/${modulo}` sin prefijo `v3/`. El back solo expone `/api/v3/*`. Adicionalmente, `VisitReasons` era una feature dead que el menú seguía mostrando.

## Diagnóstico

`useCrud` (hook central del admin) usa `modulo: "X"` para construir `/${modulo}` y terminar pegando a `/api/X`. El back solo expone `/api/v3/X`. Audit cross-archivo: `php artisan route:list --path=api | grep -E 'dptos|owners|homeowners|reservations|surveys|invitations'` confirmó que **todos** los endpoints canónicos están en `/api/v3/`.

## Cambios

### A) 6 archivos `modulo:` → prefijo v3/ (R-PKG-016 sweep)

| Archivo | Antes | Después |
|---|---|---|
| `src/modulos/Owners/Owners.tsx` | `modulo: "owners"` | `modulo: "v3/owners"` |
| `src/modulos/HomeOwners/HomeOwners.tsx` | `modulo: "homeowners"` | `modulo: "v3/homeowners"` |
| `src/modulos/Reservas/Reserva.tsx` | `modulo: "reservations"` | `modulo: "v3/reservations"` |
| `src/modulos/Reservas/ReservaPending.tsx` | `modulo: "reservations"` | `modulo: "v3/reservations"` |
| `src/modulos/Surveys/config/surveys.config.tsx` | `modulo: "surveys"` | `modulo: "v3/surveys"` |
| `src/modulos/Activities/QrTab/QrTab.tsx` | `modulo: "invitations"` | `modulo: "v3/invitations"` |

### B) URLs axios directo → prefijo v3/ (4 archivos)

- `src/modulos/DashDptos/DashDptos.tsx`: 4 URLs (`/dptos`, `/dptos/{id}` DELETE, `/dptos-change-owner`, `/dptos-release-owner`)
- `src/modulos/DashDptos/UnitInfo/UnitInfo.tsx`: 2 URLs (`/dptos-change-titular`, `/dptos-release-owner`)
- `src/components/ActiveOwner/ActiveOwner.tsx`: `/dptos`

### C) VisitReasons: feature dead pin

`modulo: "visit-reasons"` no tiene endpoint en el back (verificado `php artisan route:list | grep visit-reasons` → vacío). El módulo tenía `permiso: ""` y siempre mostraba NotAccess.

- `src/components/MainMenu/mainMenuConfig.ts`: removido el entry del menú Backoffice.
- `src/modulos/VisitReasons/VisitReasons.tsx`: pineado a NotAccess con docstring que documenta el estado dead + 3 pasos para reactivar (back controller + routes/api.php + restaurar entry del menú + reemplazar placeholder).

La página huérfana `src/app/visit-reasons/page.tsx` queda pendiente de remoción (sprint futuro si Mario confirma dead permanente).

## Tests

- `vitest run` (Owners, HomeOwners, Reservas, Surveys, Activities): **14/14 passing**
- `vitest run src/modulos/DashDptos src/components/ActiveOwner`: **28/28 passing**
- 8 tests pre-existentes fallan (`useAsyncExport` + `AssemblyStatusActions`) — no introducidos por S103. Verificado corriendo antes y después.
- `tsc --noEmit`: solo errores pre-existentes en `src/modulos/Reports/__tests__/reportPresets.test.ts`. NO introducidos por S103.

## Pendiente cross-project (no bloqueante)

1. **HALLAZGO-NEW-17** (prod hotfix perdido) — Mario pendiente de source o "marcar como perdida".
2. Reducir la página huérfana `/visit-reasons` (sprint futuro si Mario confirma dead).
3. `/dptos-export-deudas` en Dptos.tsx console.log — endpoint no existe en `/v3/`. Probablemente `/v3/debt-dptos/dptos-debts` (verificar).
4. Pinear test de regresión para los 4 endpoints custom actions (`/dptos-change-owner`, `/dptos-release-owner`, `/dptos-change-titular`) que NO encajan en REST canónico.

## Refs

- HALLAZGO-NEW-03 (source-parsing pattern, binding cross-project)
- R-PKG-016 (rename + sweep pattern)
- D-102-1 (BC layer promise, legacy alias en `routes/api.php`)
- S41 (Outlays como alias canónico de `v3/expenses`)
- S95 (legacy routing aliases agregados)
- S97 (legacy `/api/assemblies` alias)
- S102 (auth redirect 500→401 JSON)
- `HANDOFF-2026-07-27-s103-legacy-urls-audit.md` (audit original)
- `HANDOFF-2026-07-27-s103-frontend-fix.md` (este sprint)

## Cross-IA

Mavis main el 2026-07-27 (regla cross-boundary Mario "tu harás todo").
