### PR TITLE
feat(s119): UX historial — dropdown Módulo + botón Limpiar historial

### DIFF
--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.module.css
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.module.css
@@ -59,6 +59,82 @@
   opacity: 0.5;
 }
 
+/* S119: filter bar con dropdown de Módulo + botón Limpiar historial. */
+.filterBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 8px 0;
+}
+
+.filterLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #555;
+  font-weight: 500;
+}
+
+.filterLabel > span {
+  white-space: nowrap;
+}
+
+.select {
+  padding: 6px 10px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 13px;
+  color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+  min-width: 140px;
+}
+
+.select:hover:not(:disabled) {
+  border-color: #c0c0c0;
+}
+
+.select:focus {
+  outline: none;
+  border-color: #00a37a;
+  box-shadow: 0 0 0 2px rgba(0, 163, 122, 0.15);
+}
+
+.select:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.clearBtn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: #fff;
+  border: 1px solid #f0c0c0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #b22828;
+  font-weight: 500;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.clearBtn:hover:not(:disabled) {
+  background: #fce8e8;
+  border-color: #d83a3a;
+}
+
+.clearBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .refreshSpinner {
   animation: spin 1s linear infinite;
 }

--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
@@ -2,11 +2,19 @@
 /**
  * S116b front — DownloadHistory component
  *
- * Lista los reports generados por el user autenticado. Consume
- * `GET /api/v3/reports?status=...&page=...&perPage=...` (pineado en
+ * Lista los reports generados por el user autenticado. Consome
+ * `GET /api/v3/reports?status=...&type=...&page=...&perPage=...` (pineado en
  * S116b back, PR #204). Replica el patrón de S113/S115/S117 de
  * `useAsyncExport.ts` para construir URLs absolutas al back con
  * `API_BASE_URL` + `getAuthToken()` + `buildBackendUrl()`.
+ *
+ * S119 — Extendido con:
+ * - Filtro por `type` (módulo) en el dropdown. Pineá el
+ *   `?type=payments` del back (PR #207 → fix/s120 → S119).
+ * - Botón "Limpiar historial" que llama a `DELETE /api/v3/reports`
+ *   con confirm modal. Pineá el `ReportController::destroy()` del back
+ *   (S119) que borra SOLO completed/failed del user autenticado
+ *   + archivos físicos del storage. NO toca pending/processing.
  *
  * HALLAZGO-NEW-21 (binding, cross-project): cualquier `fetch()` que
  * pineá una URL del BACK debe pinear el baseURL del back
@@ -21,6 +29,10 @@
  * `/v3/reports` (NO legacy alias `/api/reports` con Controller roto
  * HALLAZGO-NEW-22).
  *
+ * HALLAZGO-NEW-26 (S116b front, binding cross-project): modal de flow
+ * async debe pinear salida explícita. Principio: el Clear flow es
+ * destructivo → confirm modal obligatorio antes de pinear DELETE.
+ *
  * Uso:
  *
  *     <DownloadHistory onDownload={(url, type) => downloadReport(url, type)} />
@@ -29,7 +41,7 @@
  *
  *     <DownloadHistoryModal ... />
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Download,
   RefreshCw,
@@ -38,8 +50,10 @@ import {
   Inbox,
   AlertCircle,
   Loader2,
+  Trash2,
 } from "lucide-react";
 import Button from "../../forms/Button/Button";
+import NewModal from "../NewModal/NewModal";
 import styles from "./DownloadHistory.module.css";
 
 /**
@@ -115,6 +129,18 @@ type DownloadHistoryProps = {
   onDownload?: (item: DownloadHistoryItem) => void | Promise<void>;
   /** Custom render para mensajes vacíos / errores. */
   emptyMessage?: string;
+  /**
+   * S119: si se pasa, oculta el botón "Limpiar historial". Útil cuando
+   * el parent quiere pinear el Clear desde otro lado (e.g. un menú
+   * de "Más opciones"). Default: false (botón visible si hay items).
+   */
+  hideClearButton?: boolean;
+  /**
+   * S119: callback cuando el Clear se completa exitosamente. Útil
+   * para que el parent muestre un toast o haga algo más. Si no se
+   * pineá, no se notifica al parent.
+   */
+  onClearCompleted?: (deletedReports: number, deletedFiles: number) => void;
 };
 
 export type { DownloadHistoryProps };
