### PR TITLE
feat(s118b): Outlays.tsx type='outlays' + Expenses.tsx params.title + useCrud merge extraParams

### DIFF
--- a/src/mk/hooks/useCrud/__tests__/Sprint118UseCrudExtraParamsMergePin.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/Sprint118UseCrudExtraParamsMergePin.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * S118 front — Pin de regresión para el fix "useCrud merge extraParams
+ * con filterBy/searchBy".
+ *
+ * Historia del bug (2026-07-27, Mario):
+ *   Pre-S118: useCrud pinea `params={mod.exportAsync.extraParams}` SOLO.
+ *   Si pineabas `extraParams: { title: "X" }`, los `filterBy` + `searchBy`
+ *   del store se PERDÍAN. El user clickeaba "Exportar" con un filtro
+ *   activo y el PDF salía con TODOS los datos (sin filtro).
+ *
+ * Fix (S118):
+ *   useCrud ahora merge `extraParams` CON `filterBy` + `searchBy`:
+ *   `params={{ ...(extraParams ?? {}), filterBy, searchBy, exportCols? }}`
+ *   Así, el `title` y los filtros se pinean juntos al back.
+ *
+ * Cross-project: aplica a TODOS los `mod.exportAsync` con `extraParams`.
+ * El patrón canónico es `extraParams: { title: "X", ... }` (S118) +
+ * useCrud merge (no override) — back recibe `params.title` Y `params.filterBy`.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const FRONT_ROOT = process.cwd();
+const USE_CRUD_PATH = path.join(FRONT_ROOT, "src/mk/hooks/useCrud/useCrud.tsx");
+
+describe("S118 front — useCrud merge extraParams con filterBy/searchBy", () => {
+  it("useCrud.tsx usa spread de extraParams (no asignacion directa)", () => {
+    const source = fs.readFileSync(USE_CRUD_PATH, "utf8");
+    expect(source).toMatch(/\.\.\.\(mod\.exportAsync\?\.extraParams\s*\?\?\s*\{\}\)/);
+  });
+
+  it("useCrud.tsx NO hace return directo de extraParams (debe mergear con filterBy)", () => {
+    const source = fs.readFileSync(USE_CRUD_PATH, "utf8");
+    expect(source).not.toMatch(/return\s+mod\.exportAsync\?\.extraParams;/);
+  });
+
+  it("useCrud.tsx pinea filterBy en out (después de spread de extraParams)", () => {
+    const source = fs.readFileSync(USE_CRUD_PATH, "utf8");
+    expect(source).toMatch(/if\s*\(\s*params\?\.filterBy\s*\)\s*out\.filterBy\s*=\s*params\.filterBy/);
+  });
+
+  it("useCrud.tsx pinea searchBy en out (después de spread de extraParams)", () => {
+    const source = fs.readFileSync(USE_CRUD_PATH, "utf8");
+    expect(source).toMatch(/if\s*\(\s*params\?\.searchBy\s*\)\s*out\.searchBy\s*=\s*params\.searchBy/);
+  });
+});

--- a/src/mk/hooks/useCrud/__tests__/useCrud.exportAsync.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrud.exportAsync.test.tsx
@@ -288,9 +288,10 @@ describe("useCrud — exportAsync slot (S36.5)", () => {
     ).toBeInTheDocument();
   });
 
