### PR TITLE
feat(s119b): pre-seleccionar módulo en el dropdown de historial

### DIFF
--- a/src/mk/components/ui/AsyncExportButton/AsyncExportButton.tsx
+++ b/src/mk/components/ui/AsyncExportButton/AsyncExportButton.tsx
@@ -151,6 +151,10 @@ export default function AsyncExportButton({
       <DownloadHistoryModal
         open={historyOpen}
         onClose={() => setHistoryOpen(false)}
+        // S119b: pre-selecciona el módulo del que se está abriendo el
+        // historial. Si el user está en "Outlays" y click "Historial",
+        // el dropdown arranca en "outlays" en vez de "Todos".
+        initialType={type}
       />
     </>
   );

--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
@@ -118,6 +118,14 @@ export type DownloadHistoryResponse = {
 type DownloadHistoryProps = {
   /** Status inicial. Default "completed" (lo que el user normalmente quiere). */
   initialStatus?: DownloadHistoryStatus;
+  /**
+   * S119b: type inicial (módulo) para el filtro. Útil cuando el modal
+   * se abre desde un módulo específico (e.g. Outlays.tsx) y queremos
+   * que el dropdown "Módulo" ya esté pre-seleccionado en "outlays".
+   * Default: null ("Todos"). Si se pasa, el filtro del GET inicial
+   * pinea `?type=<value>`.
+   */
+  initialType?: string | null;
   /** Polling automático para reports pending/processing (cada N ms). 0 = off. */
   pollIntervalMs?: number;
   /**
@@ -235,6 +243,7 @@ const StatusPill = ({ status }: { status: DownloadHistoryStatus }) => {
 
 export default function DownloadHistory({
   initialStatus = DEFAULT_STATUS,
+  initialType = null,
   pollIntervalMs = DEFAULT_POLL_MS,
   onDownload,
   emptyMessage = "Aún no generaste ningún reporte. Probá exportar algo desde un módulo con botón \"Exportar XLSX\" o \"Exportar PDF\".",
@@ -243,7 +252,9 @@ export default function DownloadHistory({
 }: DownloadHistoryProps) {
   const [status, setStatus] = useState<DownloadHistoryStatus>(initialStatus);
   // S119: filtro por módulo/type. null = "Todos".
-  const [type, setType] = useState<string | null>(null);
+  // S119b: si el parent pinea `initialType` (e.g. AsyncExportButton
+  // pasando su `type` prop), el dropdown arranca pre-seleccionado.
+  const [type, setType] = useState<string | null>(initialType);
   const [page, setPage] = useState(1);
   const [items, setItems] = useState<DownloadHistoryItem[]>([]);
   const [total, setTotal] = useState(0);

--- a/src/mk/components/ui/DownloadHistory/DownloadHistoryModal.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistoryModal.tsx
@@ -6,6 +6,11 @@
  * para pinear como "Ver historial" en el `ExportProgressModal` y
  * `AsyncExportButton`. Mantiene el contrato del `NewModal` que el
  * proyecto ya pineá en 30+ lugares.
+ *
+ * S119b: pineá `initialType` para que cuando el modal se abra desde
+ * un módulo específico (e.g. `AsyncExportButton` con `type="outlays"`),
+ * el dropdown "Módulo" del `DownloadHistory` ya esté pre-seleccionado
+ * en el type correspondiente. Default: null ("Todos").
  */
 import NewModal from "../NewModal/NewModal";
 import DownloadHistory, {
@@ -20,6 +25,11 @@ type DownloadHistoryModalProps = {
   onDownload?: (item: DownloadHistoryItem) => void | Promise<void>;
   /** Status inicial. Default "completed". */
   initialStatus?: DownloadHistoryProps["initialStatus"];
+  /**
+   * S119b: type inicial (módulo) para el filtro. Si se pasa, el dropdown
+   * "Módulo" arranca pre-seleccionado. Default: null ("Todos").
+   */
+  initialType?: DownloadHistoryProps["initialType"];
   /** Polling opcional para reports pending/processing. */
   pollIntervalMs?: number;
 };
@@ -29,6 +39,7 @@ export default function DownloadHistoryModal({
   onClose,
   onDownload,
   initialStatus,
+  initialType,
   pollIntervalMs,
 }: DownloadHistoryModalProps) {
   return (
@@ -47,6 +58,7 @@ export default function DownloadHistoryModal({
       <DownloadHistory
         onDownload={onDownload}
         initialStatus={initialStatus}
+        initialType={initialType}
         pollIntervalMs={pollIntervalMs}
       />
     </NewModal>

--- a/src/mk/components/ui/DownloadHistory/__tests__/Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx
+++ b/src/mk/components/ui/DownloadHistory/__tests__/Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx
@@ -25,6 +25,11 @@ const COMPONENT_PATH = path.resolve(
   "../DownloadHistory.tsx",
 );
 
+const ASYNC_EXPORT_BUTTON_PATH = path.resolve(
+  __dirname,
+  "../../AsyncExportButton/AsyncExportButton.tsx",
+);
+
 let src = "";
 
 describe("S119 (front) - DownloadHistory Modulo filter + Clear", () => {
@@ -33,8 +38,10 @@ describe("S119 (front) - DownloadHistory Modulo filter + Clear", () => {
   });
 
   it("declara type state para el filtro por modulo", () => {
+    // S119b: ahora el state pineá `initialType` (no null hardcoded).
+    // Back-compat: si el parent no pinea initialType, default null.
     expect(src).toMatch(
-      /const\s+\[\s*type\s*,\s*setType\s*\]\s*=\s*useState\s*<\s*string\s*\|\s*null\s*>\s*\(\s*null\s*\)/,
+      /const\s+\[\s*type\s*,\s*setType\s*\]\s*=\s*useState\s*<\s*string\s*\|\s*null\s*>\s*\(\s*initialType\s*\)/,
     );
   });
 
@@ -133,5 +140,59 @@ describe("S119 (front) - DownloadHistory Modulo filter + Clear", () => {
       /import\s*\{[^}]*Trash2[^}]*\}\s*from\s*["']lucide-react["']/,
     );
     expect(src).toMatch(/<Trash2\s+size=\{14\}\s*\/>/);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // S119b — pre-seleccionar módulo en el dropdown cuando el modal
+  // se abre desde un módulo específico (e.g. AsyncExportButton).
+  // ─────────────────────────────────────────────────────────────────
+
+  it("S119b: pinea la prop opcional initialType string or null", () => {
+    // Back-compat: default null (Todos). Parents pinean initialType
+    // para pre-seleccionar el módulo.
+    expect(src).toMatch(/initialType\?:\s*string\s*\|\s*null/);
+  });
+
+  it("S119b: pinea initialType con default null en el destructuring", () => {
+    // La prop debe tener un valor default para back-compat. Si un
+    // parent viejo no la pineá, initialType = null = "Todos".
+    expect(src).toMatch(/initialType\s*=\s*null/);
+  });
+
+  it("S119b: el useState de type arranca con initialType", () => {
+    // El state del filtro debe inicializarse con initialType, NO con
+    // null hardcoded. Si pineás `useState<string | null>(null)` en
+    // vez de `useState<string | null>(initialType)`, el initialType
+    // prop es inútil.
+    expect(src).toMatch(
+      /useState\s*<\s*string\s*\|\s*null\s*>\s*\(\s*initialType\s*\)/,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// S119b — integración en AsyncExportButton (pasa initialType)
+// ─────────────────────────────────────────────────────────────────
+
+describe("S119b (front) - AsyncExportButton pinea initialType en DownloadHistoryModal", () => {
+  let asyncSrc = "";
+  beforeAll(() => {
+    asyncSrc = fs.readFileSync(ASYNC_EXPORT_BUTTON_PATH, "utf-8");
+  });
+
+  it("AsyncExportButton pinea initialType=type en el DownloadHistoryModal", () => {
+    // S119b: cuando el user está en Outlays (type=outlays) y click
+    // "Historial", el modal debe arrancar con initialType=outlays.
+    // El componente ya tiene la prop `type: string` (la que se pineá
+    // al POST /export). Solo necesitamos pinearla al modal.
+    expect(asyncSrc).toMatch(
+      /<DownloadHistoryModal[\s\S]*?initialType=\{type\}/,
+    );
+  });
+
+  it("AsyncExportButton sigue pineando open y onClose en el modal", () => {
+    // Back-compat: las props originales pineadas.
+    expect(asyncSrc).toMatch(/<DownloadHistoryModal[\s\S]*?open=\{historyOpen\}/);
+    expect(asyncSrc).toMatch(/<DownloadHistoryModal[\s\S]*?onClose=\{[\s\S]*?setHistoryOpen\(false\)[\s\S]*?\}/);
   });
 });


### PR DESCRIPTION
# feat(s119b): pre-seleccionar módulo en el dropdown de historial

**Cierra**: S119b (Mario pidió "al abrir el historico que el modulo al que esdta llamando, este seleccionado en el filtro por defecto.")

## Cambios

### `DownloadHistory.tsx`
- Nueva prop opcional `initialType?: string | null` (default `null` = "Todos"). Si el parent la pinea, el dropdown "Módulo" arranca pre-seleccionado.
- El state `type` ahora se inicializa con `initialType` en vez de `null` hardcoded.

### `DownloadHistoryModal.tsx`
- Nueva prop opcional `initialType?: DownloadHistoryProps["initialType"]` que se propaga al `DownloadHistory` interno.

### `AsyncExportButton.tsx`
- Pasa `initialType={type}` al `DownloadHistoryModal`. Como el botón ya tiene la prop `type: string` (la que se pineá al POST /export), reusamos esa misma prop.

## Cómo se usa

Cuando un módulo abre el `DownloadHistory` (vía `AsyncExportButton` o `DownloadHistoryModal` directo), el dropdown ya arranca con el módulo correcto:

```tsx
// En Outlays.tsx — pre-selecciona "outlays"
<AsyncExportButton type="outlays" ... />
// Click "Historial" → modal abre con dropdown en "Egresos"

// Sin AsyncExportButton (uso directo del modal)
<DownloadHistoryModal
  open={isOpen}
  onClose={...}
  initialType="reservations"  // pre-selecciona "Reservas"
/>
```

**Back-compat**: si el parent NO pinea `initialType`, el dropdown arranca en "Todos" (default `null`). No rompe consumers viejos.

## Tests

- Extender `Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx` con 5 nuevos pines:
  - `initialType?: string | null` pineado
  - `initialType = null` default pineado
  - `useState<string | null>(initialType)` pineado (no `null` hardcoded)
  - 2 pines de integración en `AsyncExportButton`: pinea `initialType={type}` y mantiene `open`/`onClose`
- Actualizar 1 pin existente: `declara type state para el filtro por modulo` ahora matchea `useState<string | null>(initialType)` en vez de `useState<string | null>(null)`.

**Suite DownloadHistory**: 33 tests verde.

## HALLAZGOS pineados

- HALLAZGO-NEW-20/22 (canónico `/v3/`)
- HALLAZGO-NEW-21 (multi-tenant implícito)
- HALLAZGO-NEW-24 (buildBackendUrl helper)
- HALLAZGO-NEW-26 (async flow UX)
- HALLAZGO-NEW-29 (vitest naming: `Sprint119*`)

## Cross-IA

Mario, este PR es front companion del bug fix S122 (#209). Después de mergear:
1. Verificar manualmente: en `/outlays`, click "Historial" → modal abre con dropdown en "Egresos".
2. Idem para `/expenses` → "Expensas", `/payments` → "Pagos", etc.

## Refs

- S116b (PR #642) — pineo el `DownloadHistory` original
- S118b (PR #643) — pre-select title dinámico en reports
- S119 (PR #644 MERGED) — dropdown Módulo + botón Limpiar (este PR agrega S119b encima)
- S122 (PR #209 OPEN) — bug fix áreas + reservations (front companion de este)