@@ -123,21 +149,43 @@ const DEFAULT_STATUS: DownloadHistoryStatus = "completed";
 const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_POLL_MS = 5000;
 
+/**
+ * S119: lista de tipos conocidos para el dropdown "Módulo". Esta lista
+ * se mantiene manualmente (no hay endpoint back que la exponga —
+ * podríamos agregarlo en S119b si Mario quiere dropdown dinámico).
+ * El `value` matchea con el `type` que devuelve el back (campo
+ * `reports.type`). El `label` es lo que ve el user.
+ *
+ * Mantener sincronizado con `App\Reports\ReportTypeRegistry` del back
+ * (php artisan tinker → `app(App\Reports\ReportTypeRegistry::class)->availableTypes()`).
+ */
+const KNOWN_TYPES: { value: string; label: string }[] = [
+  { value: "payments", label: "Pagos" },
+  { value: "payments-xlsx", label: "Pagos XLSX" },
+  { value: "outlays", label: "Egresos" },
+  { value: "expenses", label: "Expensas" },
+  { value: "accesses", label: "Accesos" },
+  { value: "defaulters", label: "Morosos" },
+  { value: "dpto-deudas", label: "Deudas por Dpto" },
+  { value: "bank-accounts", label: "Cuentas Bancarias" },
+  { value: "areas", label: "Áreas" },
+  { value: "events", label: "Eventos" },
+  { value: "guards", label: "Guardias" },
+  { value: "homeowner", label: "Propietarios" },
+  { value: "owner", label: "Owners" },
+  { value: "reservation", label: "Reservas" },
+  { value: "invitation", label: "Invitaciones" },
+  { value: "budget", label: "Presupuesto" },
+  { value: "bank-entities", label: "Entidades Bancarias" },
+  { value: "debt-group", label: "Grupos de Deuda" },
+  { value: "assembly-attendances", label: "Asistencia a Asambleas" },
+  { value: "array_chunked", label: "Reporte (genérico)" },
+];
+
 /** Humaniza el `type` del report ("payments-xlsx" → "Pagos XLSX"). */
 const humanizeType = (type: string): string => {
-  // Mapeo conocido (ReportTypeRegistry)
-  const known: Record<string, string> = {
-    payments: "Pagos",
-    "payments-xlsx": "Pagos XLSX",
-    accesses: "Accesos",
-    defaulters: "Morosos",
-    "dptos-deudas": "Deudas por Dpto",
-    "bank-accounts": "Cuentas Bancarias",
-    expenses: "Expensas",
-    areas: "Áreas",
-    "array_chunked": "Reporte (genérico)",
-  };
-  if (known[type]) return known[type];
+  const known = KNOWN_TYPES.find((t) => t.value === type);
+  if (known) return known.label;
   // Fallback: humanizar el slug
   return type
     .replace(/[-_]/g, " ")
@@ -190,17 +238,31 @@ export default function DownloadHistory({
   pollIntervalMs = DEFAULT_POLL_MS,
   onDownload,
   emptyMessage = "Aún no generaste ningún reporte. Probá exportar algo desde un módulo con botón \"Exportar XLSX\" o \"Exportar PDF\".",
+  hideClearButton = false,
+  onClearCompleted,
 }: DownloadHistoryProps) {
   const [status, setStatus] = useState<DownloadHistoryStatus>(initialStatus);
+  // S119: filtro por módulo/type. null = "Todos".
+  const [type, setType] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [items, setItems] = useState<DownloadHistoryItem[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [downloadingUuid, setDownloadingUuid] = useState<string | null>(null);
+  // S119: estado del modal de confirmación de Clear.
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [clearError, setClearError] = useState<string | null>(null);
 
   const perPage = DEFAULT_PAGE_SIZE;
   const totalPages = Math.max(1, Math.ceil(total / perPage));
+
+  // S119: cuando cambia type o status, reset page a 1 (no tiene sentido
+  // quedarse en page=5 si el filtro cambió).
+  useEffect(() => {
+    setPage(1);
+  }, [type, status]);
 
   const fetchPage = useCallback(
     async (showSpinner = true) => {
@@ -208,9 +270,15 @@ export default function DownloadHistory({
       setError(null);
       try {
         // S116b: pinea endpoint canónico `/v3/reports` (NO legacy alias
-        // `/api/reports` HALLAZGO-NEW-22). Query params: status, page, perPage.
-        // URL absoluta al back (HALLAZGO-NEW-21).
-        const url = `${API_BASE_URL}/v3/reports?status=${status}&page=${page}&perPage=${perPage}`;
+        // `/api/reports` HALLAZGO-NEW-22). Query params: status, type,
+        // page, perPage. URL absoluta al back (HALLAZGO-NEW-21).
+        const params = new URLSearchParams();
+        params.set("status", status);
+        params.set("page", String(page));
+        params.set("perPage", String(perPage));
+        if (type) params.set("type", type);
+
+        const url = `${API_BASE_URL}/v3/reports?${params.toString()}`;
         const token = getAuthToken();
         const res = await fetch(url, {
           method: "GET",
@@ -243,10 +311,10 @@ export default function DownloadHistory({
         if (showSpinner) setLoading(false);
       }
     },
-    [status, page, perPage],
+    [status, type, page, perPage],
   );
 
-  // Initial + when status/page changes
+  // Initial + when status/page/type changes
   useEffect(() => {
     fetchPage(true);
   }, [fetchPage]);
@@ -304,6 +372,56 @@ export default function DownloadHistory({
     [onDownload],
   );
 
+  // S119: handler del Clear. Llama DELETE /api/v3/reports (canónico,
+  // NO legacy alias), con Bearer + buildBackendUrl pattern. Multi-tenant
+  // viene del token — el back filtra por user_id automáticamente.
+  const handleClear = useCallback(async () => {
+    setClearing(true);
+    setClearError(null);
+    try {
+      // HALLAZGO-NEW-20: pinear endpoint canónico `/v3/reports`.
+      // HALLAZGO-NEW-21: URL absoluta via API_BASE_URL.
+      const url = `${API_BASE_URL}/v3/reports`;
+      const token = getAuthToken();
+      const res = await fetch(url, {
+        method: "DELETE",
+        headers: {
+          Accept: "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(
+          data?.message ?? `Error al limpiar el historial (${res.status})`,
+        );
+      }
+      const data = await res.json().catch(() => ({}));
+      // Reset page + cerrar modal + refetch.
+      setPage(1);
+      setShowClearConfirm(false);
+      await fetchPage(true);
+      if (onClearCompleted) {
+        onClearCompleted(
+          data?.deleted_reports ?? 0,
+          data?.deleted_files ?? 0,
+        );
+      }
+    } catch (err: any) {
+      setClearError(err?.message ?? "Error de red al limpiar el historial");
+    } finally {
+      setClearing(false);
+    }
+  }, [fetchPage, onClearCompleted]);
+
+  // S119: lista de types disponibles para el dropdown. Mostramos
+  // "Todos" + los types del KNOWN_TYPES que el user probablemente use.
+  // Si Mario quiere dropdown dinámico (basado en los types que el user
+  // realmente tiene), eso es S119b — pinear endpoint
+  // `GET /api/v3/reports/types` que retorne distinct types del user.
+  const typeOptions = useMemo(() => KNOWN_TYPES, []);
+
   return (
     <div className={styles.body} data-testid="download-history">
       <div className={styles.header}>
@@ -327,6 +445,44 @@ export default function DownloadHistory({
           )}
           Refrescar
         </button>
+      </div>
+
+      {/* S119: filter bar con dropdown de Módulo + botón Limpiar. */}
+      <div className={styles.filterBar} data-testid="download-history-filter-bar">
+        <label className={styles.filterLabel}>
+          <span>Módulo:</span>
+          <select
+            value={type ?? ""}
+            onChange={(e) => setType(e.target.value || null)}
+            className={styles.select}
+            data-testid="download-history-type-filter"
+            disabled={loading}
+          >
+            <option value="">Todos</option>
+            {typeOptions.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {!hideClearButton && items.length > 0 && (
+          <button
+            type="button"
+            className={styles.clearBtn}
+            onClick={() => {
+              setClearError(null);
+              setShowClearConfirm(true);
+            }}
+            disabled={loading || clearing}
+            data-testid="download-history-clear-btn"
+            aria-label="Limpiar historial"
+          >
+            <Trash2 size={14} />
+            Limpiar historial
+          </button>
+        )}
       </div>
 
       {error ? (
@@ -418,6 +574,30 @@ export default function DownloadHistory({
           </button>
         </div>
       )}
+
+      {/* S119: confirm modal del Clear. PINEA el flow destructivo:
+          user debe confirmar antes de pinear DELETE. Back-compat:
+          si parent no pineá `hideClearButton`, se muestra el botón
+          que abre este modal. */}
+      <NewModal
+        open={showClearConfirm}
+        onClose={() => {
+          if (!clearing) setShowClearConfirm(false);
+        }}
+        onSave={handleClear}
+        title="¿Limpiar historial?"
+        subtitle={`Se eliminarán todos los reportes completados y fallidos (${items.length} en esta página). Esta acción no se puede deshacer.`}
+        buttonText={clearing ? "Limpiando…" : "Sí, limpiar"}
+        buttonCancel="Cancelar"
+        disabled={clearing}
+      >
+        {clearError && (
+          <div className={styles.error} style={{ padding: 0 }}>
+            <AlertCircle size={20} />
+            <p style={{ fontSize: 13 }}>{clearError}</p>
+          </div>
+        )}
+      </NewModal>
     </div>
   );
 }

--- a/src/mk/components/ui/DownloadHistory/__tests__/S116bDownloadHistoryEndpointAndStatusPin.test.ts
+++ b/src/mk/components/ui/DownloadHistory/__tests__/S116bDownloadHistoryEndpointAndStatusPin.test.ts
@@ -23,7 +23,10 @@ describe("S116b front — DownloadHistory endpoint + status + pagination", () =>
     const src = fs.readFileSync(COMPONENT_PATH, "utf8");
     // S116b back (PR #204) acepta ?status=completed|failed|pending|processing|all.
     // Default: completed (lo que el user normalmente quiere ver).
-    expect(src).toMatch(/status=\$\{status\}/);
+    // S119: el URL building se refactorizó a URLSearchParams en vez de
+    // template literal inline. La intención es la misma: pinear status
+    // en el query string. Test actualizado al nuevo patrón.
+    expect(src).toMatch(/params\.set\(\s*["']status["']\s*,\s*status\s*\)/);
     // El default de initialStatus es "completed"
     expect(src).toMatch(/DEFAULT_STATUS[^;]*=\s*["']completed["']/);
   });
@@ -31,8 +34,9 @@ describe("S116b front — DownloadHistory endpoint + status + pagination", () =>
   it("DownloadHistory.tsx pinea page + perPage query params (S116b back pagination)", () => {
     const src = fs.readFileSync(COMPONENT_PATH, "utf8");
     // El back pinea ?page=...&perPage=... (clamp 1-100, default 20).
-    expect(src).toMatch(/page=\$\{page\}/);
-    expect(src).toMatch(/perPage=\$\{perPage\}/);
+    // S119: refactor a URLSearchParams — pinear el patrón nuevo.
+    expect(src).toMatch(/params\.set\(\s*["']page["']\s*,\s*String\(page\)\s*\)/);
+    expect(src).toMatch(/params\.set\(\s*["']perPage["']\s*,\s*String\(perPage\)\s*\)/);
   });
 
   it("DownloadHistory.tsx pinea anti IDOR (NO acepta user_id en query)", () => {
@@ -62,10 +66,15 @@ describe("S116b front — DownloadHistory endpoint + status + pagination", () =>
     const src = fs.readFileSync(COMPONENT_PATH, "utf8");
     // Mapeo humanizado para los tipos conocidos de reports
     // (S32-S45). Si el back agrega uno nuevo, pinear acá.
-    expect(src).toMatch(/payments:\s*["']Pagos["']/);
-    expect(src).toMatch(/expenses:\s*["']Expensas["']/);
-    expect(src).toMatch(/defaulters:\s*["']Morosos["']/);
-    expect(src).toMatch(/accesses:\s*["']Accesos["']/);
+    // S119: el mapping se refactorizó de `Record<string,string>` (objeto)
+    // a `KNOWN_TYPES: { value, label }[]` (array) para pinear la
+    // estructura del dropdown. El test se actualiza para matchear
+    // la nueva forma pero pinea LA MISMA INTENCIÓN: que los types
+    // principales estén mapeados a labels humanizados.
+    expect(src).toMatch(/value:\s*["']payments["']\s*,\s*label:\s*["']Pagos["']/);
+    expect(src).toMatch(/value:\s*["']expenses["']\s*,\s*label:\s*["']Expensas["']/);
+    expect(src).toMatch(/value:\s*["']defaulters["']\s*,\s*label:\s*["']Morosos["']/);
+    expect(src).toMatch(/value:\s*["']accesses["']\s*,\s*label:\s*["']Accesos["']/);
   });
 
   it("DownloadHistory.tsx pinea download button disabled cuando !isCompleted", () => {

--- a/src/mk/components/ui/DownloadHistory/__tests__/Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx
+++ b/src/mk/components/ui/DownloadHistory/__tests__/Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * S119 (front) - Source-parsing pin para DownloadHistory.
+ *
+ * Pinea INTENCION (no efectividad) de los features S119:
+ * 1. Dropdown "Modulo" pinea type en el GET del back.
+ * 2. Boton "Limpiar historial" pinea DELETE /api/v3/reports
+ *    con Bearer + API_BASE_URL.
+ * 3. Confirm modal obligatorio antes del DELETE (HALLAZGO-NEW-26).
+ * 4. Multi-tenant implicito: el back filtra por user_id del token
+ *    (HALLAZGO-NEW-21). El front NUNCA envia user_id.
+ * 5. Pin canonico /v3/reports (HALLAZGO-NEW-20/22) - NO legacy alias.
+ *
+ * HALLAZGO-NEW-29: vitest con S118 S118b no los detecta.
+ * Usar Sprint119* para evitar el bug.
+ *
+ * HALLAZGO-NEW-03: source-parsing pinea INTENCION. Los e2e con
+ * un back mockeado pinean EFECTIVIDAD. Ambos deben correr juntos.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const COMPONENT_PATH = path.resolve(
+  __dirname,
+  "../DownloadHistory.tsx",
+);
+
+let src = "";
+
+describe("S119 (front) - DownloadHistory Modulo filter + Clear", () => {
+  beforeAll(() => {
+    src = fs.readFileSync(COMPONENT_PATH, "utf-8");
+  });
+
+  it("declara type state para el filtro por modulo", () => {
+    expect(src).toMatch(
+      /const\s+\[\s*type\s*,\s*setType\s*\]\s*=\s*useState\s*<\s*string\s*\|\s*null\s*>\s*\(\s*null\s*\)/,
+    );
+  });
+
+  it("declara showClearConfirm y clearing state para el flow Clear", () => {
+    expect(src).toMatch(
+      /const\s+\[\s*showClearConfirm\s*,\s*setShowClearConfirm\s*\]\s*=\s*useState/,
+    );
+    expect(src).toMatch(
+      /const\s+\[\s*clearing\s*,\s*setClearing\s*\]\s*=\s*useState/,
+    );
+  });
+
+  it("declara KNOWN_TYPES con la lista de modulos", () => {
+    expect(src).toMatch(/const\s+KNOWN_TYPES\s*:/);
+    expect(src).toContain("payments");
+    expect(src).toContain("outlays");
+    expect(src).toContain("expenses");
+    expect(src).toContain("accesses");
+    expect(src).toContain("defaulters");
+  });
+
+  it("el GET pinea type en query string cuando hay filtro seleccionado", () => {
+    // HALLAZGO-NEW-20: pinear endpoint canonico /v3/reports.
+    // HALLAZGO-NEW-21: URL absoluta via API_BASE_URL.
+    // El codigo usa template literal: `${API_BASE_URL}/v3/reports?...`
+    expect(src).toMatch(/`\$\{API_BASE_URL\}\/v3\/reports/);
+    expect(src).toMatch(/params\.set\(\s*["']type["']\s*,\s*type\s*\)/);
+  });
+
+  it("el GET NO pinea user_id - multi-tenant viene del token", () => {
+    // HALLAZGO-NEW-21: el front NUNCA envia user_id en query string.
+    // Si alguien lo agrega, IDOR attack es trivial.
+    expect(src).not.toMatch(/params\.set\(\s*["']user_id["']/);
+  });
+
+  it("el Clear button pinea DELETE al endpoint canonico /v3/reports", () => {
+    // HALLAZGO-NEW-20: endpoint canonico. HALLAZGO-NEW-22: NO legacy alias.
+    // HALLAZGO-NEW-24: API_BASE_URL ya tiene /api, no concatenar /api/extra.
+    // El codigo usa template literal: `${API_BASE_URL}/v3/reports`
+    expect(src).toMatch(/method:\s*["']DELETE["']/);
+    expect(src).toMatch(/`\$\{API_BASE_URL\}\/v3\/reports`/);
+  });
+
+  it("el Clear pinea Authorization Bearer token HALLAZGO-NEW-21", () => {
+    // El delete request debe pinear Bearer. Si no lo pinea, el back
+    // retorna 401 y el historial no se borra.
+    const handleClearMatch = src.match(
+      /handleClear[\s\S]*?fetch\([\s\S]*?\{([\s\S]*?)\}\s*\)/,
+    );
+    expect(handleClearMatch).not.toBeNull();
+    expect(handleClearMatch![1]).toMatch(
+      /Authorization:\s*[`"']Bearer\s*\$\{token\}/,
+    );
+  });
+
+  it("el Clear pinea confirm modal NewModal antes del DELETE HALLAZGO-NEW-26", () => {
+    // El modal debe pinearse ANTES de pinear el DELETE. El NewModal
+    // tiene buttonText que pinea onSave=handleClear.
+    expect(src).toMatch(/<NewModal[\s\S]*?title=["']\u00bfLimpiar historial\?["']/);
+    expect(src).toMatch(/onSave=\{handleClear\}/);
+  });
+
+  it("el Clear button tiene data-testid download-history-clear-btn", () => {
+    expect(src).toMatch(/data-testid=["']download-history-clear-btn["']/);
+  });
+
+  it("el dropdown tiene data-testid download-history-type-filter", () => {
+    expect(src).toMatch(/data-testid=["']download-history-type-filter["']/);
+  });
+
+  it("el filter bar tiene data-testid download-history-filter-bar", () => {
+    expect(src).toMatch(/data-testid=["']download-history-filter-bar["']/);
+  });
+
+  it("pinea la prop opcional hideClearButton para back-compat", () => {
+    // S119: prop opcional para que parents que pinean Clear desde
+    // otro lado puedan ocultar el boton. Default false.
+    expect(src).toMatch(/hideClearButton\?:\s*boolean/);
+    expect(src).toMatch(/hideClearButton\s*=\s*false/);
+  });
+
+  it("pinea la prop opcional onClearCompleted callback", () => {
+    // S119: callback cuando el Clear termina bien. Util para toasts.
+    expect(src).toMatch(/onClearCompleted\?:\s*\(\s*deletedReports/);
+  });
+
+  it("resetea page a 1 cuando cambia type o status", () => {
+    // S119: si cambia el filtro y estas en page=5, no tiene sentido.
+    expect(src).toMatch(
+      /useEffect\(\s*\(\s*\)\s*=>\s*\{\s*setPage\(1\)\s*;\s*\}\s*,\s*\[type\s*,\s*status\]\s*\)/,
+    );
+  });
+
+  it("pinea Trash2 icon para el boton Clear", () => {
+    expect(src).toMatch(
+      /import\s*\{[^}]*Trash2[^}]*\}\s*from\s*["']lucide-react["']/,
+    );
+    expect(src).toMatch(/<Trash2\s+size=\{14\}\s*\/>/);
+  });
+});


### PR DESCRIPTION
# feat(s119): UX historial — dropdown Módulo + botón Limpiar historial

**Cierra**: S119 (UX historial) — front companion del PR back #208

## Cambios

### `DownloadHistory.tsx`

- **Dropdown "Módulo"** (filtro por type). Pinea `?type=payments` en el GET del back. Default "Todos". Lista de tipos pineada manualmente (`KNOWN_TYPES`) — 20 ReportTypes del `ReportTypeRegistry`. Si el back agrega un type nuevo, pinear acá (o si Mario quiere dinámico, S119b puede agregar endpoint `GET /api/v3/reports/types`).
- **Botón "Limpiar historial"** con confirm modal (`NewModal`). Llama `DELETE /api/v3/reports` con Bearer + `API_BASE_URL`. Multi-tenant implícito (el back filtra por `user_id` del token, el front NO envía `user_id` explícito — HALLAZGO-NEW-21 anti-IDOR).
- **Props nuevas** (back-compat, opcionales):
  - `hideClearButton?: boolean` — oculta el botón si el parent quiere pinearlo desde otro lado.
  - `onClearCompleted?: (deletedReports: number, deletedFiles: number) => void` — callback con counters para que el parent muestre toast.

### Refactors

- `fetchPage`: de template literal inline a `URLSearchParams` (más limpio).
- `KNOWN_TYPES`: de `Record<string,string>` a `{value,label}[]` (estructura del dropdown).
- `humanizeType`: usa `KNOWN_TYPES` primero, fallback al slug humanizado.

### CSS (`DownloadHistory.module.css`)

- Filter bar (`.filterBar` + `.filterLabel` + `.select` + `.clearBtn`).

## Tests

- **Nuevo `Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx`** (15 source-parsing pines, vitest usa `SprintNNN*` por bug HALLAZGO-NEW-29 con `S118*/S118b*`):
  - type state pineado
  - showClearConfirm + clearing state pineados
  - KNOWN_TYPES con lista de módulos
  - GET pinea `?type=`
  - GET NO pinea `user_id` (anti-IDOR)
  - Clear pinea `DELETE` al canónico `/v3/reports`
  - Clear pinea `Authorization: Bearer ${token}`
  - Clear pinea confirm modal antes del DELETE (HALLAZGO-NEW-26)
  - `data-testid` correctos
  - Props opcionales `hideClearButton` + `onClearCompleted`
  - Reset page cuando cambia type/status
  - `Trash2` icon pineado
- **`S116bDownloadHistoryEndpointAndStatusPin.test.ts`** actualizado al nuevo patrón URLSearchParams + KNOWN_TYPES (misma intención, nueva forma).

## Verificación

- 28 tests DownloadHistory verde (15 S119 + 13 S116b)
- 0 regresiones (7 failures pre-existentes en `useAsyncExport.test.ts` no relacionadas con este PR)
- `pnpm vitest` verde para todo el directorio

## Cross-IA

Mario, este PR es front companion del back #208. Después de mergear los 2 + cache clear:
1. El back expone `DELETE /api/v3/reports` + `?type=` filter en `GET /api/v3/reports`
2. El front pineá el dropdown + botón Clear con confirm modal
3. El schedule `reports:clean-old` corre hourly → archivos viejos se borran automáticamente

## HALLAZGOS pineados

- HALLAZGO-NEW-21 (multi-tenant / Bearer)
- HALLAZGO-NEW-20 (canónico `/v3/`)
- HALLAZGO-NEW-24 (buildBackendUrl helper — no usado en DELETE porque la URL no es de `route()`)
- HALLAZGO-NEW-26 (async flow UX: confirm modal obligatorio)
- HALLAZGO-NEW-29 (vitest naming bug: `Sprint119*` no `S119*`)
- HALLAZGO-NEW-03 (testing: source-parsing)

Refs: S32, S116b, S118b, S119, HALLAZGO-NEW-21/24/26/29.