-  it("exportAsync.extraParams pineado → override de filterBy/searchBy del store", () => {
-    // Si extraParams está pineado, useCrud NO pineá filterBy/searchBy
-    // automáticos. Validamos que el botón se renderiza correctamente.
+  it("exportAsync.extraParams pineado → merge con filterBy/searchBy del store (S118b)", () => {
+    // S118b: Si extraParams está pineado, useCrud pineá merge (no override)
+    // con filterBy/searchBy automáticos. Patrón canónico para pinear
+    // `title: "X"` sin perder los filtros del store.
     const TestComp = () => {
       const { List } = useCrud({
         paramsInitial: { page: 1, perPage: 10 },

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -1744,10 +1744,11 @@ const useCrud = ({
                   format={mod.exportAsync.format || "pdf"}
                   label={mod.exportAsync.label || "Exportar"}
                   params={(() => {
-                    if (mod.exportAsync?.extraParams) {
-                      return mod.exportAsync.extraParams;
-                    }
-                    const out: Record<string, any> = {};
+                    // S118b: merge extraParams con filterBy/searchBy (antes
+                    // pineaba SOLO extraParams, perdiendo los filtros del store).
+                    const out: Record<string, any> = {
+                      ...(mod.exportAsync?.extraParams ?? {}),
+                    };
                     if (params?.filterBy) out.filterBy = params.filterBy;
                     if (params?.searchBy) out.searchBy = params.searchBy;
                     if (

--- a/src/modulos/Expenses/Expenses.tsx
+++ b/src/modulos/Expenses/Expenses.tsx
@@ -82,11 +82,16 @@ const mod: ModCrudType = {
   // S66.5 (HALLAZGO-NEW-64): migrado al slot async S36.5.
   // S43 pineó ExpensesReportType backend (PR #129) pero el frontend
   // quedó incompleto sin exportAsync. S66.5 corrige.
+  // S118b: pinea extraParams.title: "Reporte de Expensas" → title
+  // dinámico del PDF (el back lee $report->params['title'] y el
+  // ExpensesReportType con type=expenses ahora pinea las DEUDAS
+  // de dptos, tabla debt_dptos).
   export: false,
   exportAsync: {
     type: 'expenses',
     format: 'pdf',
     label: 'Exportar PDF',
+    extraParams: { title: 'Reporte de Expensas' },
   },
   filter: true,
   permiso: 'expense',

--- a/src/modulos/Expenses/__tests__/ExpensesSprint118ParamsTitlePin.test.ts
+++ b/src/modulos/Expenses/__tests__/ExpensesSprint118ParamsTitlePin.test.ts
@@ -1,0 +1,64 @@
+/**
+ * S118 front — Pin de regresión para el bug "Expenses.tsx no pinea title".
+ *
+ * Historia del bug (2026-07-27, Mario):
+ *   Después de mergear S118a (fix doble render) y S118b back (split
+ *   Expenses vs Outlays), el back `ExpensesReportType` pineá el title
+ *   desde `$report->params['title']` con default "Reporte de Expensas".
+ *   El front `Expenses.tsx` no pineaba `extraParams.title` en su
+ *   `mod.exportAsync`, entonces el PDF mostraba el default
+ *   "Reporte de Expensas" — pero sin garantía de consistencia entre
+ *   front y back.
+ *
+ * Fix (S118 front):
+ *   - `Expenses.tsx` pinea `extraParams: { title: "Reporte de Expensas" }`
+ *     en su `mod.exportAsync`.
+ *   - El back lee `$report->params['title']` y lo usa como title del
+ *     header del PDF.
+ *
+ * Cross-project: aplica a TODO `mod.exportAsync` que quiera un title
+ * distinto del default del back. El patrón canónico es
+ * `extraParams: { title: "Reporte de X" }` (merge con filterBy/searchBy
+ * desde useCrud S118, ver `useCrud.exportAsync.test.tsx`).
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const FRONT_ROOT = process.cwd();
+const EXPENSES_PATH = path.join(
+  FRONT_ROOT,
+  "src/modulos/Expenses/Expenses.tsx",
+);
+
+describe("S118 front — Expenses.tsx params.title pin", () => {
+  it("Expenses.tsx pinea mod.exportAsync.type = 'expenses' (matchea ExpensesReportType)", () => {
+    const source = fs.readFileSync(EXPENSES_PATH, "utf8");
+    expect(source).toMatch(/exportAsync:\s*\{/);
+    expect(source).toMatch(/type:\s*['"]expenses['"]/);
+  });
+
+  it("Expenses.tsx pinea mod.exportAsync.extraParams.title = 'Reporte de Expensas'", () => {
+    const source = fs.readFileSync(EXPENSES_PATH, "utf8");
+    expect(source).toMatch(/extraParams:\s*\{\s*title:\s*['"]Reporte de Expensas['"]/);
+  });
+
+  it("Expenses.tsx pinea mod.export = false (kill legacy IconExport)", () => {
+    const source = fs.readFileSync(EXPENSES_PATH, "utf8");
+    expect(source).toMatch(/export:\s*false/);
+  });
+
+  it("Expenses.tsx pinea mod.exportAsync.format = 'pdf'", () => {
+    const source = fs.readFileSync(EXPENSES_PATH, "utf8");
+    expect(source).toMatch(/format:\s*['"]pdf['"]/);
+  });
+
+  it("Expenses.tsx NO pinea type = 'outlays' (ese es del módulo Outlays)", () => {
+    const source = fs.readFileSync(EXPENSES_PATH, "utf8");
+    const exportAsyncMatch = source.match(/exportAsync:\s*\{([\s\S]*?)\}/);
+    expect(exportAsyncMatch).not.toBeNull();
+    if (exportAsyncMatch) {
+      expect(exportAsyncMatch[1]).not.toMatch(/type:\s*['"]outlays['"]/);
+    }
+  });
+});

--- a/src/modulos/Outlays/config/__tests__/outlaysMod.test.ts
+++ b/src/modulos/Outlays/config/__tests__/outlaysMod.test.ts
@@ -2,23 +2,26 @@ import { describe, it, expect } from "vitest";
 import { getOutlaysMod } from "../outlaysMod";
 
 /**
- * outlaysMod test (S43)
+ * outlaysMod test (S43 + S118b)
  *
  * Verifica que el factory `getOutlaysMod()` retorna el `mod` literal
  * con los slots async pineados correctamente. Patrón idéntico al
  * `bankAccountsMod.test.ts` de S41 + `defaultersMod.test.ts` de S38.5
- * + `payments.config.test.ts` de S37.5 (4 tests, ~5ms sin renderizar
- * React).
+ * + `payments.config.test.ts` de S37.5.
  *
  * S41 discovery (binding, cross-project): `Outlays.tsx` pinea
  * `modulo: "v3/expenses"` + `permiso: "outlays"`. Es un alias del
- * módulo Expenses canónico. El type `"expenses"` matchea el
- * `ExpensesReportType` pineado en S43 backend.
+ * módulo Expenses canónico.
  *
- * @see HALLAZGO-NEW-57 (binding, cross-project) — ExpensesReportType canónico
+ * S118b: el `type` cambia de "expenses" a "outlays" para matchear el
+ * nuevo `OutlaysReportType` del back (que pineá gastos del condominio,
+ * tabla `expenses`). El `extraParams.title` pinea "Reporte de Egresos"
+ * para que el title del PDF sea consistente con el módulo.
+ *
+ * @see HALLAZGO-NEW-57 (binding, cross-project) — OutlaysReportType canónico
  * @see D-37.5-3 (S37.5) — factory pattern para configs `mod`
  */
-describe("Outlays mod config (S43)", () => {
+describe("Outlays mod config (S43 + S118b)", () => {
   it("mod.export = false (kill legacy IconExport, S43 D-38-5 pattern)", () => {
     // Pre-S43 pineaba `export: true` (BC) sin `mod.exportAsync`.
     // Post-S43: `export: false` (kill legacy) + `exportAsync: {...}` (async).
@@ -26,12 +29,12 @@ describe("Outlays mod config (S43)", () => {
     expect(mod.export).toBe(false);
   });
 
-  it("mod.exportAsync.type = 'expenses' (matchea ExpensesReportType S43)", () => {
-    // type debe matchear el ReportTypeRegistry pineado en S43 backend.
-    // Outlays pineá modulo: 'v3/expenses' (alias) pero el type del slot
-    // async es 'expenses' (canónico).
+  it("mod.exportAsync.type = 'outlays' (matchea OutlaysReportType S118b)", () => {
+    // S118b: type cambió de 'expenses' a 'outlays' para matchear el
+    // nuevo `OutlaysReportType` del back (que pineá gastos, NO deudas).
+    // El módulo 'Expenses' (deudas) usa type='expenses' (otro ReportType).
     const mod = getOutlaysMod();
-    expect(mod.exportAsync?.type).toBe("expenses");
+    expect(mod.exportAsync?.type).toBe("outlays");
   });
 
   it("mod.exportAsync.format = 'pdf' (ReportGenerator S32, S43 backend)", () => {
@@ -45,5 +48,13 @@ describe("Outlays mod config (S43)", () => {
     // Label del botón AsyncExportButton.
     const mod = getOutlaysMod();
     expect(mod.exportAsync?.label).toBe("Exportar PDF");
+  });
+
+  it("mod.exportAsync.extraParams.title = 'Reporte de Egresos' (S118b title dinámico)", () => {
+    // S118b: el back lee $report->params['title'] y lo usa como title
+    // del PDF. Outlays pinea 'Reporte de Egresos' (consistente con el
+    // nombre del módulo "Egresos" del sidebar).
+    const mod = getOutlaysMod();
+    expect(mod.exportAsync?.extraParams?.title).toBe("Reporte de Egresos");
   });
 });

--- a/src/modulos/Outlays/config/outlaysMod.ts
+++ b/src/modulos/Outlays/config/outlaysMod.ts
@@ -2,6 +2,7 @@ import { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
 
 /**
  * getOutlaysMod (S43 — NEW-NEW-43 Expenses async export frontend)
+ *               (S118b — split Outlays vs Expenses, title dinámico)
  *
  * Factory que retorna el `mod` literal para el módulo Outlays (Egresos).
  * Extraído de `Outlays.tsx` para permitir tests unitarios sin renderizar
@@ -12,12 +13,10 @@ import { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
  * Outlays al flow async PDF + XLSX (S32 + S43 backend
  * `ExpensesReportType`).
  *
- * S41 discovery (binding, cross-project): `Outlays.tsx` pinea
- * `modulo: "v3/expenses"` + `permiso: "outlays"`. Es un alias del
- * módulo Expenses canónico. Cuando se pineá `mod.exportAsync: { type:
- * "expenses" }` aquí, el `ExpensesReportType` (S43) sirve para ambos.
- * El permiso `outlays` se chequea a nivel del job (GenerateReportJob
- * → controller), no del ReportType.
+ * S118b: el `type` cambia de "expenses" a "outlays" para matchear el
+ * nuevo `OutlaysReportType` del back (que pineá gastos del condominio,
+ * tabla `expenses`). El `extraParams.title` pinea "Reporte de Egresos"
+ * para que el title del PDF sea consistente con el módulo.
  *
  * Pre-S43: el `Outlays.tsx` pineaba `export: true` (BC) sin
  * `mod.exportAsync`. El IconExport legacy llamaba a
@@ -26,11 +25,11 @@ import { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
  * Riesgo: listados grandes (>500 egresos) caían en timeout 60s PHP-FPM.
  *
  * Post-S43: `export: false` (kill legacy) + `exportAsync: {...}` (slot async).
- * El flow async va por `POST /api/v3/reports/expenses/export` con
+ * El flow async va por `POST /api/v3/reports/outlays/export` con
  * format=pdf|xlsx. Render en queue worker (S32), Dompdf pagination
  * automática.
  *
- * @see HALLAZGO-NEW-57 (binding, cross-project) — ExpensesReportType canónico
+ * @see HALLAZGO-NEW-57 (binding, cross-project) — OutlaysReportType canónico
  * @see D-36.5-3 (S36.5) — si pinean AMBOS `mod.export: true` Y `mod.exportAsync`,
  *   el async override el legacy
  * @see D-37.5-3 (S37.5) — factory pattern para configs `mod` (patrón reusable)
@@ -43,20 +42,25 @@ export const getOutlaysMod = (): ModCrudType => ({
   plural: "Egresos",
   filter: true,
   // S43: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
+  // S118b: type: "outlays" → matchea el nuevo OutlaysReportType del back.
+  //        extraParams.title: "Reporte de Egresos" → title dinámico del PDF.
   // - export: false → kill legacy IconExport.
   // - exportAsync: {...} → slot async que useCrud auto-renderea via
   //   AsyncExportButton (S36.5 pattern, idéntico a defaultersMod S38.5
   //   + payments.config S37.5 + bankAccountsMod S41).
-  // - type: "expenses" → matchea el ExpensesReportType pineado en
-  //   S43 backend (ReportTypeRegistry.auto-discovery).
+  // - type: "outlays" → matchea el OutlaysReportType pineado en
+  //   S118b backend (ReportTypeRegistry.auto-discovery).
   // - format: "pdf" → ReportGenerator chunked (S32). XLSX también soportado
   //   en el backend (S43 pineá excelRowProvider).
-  // - auto-pasa filterBy+searchBy del store actual (useCrud S36.5 D-36.5-2).
+  // - extraParams.title: "Reporte de Egresos" → title del PDF (S118b).
+  // - auto-pasa filterBy+searchBy del store actual (useCrud S36.5 D-36.5-2,
+  //   merge con extraParams desde S118b).
   export: false,
   exportAsync: {
-    type: "expenses",
+    type: "outlays",
     format: "pdf",
     label: "Exportar PDF",
+    extraParams: { title: "Reporte de Egresos" },
   },
   permiso: "outlays",
   extraData: true,


### PR DESCRIPTION
# feat(s118b): Outlays.tsx type='outlays' + Expenses.tsx params.title + useCrud merge

## Bug

Mario reportó que el flow de export async "ambos módulos bajan el mismo PDF":
- `http://localhost:3001/expenses` (módulo Expensas, deudas) → PDF con "Reporte de EGRESOS"
- `http://localhost:3001/outlays` (módulo Egresos, gastos) → mismo PDF

S118b back ([PR #206](https://github.com/mariogfos/condaty2025-api/pull/206)) pineó el split: `ExpensesReportType` (deudas, tabla `debt_dptos`) + `OutlaysReportType` (gastos, tabla `expenses`). Title dinámico desde `$report->params['title']` con default.

S118b front (este PR) pineá el front para matchear el back.

## Cambios

### `Outlays.tsx` (config `outlaysMod.ts`)

```diff
  export: false,
  exportAsync: {
-   type: "expenses",
+   type: "outlays",
    format: "pdf",
    label: "Exportar PDF",
+   extraParams: { title: "Reporte de Egresos" },
  },
```

### `Expenses.tsx` (config inline)

```diff
  export: false,
  exportAsync: {
    type: 'expenses',
    format: 'pdf',
    label: 'Exportar PDF',
+   extraParams: { title: 'Reporte de Expensas' },
  },
```

### `useCrud.tsx` (fix merge)

Pre-S118b: si pineabas `extraParams: { title: "X" }`, los `filterBy` + `searchBy` del store se PERDÍAN.

```diff
  params={(() => {
-   if (mod.exportAsync?.extraParams) {
-     return mod.exportAsync.extraParams;
-   }
-   const out: Record<string, any> = {};
+   const out: Record<string, any> = {
+     ...(mod.exportAsync?.extraParams ?? {}),
+   };
    if (params?.filterBy) out.filterBy = params.filterBy;
    if (params?.searchBy) out.searchBy = params.searchBy;
    // ...
  })()}
```

Post-S118b: `params={{ ...(extraParams ?? {}), filterBy, searchBy, exportCols? }}` → back recibe `params.title` Y `params.filterBy` juntos.

## Tests (20/20 verde)

- **ExpensesSprint118ParamsTitlePin** (5 tests, source-parsing, nuevo): pino `extraParams.title = 'Reporte de Expensas'`, `type = 'expenses'`, NO `type = 'outlays'` (anti-regresión).
- **Sprint118UseCrudExtraParamsMergePin** (4 tests, source-parsing, nuevo): spread de extraParams, NO return directo, `filterBy` + `searchBy` merge.
- **outlaysMod** (5 tests, actualizado): `type = 'outlays'` (antes `'expenses'`), `extraParams.title = 'Reporte de Egresos'`.
- **useCrud.exportAsync** (6 tests, pre-existente, comentario actualizado): merge en vez de override.

## Verificación end-to-end (con S118b back mergeado)

1. Login admin → módulo Expensas (`/expenses`).
2. Click "Exportar PDF" → modal "Generando...".
3. PDF descargado dice **"Reporte de Expensas"** + lista de dptos con sus expensas por periodo (Periodo, Dpto, Descripción, Vencimiento, Monto, Estado).
4. Login admin → módulo Egresos (`/outlays`).
5. Click "Exportar PDF" → PDF descargado dice **"Reporte de Egresos"** + lista de gastos del condominio (Fecha de pago, Subcategoría, Estado, Total).
6. **Diferente del bug**: el módulo Outlays ya NO muestra "Reporte de EGRESOS" ni los gastos del módulo Expensas.

## Refs

- S43 (ExpensesReportType original, pineaba gastos)
- S118a (PR #205, fix doble render)
- S118b back (PR #206, split)
- S118b front (este PR)
- S119 (pendiente: UX historial)
- S120 (pendiente: barrer doble render de 15 ReportTypes restantes)
- S121 (pendiente: barrer XLS rotos)

## NOTA técnica

Archivos de test se llaman `Sprint118*` en vez de `S118*` o `S118b*` porque pnpm/vitest tiene un bug con el pattern `S118*`/`S118b*` que omite archivos en `vitest list`. El sprint sigue siendo S118b.

---

Cross-IA: Mavis main el 2026-07-27 (regla cross-boundary Mario "tu harás todo").
