### PR TITLE
fix(s115): useAsyncExport.download() pino baseURL + Bearer (S113 missed download)

### DIFF
--- a/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
+++ b/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
@@ -72,4 +72,16 @@ describe("S113 — useAsyncExport baseURL + auth pin", () => {
     // pinear credentials: 'include' para enviar cookies cross-domain.
     expect(src).toMatch(/credentials:\s*['"]include['"]/);
   });
+
+  it("useAsyncExport.ts pino downloadUrl con API_BASE_URL (S115 fix)", () => {
+    const src = fs.readFileSync(HOOK_PATH, "utf8");
+    // S115: el `downloadUrl` que viene del back es relativo (vía route()).
+    // El download() del hook pinea API_BASE_URL cuando NO es absoluto.
+    // Si alguien pineá restaurar `fetch(state.downloadUrl)` directo, el
+    // navegador va al front (Next.js) en lugar del back → 404.
+    expect(src).toMatch(/\$\{API_BASE_URL\}\$\{state\.downloadUrl\}/);
+    // Anti-regresión: el download() NO pinea `fetch(state.downloadUrl)`
+    // directo (sin prefijo API_BASE_URL).
+    expect(src).not.toMatch(/fetch\(\s*state\.downloadUrl\s*\)/);
+  });
 });

--- a/src/mk/hooks/useAsyncExport/useAsyncExport.ts
+++ b/src/mk/hooks/useAsyncExport/useAsyncExport.ts
@@ -311,7 +311,21 @@ export function useAsyncExport(
       return;
     }
     try {
-      const res = await fetch(state.downloadUrl);
+      // S115: el `downloadUrl` que viene del back es RELATIVO
+      // (`/api/v3/reports/{uuid}/download` vía `route('reports.download', ...)`).
+      // El navegador lo resuelve contra `window.location.origin` (el front en
+      // :3000), no contra el back en :8000 → 404 + "No autenticado" del
+      // proxy de Next.js. Fix: pinear API_BASE_URL + token del localStorage
+      // (mismo patrón que S113 fix para export + status).
+      const downloadUrl = state.downloadUrl.startsWith("http")
+        ? state.downloadUrl
+        : `${API_BASE_URL}${state.downloadUrl}`;
+      const res = await fetch(downloadUrl, {
+        headers: {
+          ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),
+        },
+        credentials: "include",
+      });
       if (!res.ok) {
         if (res.status === 410) {
           showToast("El reporte expiró", "error");


### PR DESCRIPTION
# Sprint S115 — useAsyncExport.download() baseURL + Bearer (S113 missed download)

## Resumen

Mario reportó: al hacer un export en egresos, el PDF se generaba correctamente (status: completed) pero el botón "Descargar PDF" daba error `"No autenticado"`. La causa raíz: S113 pineó el baseURL + Bearer para los fetch de `export` y `status`, pero se olvidó del `download` (3er fetch del hook). S115 pinea el download.

## Diagnóstico

S113 fix pineó el baseURL + Bearer token para 2 de 3 calls en `useAsyncExport.ts`:
- `start()` (línea 232): `fetch(\`${API_BASE_URL}/v3/reports/${type}/export\`, ...)` — pinea export.
- `pollStatus()` (línea 143): `fetch(\`${API_BASE_URL}/v3/reports/${jobId}/status\`, ...)` — pinea status.

PERO el 3er call, `download()` (línea 314 original, ahora 322), pineá `fetch(state.downloadUrl)` directamente. El `downloadUrl` viene del back vía `route('reports.download', ...)` que retorna URL RELATIVA (`/api/v3/reports/{uuid}/download`). El navegador la resuelve contra `window.location.origin` (Next.js :3000), no contra el back (:8000) → 404 + `"No autenticado"` del proxy de Next.js.

## Cambios

### `src/mk/hooks/useAsyncExport/useAsyncExport.ts` — `download()`
```diff
- const res = await fetch(state.downloadUrl);
+ const downloadUrl = state.downloadUrl.startsWith("http")
+   ? state.downloadUrl
+   : `${API_BASE_URL}${state.downloadUrl}`;
+ const res = await fetch(downloadUrl, {
+   headers: {
+     ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),
+   },
+   credentials: "include",
+ });
```

Si el `downloadUrl` ya es absoluto (empieza con `http`), se usa tal cual. Si es relativo, se pinea el `API_BASE_URL`. Mismo patrón que S113 pineó para export/status.

## Test pin (HALLAZGO-NEW-03 pattern, agregué 6to test)

`src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts`:

**6. `useAsyncExport.ts` pinea `${API_BASE_URL}` + `state.downloadUrl` (template literal) en el `download()`. Y NO pinea `fetch(state.downloadUrl)` directo (sin prefijo API_BASE_URL).**

Si alguien pineá restaurar el legacy, el test grita con mensaje claro.

## Tests

- `vitest run src/mk/hooks/useAsyncExport/__tests__/S113...`: **6/6 passing**
- `tsc --noEmit`: 0 nuevos errores

## Pendiente (S116 — modal bug)

Mario reportó 3 bugs adicionales en el modal que requieren S116:

1. **Ingresos XLS export "se queda pensando"** — posible causa: el back rechaza `format=xlsx` o el render tarda más que el timeout del modal. Necesita debug del back.
2. **Modal sin botón Cerrar** cuando `state.status === 'pending' | 'processing'`. Línea 89: `iconClose={!showProgress}` hace que el modal NO tenga botón X (cerrar) durante el loading. El hint dice "podés cerrar este modal" pero el botón NO EXISTE.
3. **"Historial de descargas"** — el hint dice "el reporte quedará disponible en tu historial de descargas" pero ese componente NO EXISTE en el código.
4. **Hardcoded PDF** — el botón dice "Descargar PDF" y el texto "Generando PDF en chunks" están hardcoded. Si el formato es XLS, debería decir "Descargar XLSX" / "Generando XLSX".

S116 va a:
- Hacer el botón Cerrar SIEMPRE visible (`iconClose={true}`).
- Quitar el hint del "historial" (o implementarlo, decisión de Mario).
- Hacer el label dinámico por formato (`format === 'xlsx' ? 'XLSX' : 'PDF'`).
- Investigar el bug del XLS (puede ser otro bug separado, requiere login + reproduce).

## Refs

- HALLAZGO-NEW-03 (source-parsing pattern, binding cross-project)
- HALLAZGO-NEW-21 (fetch URL pino baseURL back, S113)
- S32 (NEW-NEW-43 reports async + chunking)
- S95 (legacy routing aliases)
- S113 (useAsyncExport baseURL+Bearer para export+status)
- S114 (back legacy route Controller fix)
- S115 (este sprint)

## Cross-IA

Mavis main el 2026-07-27 (regla cross-boundary Mario "tu harás todo").
