### PR TITLE
fix(s113): useAsyncExport pino baseURL + Bearer token (404 → 200)

### DIFF
--- a/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
+++ b/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
@@ -1,0 +1,65 @@
+/**
+ * S113 — Pin de regresión para el bug "ningún export funciona en ningún módulo".
+ *
+ * Historia del bug (2026-07-27, Mario):
+ *   `useAsyncExport.ts` pineá `fetch(\`/api/v3/reports/${type}/export\`)`
+ *   con RUTA RELATIVA. El navegador la resuelve contra `window.location.origin`
+ *   (el front en :3000), no contra el back en :8000. Resultado: 404 en
+ *   TODOS los exports async (useAsyncExport es el flow canónico de S32/S66.5).
+ *
+ * HALLAZGO-NEW-21 (binding, cross-project): cualquier `fetch()` que pineá
+ * una URL del BACK debe usar el baseURL del back (`process.env.NEXT_PUBLIC_API_URL`),
+ * no ruta relativa. Las rutas relativas OK son las que pinean proxies Next.js
+ * (`/api/translate`, `/api/cloudinary-upload`) o paths internos del front.
+ *
+ * HALLAZGO-NEW-03 (binding cross-project): source-parsing pinea INTENCIÓN.
+ * Si alguien pineá restaurar fetch("/api/v3/reports/...") o quita el
+ * `Authorization: Bearer`, el test falla con mensaje claro.
+ *
+ * Cross-IA: Mavis main el 2026-07-27.
+ * Refs: S32 (NEW-NEW-43 reports async), S66.5 (exportAsync slot),
+ *       S103, S111, S112, S113 (este sprint).
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const FRONT_ROOT = path.resolve(__dirname, "..", "..", "..", "..", "..");
+const HOOK_PATH = path.join(
+  FRONT_ROOT,
+  "src/mk/hooks/useAsyncExport/useAsyncExport.ts",
+);
+
+describe("S113 — useAsyncExport baseURL + auth pin", () => {
+  it("useAsyncExport.ts NO usa ruta relativa /api/v3/reports/ (pineaba 404 al front)", () => {
+    const src = fs.readFileSync(HOOK_PATH, "utf8");
+    // El bug original pineá `fetch(\`/api/v3/reports/${type}\`)` que se
+    // resolvía contra el front (:3000), no contra el back (:8000).
+    // S113 fix pineá \`${API_BASE_URL}/reports/${type}\` con baseURL del back.
+    expect(src).not.toMatch(/fetch\([^)]*`\/api\/v3\/reports\//);
+  });
+
+  it("useAsyncExport.ts pinea API_BASE_URL desde NEXT_PUBLIC_API_URL", () => {
+    const src = fs.readFileSync(HOOK_PATH, "utf8");
+    // El fix pineá:
+    //   const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
+    // para construir URLs absolutas al back.
+    expect(src).toMatch(/API_BASE_URL\s*=/);
+    expect(src).toMatch(/NEXT_PUBLIC_API_URL/);
+  });
+
+  it("useAsyncExport.ts pinea el token Bearer para auth (no rompe Sanctum)", () => {
+    const src = fs.readFileSync(HOOK_PATH, "utf8");
+    // Sin el token, el back retorna 401 (Sanctum requiere Authorization
+    // header con Bearer <token> del personal_access_token).
+    expect(src).toMatch(/Authorization:\s*[`"]Bearer\s+\$\{getAuthToken\(\)\}[`"]/);
+    expect(src).toMatch(/getAuthToken\s*\(/);
+  });
+
+  it("useAsyncExport.ts usa credentials: 'include' (CORS cross-domain)", () => {
+    const src = fs.readFileSync(HOOK_PATH, "utf8");
+    // El back pinea supports_credentials: true en CORS. El front debe
+    // pinear credentials: 'include' para enviar cookies cross-domain.
+    expect(src).toMatch(/credentials:\s*['"]include['"]/);
+  });
+});

--- a/src/mk/hooks/useAsyncExport/useAsyncExport.ts
+++ b/src/mk/hooks/useAsyncExport/useAsyncExport.ts
@@ -4,6 +4,34 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import useToast from "../useToast";
 
 /**
+ * S113: el bug original pineaba `fetch("/api/v3/reports/...")` con RUTA
+ * RELATIVA — el navegador la resolvía contra `window.location.origin` (el
+ * front en :3000), no contra el back en :8000. Resultado: 404 silencioso
+ * en TODOS los exports. El fix pinea el baseURL via
+ * `process.env.NEXT_PUBLIC_API_URL` + replica el patrón del token del
+ * localStorage que el axiosInterceptors pinea.
+ */
+const API_BASE_URL =
+  (typeof process !== "undefined" && process.env.NEXT_PUBLIC_API_URL) || "";
+
+/**
+ * Lee el token de localStorage pineado por el flow de auth.
+ * Replica el patrón de `src/mk/interceptors/axiosInterceptors.tsx`.
+ * Retorna null si no hay token (caller decide cómo manejar).
+ */
+const getAuthToken = (): string | null => {
+  try {
+    const raw = localStorage.getItem(
+      (process.env.NEXT_PUBLIC_AUTH_IAM as string) + "token"
+    );
+    if (!raw) return null;
+    return JSON.parse(raw + "").token ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
  * useAsyncExport (S33 — NEW-NEW-43 PDF Reports Async + Chunking)
  *
  * Hook que pineá el flow async de export PDF introducido en S32:
@@ -112,9 +140,13 @@ export function useAsyncExport(
   const pollStatus = useCallback(
     async (jobId: string) => {
       try {
-        const res = await fetch(`/api/v3/reports/${jobId}/status`, {
+        const res = await fetch(`${API_BASE_URL}/reports/${jobId}/status`, {
           method: "GET",
-          headers: { Accept: "application/json" },
+          headers: {
+            Accept: "application/json",
+            ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),
+          },
+          credentials: "include",
         });
 
         if (res.status === 404) {
@@ -197,12 +229,14 @@ export function useAsyncExport(
       });
 
       try {
-        const res = await fetch(`/api/v3/reports/${type}/export`, {
+        const res = await fetch(`${API_BASE_URL}/reports/${type}/export`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
             Accept: "application/json",
+            ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),
           },
+          credentials: "include",
           body: JSON.stringify(params ?? {}),
         });
 


### PR DESCRIPTION
# Sprint S113 — Fix useAsyncExport 404 (ruta relativa → baseURL + Bearer)

## Resumen

Mario reportó bug cross-cutting: **"ningún export funciona en ningún módulo, sale Error 404 al encolar el reporte"**. Identifiqué el bug: `useAsyncExport.ts` pineá `fetch(\`/api/v3/reports/${type}/export\`)` con **ruta relativa** que el navegador resuelve contra `window.location.origin` (el front en :3000), no contra el back en :8000. Resultado: 404 silencioso en TODOS los exports async.

S113 lo corrige pineando el baseURL del back + replicando el patrón de token del localStorage que el `axiosInterceptors` ya pineá para axios.

## Diagnóstico

`src/mk/hooks/useAsyncExport/useAsyncExport.ts` (líneas 115 y 200) pineá:

```ts
const res = await fetch(`/api/v3/reports/${type}/export`, { ... });
```

Como la URL es relativa, el navegador concatena con `window.location.origin` que es `http://localhost:3000` (el front Next.js, no el back en :8000). El front Next.js no tiene esa ruta → 404.

Las otras 2 rutas de `fetch` en el front SÍ funcionan porque son proxies Next.js (`route.ts` en `src/app/api/translate` y `src/app/api/cloudinary-upload`).

## HALLAZGO-NEW-21 (binding, cross-project)

Cualquier `fetch()` que pineá una URL del BACK debe usar el baseURL del back (`process.env.NEXT_PUBLIC_API_URL`), no ruta relativa. Las rutas relativas OK son las que pinean proxies Next.js o paths internos del front.

## Cambios

### `src/mk/hooks/useAsyncExport/useAsyncExport.ts`
- Helper `API_BASE_URL` desde `process.env.NEXT_PUBLIC_API_URL`.
- Helper `getAuthToken()` que replica el patrón del localStorage de `src/mk/interceptors/axiosInterceptors.tsx` (que pineá el token Sanctum en axios).
- Las 2 URLs (start + pollStatus) pinean `${API_BASE_URL}/reports/...` en vez de `/api/v3/reports/...`.
- Headers `Authorization: Bearer ${getAuthToken()}` cuando hay token.
- `credentials: 'include'` para CORS cross-domain (back pinea `supports_credentials: true`).

La línea 280 (`fetch(state.downloadUrl)`) NO se tocó — el `downloadUrl` ya es absoluto (viene del back vía `buildAcceptedResponse`).

## Test pin (HALLAZGO-NEW-03 pattern)

`src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts` — **4 tests source-parsing**:

1. `useAsyncExport.ts` NO contiene `fetch(.../api/v3/reports/...)` (ruta relativa pineá 404 — bug original)
2. `useAsyncExport.ts` pinea `API_BASE_URL` desde `NEXT_PUBLIC_API_URL`
3. `useAsyncExport.ts` pinea `Authorization: Bearer ${getAuthToken()}`
4. `useAsyncExport.ts` pinea `credentials: 'include'` (CORS cross-domain)

## Tests

- `vitest run src/mk/hooks/useAsyncExport/__tests__/S113...`: **4/4 passing**
- `tsc --noEmit`: 0 nuevos errores en `useAsyncExport.ts`

## Pendiente (debug paralelo)

Bug "estado desconocido en egresos" — separado, requiere que Mario describa:
- Qué campo exactamente muestra "estado desconocido"
- Si el bug es de **datos** (el back retorna un valor que la UI no reconoce) o de **UI** (el helper `isUnitInDefault()` o similar no pineá un valor)

Posible causa: el endpoint `/v3/debt-groups` (canónico, pineado en S112) retorna campos con valores que la UI no pineá en su enum.

## Refs

- HALLAZGO-NEW-03 (source-parsing pattern, binding cross-project)
- HALLAZGO-NEW-21 (fetch URL pino baseURL back, S113)
- S32 (NEW-NEW-43 reports async)
- S66.5 (exportAsync slot pineado en useCrud)
- S103, S111, S112 (sprints previos)
- S113 (este sprint)

## Cross-IA

Mavis main el 2026-07-27 (regla cross-boundary Mario "tu harás todo").
