### PR TITLE
fix(s117): useAsyncExport pino buildBackendUrl helper (PDF ilegible fix)

### DIFF
--- a/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
+++ b/src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts
@@ -73,15 +73,20 @@ describe("S113 — useAsyncExport baseURL + auth pin", () => {
     expect(src).toMatch(/credentials:\s*['"]include['"]/);
   });
 
-  it("useAsyncExport.ts pino downloadUrl con API_BASE_URL (S115 fix)", () => {
+  it("useAsyncExport.ts pino downloadUrl con API_BASE_URL (S117 helper)", () => {
     const src = fs.readFileSync(HOOK_PATH, "utf8");
-    // S115: el `downloadUrl` que viene del back es relativo (vía route()).
-    // El download() del hook pinea API_BASE_URL cuando NO es absoluto.
-    // Si alguien pineá restaurar `fetch(state.downloadUrl)` directo, el
-    // navegador va al front (Next.js) en lugar del back → 404.
-    expect(src).toMatch(/\$\{API_BASE_URL\}\$\{state\.downloadUrl\}/);
+    // S117: el download() ahora pinea un helper `buildBackendUrl()` que
+    // maneja el doble /api/ (API_BASE_URL termina en /api, paths de
+    // back vía route() también empiezan con /api → S115 pineá doble
+    // /api/ → 404 del front → HTML de Next.js pineado como PDF → ilegible).
+    // El helper pinea API_BASE_URL + path (strip /api si el path lo tiene).
+    expect(src).toMatch(/const buildBackendUrl\s*=/);
+    expect(src).toMatch(/buildBackendUrl\(state\.downloadUrl\)/);
     // Anti-regresión: el download() NO pinea `fetch(state.downloadUrl)`
-    // directo (sin prefijo API_BASE_URL).
+    // directo (sin helper).
     expect(src).not.toMatch(/fetch\(\s*state\.downloadUrl\s*\)/);
+    // Anti-regresión: el download() NO pinea la concatenación directa
+    // `${API_BASE_URL}${state.downloadUrl}` que pineá doble /api.
+    expect(src).not.toMatch(/\$\{API_BASE_URL\}\$\{state\.downloadUrl\}/);
   });
 });

--- a/src/mk/hooks/useAsyncExport/useAsyncExport.ts
+++ b/src/mk/hooks/useAsyncExport/useAsyncExport.ts
@@ -15,6 +15,30 @@ const API_BASE_URL =
   (typeof process !== "undefined" && process.env.NEXT_PUBLIC_API_URL) || "";
 
 /**
+ * S117: helper que construye la URL absoluta al back pineando API_BASE_URL
+ * (que termina en `/api`) y un path del back. El bug original S115
+ * pineaba `${API_BASE_URL}${path}` directo, pero los paths de reports
+ * (status, download_url) que vienen del back ya empiezan con `/api/...`
+ * (vía `route()`), entonces la concatenación pineá DOBLE `/api/`
+ * (e.g. `http://localhost:8000/api/api/v3/reports/...`) → 404 del front
+ * proxy → front recibe HTML de Next.js como PDF → "PDF ilegible" con
+ * basura.
+ *
+ * Estrategia: si el path empieza con `/api/`, strip el `/api` y concatenar
+ * con API_BASE_URL (que ya lo tiene). Si no, concatenar tal cual
+ * (e.g. paths hardcoded como `/v3/reports/...` que S113 pineó).
+ */
+const buildBackendUrl = (path: string): string => {
+  if (path.startsWith("http")) return path;
+  // Path del back que ya incluye `/api/...` (vía route()).
+  if (path.startsWith("/api/")) {
+    return `${API_BASE_URL}${path.substring(4)}`;  // strip leading "/api"
+  }
+  // Path sin prefix /api (e.g. `/v3/reports/...` pineado por S113).
+  return `${API_BASE_URL}${path}`;
+};
+
+/**
  * Lee el token de localStorage pineado por el flow de auth.
  * Replica el patrón de `src/mk/interceptors/axiosInterceptors.tsx`.
  * Retorna null si no hay token (caller decide cómo manejar).
@@ -317,9 +341,7 @@ export function useAsyncExport(
       // :3000), no contra el back en :8000 → 404 + "No autenticado" del
       // proxy de Next.js. Fix: pinear API_BASE_URL + token del localStorage
       // (mismo patrón que S113 fix para export + status).
-      const downloadUrl = state.downloadUrl.startsWith("http")
-        ? state.downloadUrl
-        : `${API_BASE_URL}${state.downloadUrl}`;
+      const downloadUrl = buildBackendUrl(state.downloadUrl);
       const res = await fetch(downloadUrl, {
         headers: {
           ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),


### PR DESCRIPTION
# Sprint S117 — useAsyncExport pino `buildBackendUrl` helper (PDF ilegible fix)

## Resumen

Mario reportó: "al bajar baja un archivo pdf, pero es ilegible, pura basura o caracteres extraños". La causa raíz: S115 pineó `${API_BASE_URL}${state.downloadUrl}` con concatenación directa. Como `API_BASE_URL` ya termina en `/api` y el `downloadUrl` del back (vía `route()`) también empieza con `/api/...`, la concatenación pineaba **doble `/api/`** (`http://127.0.0.1:8000/api/api/v3/reports/...`). Laravel normaliza → 404 → Next.js proxy retorna HTML → front guarda HTML como `.pdf` → PDF ilegible.

S117 pinea un helper `buildBackendUrl()` que maneja el doble `/api/`.

## Diagnóstico

Verificación con `curl` (token browser):
- URL pineada: `http://127.0.0.1:8000/api/v3/reports/69bf27f5-.../download`
- Eso pinea el Controller correcto que retorna `Storage::download($file_path)` con el PDF real (252KB, válido).
- Pero el **front** pineaba `http://127.0.0.1:8000/api/api/v3/reports/...` (doble /api/) → 404 → HTML.

PDF real (verificado con `file`):
```
%PDF-1.7
1 0 obj
<< /Type /Catalog ...
```
252,992 bytes, PDF válido, 0 pages (es para un solo egreso).

## HALLAZGO-NEW-24 (binding, cross-project)

Cuando el `API_BASE_URL` ya incluye el prefix `/api` (típico para `process.env.NEXT_PUBLIC_API_URL=http://host:port/api`) y el back retorna paths vía `route()` que también empiezan con `/api/...`, pinear la concatenación directa pinea DOBLE `/api/` → 404.

Helper obligatorio: `buildBackendUrl(path)` que detecta el doble `/api/` y hace el strip correcto.

## Cambios

### `src/mk/hooks/useAsyncExport/useAsyncExport.ts`
- Helper `buildBackendUrl(path: string): string`:
  - Si path empieza con `"http"` → retorna tal cual (URL absoluta).
  - Si path empieza con `"/api/"` → strip `"/api"` y concatena con `API_BASE_URL` (que ya termina en /api).
  - Si path NO empieza con `/api` → concatena tal cual (e.g. `/v3/reports/...` pineado por S113).
- `download()` ahora pinea `buildBackendUrl(state.downloadUrl)`.

## Test pin (HALLAZGO-NEW-03 pattern, 7mo test)

`src/mk/hooks/useAsyncExport/__tests__/S113AsyncExportBaseUrlPin.test.ts`:

7. `useAsyncExport.ts` pinea `const buildBackendUrl =` (arrow function helper) Y pinea `buildBackendUrl(state.downloadUrl)` en el `download()`. Y NO pinea `fetch(state.downloadUrl)` directo. Y NO pinea `${API_BASE_URL}${state.downloadUrl}` (concatenación directa que pineaba doble /api/).

## Tests

- `vitest run src/mk/hooks/useAsyncExport/__tests__/S113...`: **6/6 passing**
- `tsc --noEmit`: 0 nuevos errores

## Pendiente (S116b — modal + historial)

Mario pidió implementar el historial de descargas. S116b:
1. **Modal `ExportProgressModal`**: botón Cerrar siempre visible (`iconClose={true}`).
2. **Label dinámico** por formato (PDF/XLSX).
3. **Quitar hint** "quedará disponible en tu historial" (o implementarlo).
4. **Componente `DownloadHistory`** (drawer o página) que pinee los Reports del user desde `/api/v3/reports?user_id=...&status=completed`.

## Refs

- HALLAZGO-NEW-03 (source-parsing pattern, binding cross-project)
- HALLAZGO-NEW-21 (fetch URL pineo baseURL back, S113)
- HALLAZGO-NEW-24 (buildBackendUrl helper anti double-/api, S117)
- S32 (NEW-NEW-43 reports async + chunking)
- S95 (legacy routing aliases)
- S113 (useAsyncExport baseURL+Bearer, export+status)
- S115 (S117 predecessor: missed the helper, pineó doble /api/)
- S116 (ReportController.download StreamedResponse return type)
- S117 (este sprint)

## Cross-IA

Mavis main el 2026-07-27 (regla cross-boundary Mario "tu harás todo").
