### PR TITLE
fix(s113b): useAsyncExport pino /v3/reports/ (canónico, no legacy alias)

### DIFF
--- a/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
+++ b/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
@@ -35,8 +35,18 @@ describe("S113 — useAsyncExport baseURL + auth pin", () => {
     const src = fs.readFileSync(HOOK_PATH, "utf8");
     // El bug original pineá `fetch(\`/api/v3/reports/${type}\`)` que se
     // resolvía contra el front (:3000), no contra el back (:8000).
-    // S113 fix pineá \`${API_BASE_URL}/reports/${type}\` con baseURL del back.
+    // S113 fix pineá \`${API_BASE_URL}/v3/reports/${type}\` con baseURL del back.
     expect(src).not.toMatch(/fetch\([^)]*`\/api\/v3\/reports\//);
+  });
+
+  it("useAsyncExport.ts pinea /v3/reports/ (canónico, no legacy alias)", () => {
+    const src = fs.readFileSync(HOOK_PATH, "utf8");
+    // S113b (R-PKG-016 sweep): pinear el canónico `/v3/reports/...` en
+    // lugar del legacy `/api/reports/...` que pineá un Controller con
+    // getNameModel roto (HALLAZGO-NEW-22, S114).
+    expect(src).toMatch(/`\$\{API_BASE_URL\}\/v3\/reports\//);
+    // Anti-regresión: NO pinea el legacy alias `/reports/` (sin v3).
+    expect(src).not.toMatch(/`\$\{API_BASE_URL\}\/reports\//);
   });
 
   it("useAsyncExport.ts pinea API_BASE_URL desde NEXT_PUBLIC_API_URL", () => {

--- a/src/mk/hooks/useAsyncExport/useAsyncExport.ts
+++ b/src/mk/hooks/useAsyncExport/useAsyncExport.ts
@@ -140,7 +140,7 @@ export function useAsyncExport(
   const pollStatus = useCallback(
     async (jobId: string) => {
       try {
-        const res = await fetch(`${API_BASE_URL}/reports/${jobId}/status`, {
+        const res = await fetch(`${API_BASE_URL}/v3/reports/${jobId}/status`, {
           method: "GET",
           headers: {
             Accept: "application/json",
@@ -229,7 +229,7 @@ export function useAsyncExport(
       });
 
       try {
-        const res = await fetch(`${API_BASE_URL}/reports/${type}/export`, {
+        const res = await fetch(`${API_BASE_URL}/v3/reports/${type}/export`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
# Sprint S113b — useAsyncExport pino `/v3/reports/` (canónico, no legacy alias)

## Resumen

S113b es R-PKG-016 sweep del fix S113. Cambia el pineo de `/api/reports/...` (legacy) a `/api/v3/reports/...` (canónico) en `useAsyncExport.ts`. Junto con S114 (back), cierra el bug "Class `App\Modules\Reports\Models\Reports` not found" reportado por Mario.

## Diagnóstico

S113 (PR #638) pineá:
```ts
fetch(`${API_BASE_URL}/reports/${type}/export`, ...)
```

Con `API_BASE_URL = "http://127.0.0.1:8000/api"`, la URL final es `http://127.0.0.1:8000/api/reports/.../export` (LEGACY route, BC layer S95). Ese legacy route pinea `App\Modules\Reports\Controllers\ReportsController` que hereda de `App\Mk\Controller` y `getNameModel` autodescubre `App\Modules\Reports\Models\Reports` (con S) que NO EXISTE → 500.

**S114 (back, PR #202)** corrige el legacy route pineando `App\Http\Controllers\ReportController` (S32 canónico). Después de S114, el legacy route funciona.

**S113b (front, este PR)** alinea el front con el canónico `/v3/reports/...` (R-PKG-016 sweep, no legacy alias) según la doc y los tests del proyecto. Hace el flujo más limpio y evita depender del BC layer legacy.

## Cambios

### `src/mk/hooks/useAsyncExport/useAsyncExport.ts`
- `${API_BASE_URL}/reports/${jobId}/status` → `${API_BASE_URL}/v3/reports/${jobId}/status`
- `${API_BASE_URL}/reports/${type}/export` → `${API_BASE_URL}/v3/reports/${type}/export`

## Test pin (HALLAZGO-NEW-03 pattern)

`src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts` — agregué un 5to test:

5. `useAsyncExport.ts` pinea `${API_BASE_URL}/v3/reports/` (canónico) Y NO pinea `${API_BASE_URL}/reports/` (legacy alias eliminado)

Si alguien pineá restaurar el legacy alias, el test grita.

## Tests

- `vitest run src/mk/hooks/useAsyncExport/__tests__/S113...`: **5/5 passing**
- `tsc --noEmit`: 0 nuevos errores

## Orden de merge

- S113b ANTES de S114: front pinea `/v3/reports/...` que es canónico, funciona desde ya.
- S114 ANTES de S113b: legacy route pinea Controller correcto, S113b después alinea el front al canónico.

Cualquier orden funciona. Recomendado: S114 primero (fix el back roto), S113b después (alinea el front).

## Refs

- HALLAZGO-NEW-03 (source-parsing pattern, binding cross-project)
- HALLAZGO-NEW-21 (fetch URL pino baseURL back, S113)
- HALLAZGO-NEW-22 (legacy route Controller equivocado, S114)
- S32 (NEW-NEW-43 reports async + chunking)
- S95 (legacy routing aliases pineados)
- S113 (front useAsyncExport baseURL+Bearer fix, PR #638)
- S114 (back legacy route Controller fix, PR #202)

## Cross-IA

Mavis main el 2026-07-27 (regla cross-boundary Mario "tu harás todo").
