### PR TITLE
feat(s123): dropdown Módulo consume /v3/reports/types — derivá keys del back

### DIFF
--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
@@ -158,14 +158,17 @@ const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_POLL_MS = 5000;
 
 /**
- * S119: lista de tipos conocidos para el dropdown "Módulo". Esta lista
- * se mantiene manualmente (no hay endpoint back que la exponga —
- * podríamos agregarlo en S119b si Mario quiere dropdown dinámico).
- * El `value` matchea con el `type` que devuelve el back (campo
- * `reports.type`). El `label` es lo que ve el user.
+ * S123: lista de tipos con labels humanizados. S123b pineó `initialType`
+ * (pre-selecciona en dropdown). Pero los VALUES de esta lista se usan
+ * SOLO como mapa de LABELS — los VALUES reales del dropdown vienen
+ * del endpoint back `/v3/reports/types` (HALLAZGO-NEW-32).
  *
- * Mantener sincronizado con `App\Reports\ReportTypeRegistry` del back
- * (php artisan tinker → `app(App\Reports\ReportTypeRegistry::class)->availableTypes()`).
+ * Esta lista es solo un fallback + label map. El dropdown principal
+ * pineá los types del back vía `availableTypes` state.
+ *
+ * Mantener sincronizado con `App\Reports\ReportTypeRegistry::availableTypes()`
+ * del back (php artisan tinker). El back es la SSoT — esta lista es
+ * solo para humanizar.
  */
 const KNOWN_TYPES: { value: string; label: string }[] = [
   { value: "payments", label: "Pagos" },
@@ -179,14 +182,15 @@ const KNOWN_TYPES: { value: string; label: string }[] = [
   { value: "areas", label: "Áreas" },
   { value: "events", label: "Eventos" },
   { value: "guards", label: "Guardias" },
-  { value: "homeowner", label: "Propietarios" },
-  { value: "owner", label: "Owners" },
-  { value: "reservation", label: "Reservas" },
-  { value: "invitation", label: "Invitaciones" },
-  { value: "budget", label: "Presupuesto" },
+  { value: "homeowners", label: "Propietarios" },
+  { value: "owners", label: "Owners" },
+  { value: "reservations", label: "Reservas" },
+  { value: "invitations", label: "Invitaciones" },
+  { value: "budgets", label: "Presupuesto" },
   { value: "bank-entities", label: "Entidades Bancarias" },
-  { value: "debt-group", label: "Grupos de Deuda" },
-  { value: "assembly-attendances", label: "Asistencia a Asambleas" },
+  { value: "debt-groups", label: "Grupos de Deuda" },
+  { value: "assemblies-attendances", label: "Asistencia a Asambleas" },
+  { value: "guard-news", label: "Guardias Nuevos" },
   { value: "array_chunked", label: "Reporte (genérico)" },
 ];
 
@@ -199,6 +203,42 @@ const humanizeType = (type: string): string => {
     .replace(/[-_]/g, " ")
     .replace(/\b\w/g, (c) => c.toUpperCase());
 };
+
+/**
+ * S123 (HALLAZGO-NEW-32): fetcha los types disponibles del back vía
+ * `GET /api/v3/reports/types`. El back devuelve los `type` strings
+ * que el user realmente tiene generados (multi-tenant). Drift
+ * imposible — si el back renombra/agrega un type, el dropdown
+ * se actualiza solo.
+ *
+ * Si el endpoint falla (red, 500, etc.), retorna el fallback
+ * hardcoded para que el dropdown no quede vacío. La defensa es
+ * "best-effort": la lista puede no estar 100% sincronizada con el
+ * back, pero el componente sigue funcionando.
+ */
+async function fetchAvailableTypes(): Promise<string[]> {
+  try {
+    const token = getAuthToken();
+    const res = await fetch(`${API_BASE_URL}/v3/reports/types`, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: "include",
+    });
+    if (!res.ok) {
+      // Fallback silencioso — el dropdown muestra los types del fallback.
+      return KNOWN_TYPES.map((t) => t.value);
+    }
+    const body = await res.json();
+    const data = (body?.data ?? []) as string[];
+    return Array.isArray(data) ? data : [];
+  } catch {
+    // Fallback silencioso.
+    return KNOWN_TYPES.map((t) => t.value);
+  }
+}
 
 const formatBytes = (bytes: number | null): string => {
   if (bytes === null || bytes === undefined) return "";
@@ -265,6 +305,12 @@ export default function DownloadHistory({
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [clearing, setClearing] = useState(false);
   const [clearError, setClearError] = useState<string | null>(null);
+  // S123 (HALLAZGO-NEW-32): lista de types disponibles del back
+  // (vía `GET /api/v3/reports/types`). Si el fetch falla, fallback
+  // al hardcoded KNOWN_TYPES (defensa best-effort).
+  const [availableTypes, setAvailableTypes] = useState<string[]>(
+    KNOWN_TYPES.map((t) => t.value),
+  );
 
   const perPage = DEFAULT_PAGE_SIZE;
   const totalPages = Math.max(1, Math.ceil(total / perPage));
@@ -324,6 +370,23 @@ export default function DownloadHistory({
     },
     [status, type, page, perPage],
   );
+
+  // S123 (HALLAZGO-NEW-32): fetch available types del back en mount.
+  // El dropdown usa estos values. Si el endpoint falla, fallback al
+  // KNOWN_TYPES hardcoded (defensa best-effort — ver fetchAvailableTypes).
+  // Solo se ejecuta UNA VEZ en mount (deps []) para no spammear el
+  // endpoint en cada cambio de filtro.
+  useEffect(() => {
+    let cancelled = false;
+    fetchAvailableTypes().then((types) => {
+      if (!cancelled) {
+        setAvailableTypes(types);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Initial + when status/page/type changes
   useEffect(() => {
@@ -426,12 +489,26 @@ export default function DownloadHistory({
     }
   }, [fetchPage, onClearCompleted]);
 
-  // S119: lista de types disponibles para el dropdown. Mostramos
-  // "Todos" + los types del KNOWN_TYPES que el user probablemente use.
-  // Si Mario quiere dropdown dinámico (basado en los types que el user
-  // realmente tiene), eso es S119b — pinear endpoint
-  // `GET /api/v3/reports/types` que retorne distinct types del user.
-  const typeOptions = useMemo(() => KNOWN_TYPES, []);
+  // S123 (HALLAZGO-NEW-32): el dropdown usa `availableTypes` (los
+  // types reales del back) en vez de `KNOWN_TYPES` hardcoded. Cada
+  // type se labela con KNOWN_TYPES si hay match, o con humanizeType
+  // fallback. Así el dropdown está siempre sincronizado con el back
+  // y nunca se "driftea" por rename de un ReportType.
+  //
+  // El useMemo deriva el array de `{value, label}[]` a partir de
+  // availableTypes + KNOWN_TYPES map. Si availableTypes aún no
+  // cargó (primer render), usa KNOWN_TYPES hardcoded como fallback.
+  const typeOptions = useMemo(() => {
+    return availableTypes.map((value) => {
+      const known = KNOWN_TYPES.find((t) => t.value === value);
+      return {
+        value,
+        label: known?.label ?? value
+          .replace(/[-_]/g, " ")
+          .replace(/\b\w/g, (c: string) => c.toUpperCase()),
+      };
+    });
+  }, [availableTypes]);
 
   return (
     <div className={styles.body} data-testid="download-history">

--- a/src/mk/components/ui/DownloadHistory/__tests__/Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx
+++ b/src/mk/components/ui/DownloadHistory/__tests__/Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx
@@ -143,6 +143,66 @@ describe("S119 (front) - DownloadHistory Modulo filter + Clear", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────
+  // S123 — dropdown consume types del back vía /v3/reports/types
+  // (HALLAZGO-NEW-32: derivá keys del back, NO hardcodees).
+  // ─────────────────────────────────────────────────────────────────
+
+  it("S123: pinea funcion fetchAvailableTypes que consume /v3/reports/types", () => {
+    // El componente debe fetchar los types del back en vez de usar
+    // KNOWN_TYPES hardcoded. Drift imposible.
+    expect(src).toMatch(
+      /async\s+function\s+fetchAvailableTypes\s*\(\s*\)\s*:\s*Promise\s*<\s*string\[\]\s*>/,
+    );
+    expect(src).toMatch(/`\$\{API_BASE_URL\}\/v3\/reports\/types`/);
+  });
+
+  it("S123: pinea useEffect que llama fetchAvailableTypes en mount", () => {
+    // Solo se ejecuta UNA VEZ en mount (deps vacias) para no spammear
+    // el endpoint en cada cambio de filtro.
+    expect(src).toMatch(
+      /useEffect\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?fetchAvailableTypes\(\)[\s\S]*?\}\s*,\s*\[\s*\]\s*\)/,
+    );
+  });
+
+  it("S123: pinea state availableTypes para los types del back", () => {
+    // El state se inicializa con KNOWN_TYPES hardcoded como fallback,
+    // pero se sobreescribe con la response del back.
+    expect(src).toMatch(
+      /const\s+\[\s*availableTypes\s*,\s*setAvailableTypes\s*\]\s*=\s*useState/,
+    );
+  });
+
+  it("S123: el dropdown usa availableTypes en vez de KNOWN_TYPES hardcoded", () => {
+    // El typeOptions useMemo se deriva de availableTypes (no de KNOWN_TYPES).
+    expect(src).toMatch(
+      /typeOptions\s*=\s*useMemo\(\s*\(\)\s*=>\s*\{[\s\S]*?return\s+availableTypes\.map/,
+    );
+  });
+
+  it("S123: fetchAvailableTypes tiene fallback silencioso a KNOWN_TYPES", () => {
+    // Si el endpoint falla, fallback al KNOWN_TYPES hardcoded para
+    // que el dropdown no quede vacío. Defensa best-effort.
+    expect(src).toMatch(/return\s+KNOWN_TYPES\.map\(\s*\(\s*t\s*\)\s*=>\s*t\.value\s*\)/);
+  });
+
+  it("S123: el helper KNOWN_TYPES sigue existiendo como label map (no se borra)", () => {
+    // KNOWN_TYPES se pineá como label map (los labels humanizados).
+    // El back es SSoT para los values, el front pineá KNOWN_TYPES solo
+    // para mapear values a labels bonitos.
+    expect(src).toContain("const KNOWN_TYPES:");
+  });
+
+  it("S123: KNOWN_TYPES incluye values plurales (owners, homeowners, reservations) — NO singulares", () => {
+    // HALLAZGO-NEW-32 + HALLAZGO-NEW-31: el KNOWN_TYPES pinea los
+    // values exactos del back (plurales, SSoT = ReportTypeRegistry).
+    // Si alguien pinea singulares (owner, homeowner, reservation),
+    // el filter no matchea.
+    expect(src).toMatch(/value:\s*["']owners["']/);
+    expect(src).toMatch(/value:\s*["']homeowners["']/);
+    expect(src).toMatch(/value:\s*["']reservations["']/);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
   // S119b — pre-seleccionar módulo en el dropdown cuando el modal
   // se abre desde un módulo específico (e.g. AsyncExportButton).
   // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# feat(s123): dropdown Módulo consume /v3/reports/types — derivá keys del back

**Cierra**: S123 front companion de [back PR #210](https://github.com/mariogfos/condaty2025-api/pull/210)

## TL;DR

El `DownloadHistory` ahora fetcha los types disponibles del back vía `GET /api/v3/reports/types` (HALLAZGO-NEW-32). El back devuelve los `type` strings que el user realmente tiene generados. **Drift imposible** — si el back renombra/agrega un type, el dropdown se actualiza solo.

## Cambios

### `DownloadHistory.tsx`

- **Nueva función `fetchAvailableTypes()`**: fetcha `${API_BASE_URL}/v3/reports/types` con Bearer. Retorna `string[]` (los types). Si falla, fallback al `KNOWN_TYPES` hardcoded.
- **Nuevo state `availableTypes`**: lista de types del back. Inicializado con `KNOWN_TYPES.map(t => t.value)` como fallback (defensa best-effort).
- **Nuevo `useEffect` en mount** (deps `[]`): llama `fetchAvailableTypes()` una sola vez. NO se re-fetcha en cada cambio de filtro (para no spammear el endpoint).
- **`typeOptions` useMemo** ahora deriva de `availableTypes` (no de `KNOWN_TYPES`):
  ```tsx
  const typeOptions = useMemo(() => {
    return availableTypes.map((value) => {
      const known = KNOWN_TYPES.find((t) => t.value === value);
      return {
        value,
        label: known?.label ?? value.replace(/[-_]/g, " ").replace(/\b\w/g, c => c.toUpperCase()),
      };
    });
  }, [availableTypes]);
  ```
- **`KNOWN_TYPES` actualizado con values plurales** que matchean el `ReportTypeRegistry` del back:
  - `owner` → `owners`
  - `homeowner` → `homeowners`
  - `reservation` → `reservations`
  - `budget` → `budgets`
  - `assembly-attendances` → `assemblies-attendances`
  - `debt-group` → `debt-groups`
  - `invitation` → `invitations`
  - `guard-news` agregado (estaba en el back pero no en el dropdown)

### Cómo se usa (transparente para el parent)

El componente sigue teniendo la misma API:
```tsx
<DownloadHistory />                          // todos los types
<DownloadHistory initialType="outlays" />   // pre-selecciona
<AsyncExportButton type="outlays" ... />     // hereda initialType automáticamente (S119b)
```

El dropdown internamente consume `/v3/reports/types` y muestra solo los types que el user realmente tiene. Si el endpoint falla, fallback al `KNOWN_TYPES` hardcoded.

## Tests

- **`Sprint119DownloadHistoryModuloFilterAndClearPin.test.tsx`** extendido con 7 nuevos source-parsing pines S123:
  - `fetchAvailableTypes` pineado y consume `/v3/reports/types`
  - `useEffect` en mount llama `fetchAvailableTypes` (deps `[]`)
  - State `availableTypes` pineado
  - Dropdown usa `availableTypes` (no `KNOWN_TYPES`)
  - Fallback silencioso a `KNOWN_TYPES` si fetch falla
  - `KNOWN_TYPES` sigue existiendo como label map
  - `KNOWN_TYPES` pinea values plurales correctos (`owners`, `homeowners`, `reservations`)

**Suite DownloadHistory**: 40 tests verde (33 anteriores + 7 S123).

**Suite completa**: 0 regresiones. 8 failures pre-existentes en `useAsyncExport` + `AssemblyStatusActions` (no relacionados).

## HALLAZGO-NEW-32 pineado (binding, cross-project)

**Regla**: cuando pinees un dropdown/select de "modules" o "categories" en el front, NUNCA hardcodees la lista de keys en el componente. SIEMPRE derivá la lista del back vía endpoint dedicado. Razones:
- Drift: si el back renombra/agrega keys, el front queda desincronizado sin error visible.
- Multi-tenant: la lista puede depender del user/context (e.g. solo types que el user tiene generados).
- Refactors: si movés una columna, la lista hardcoded queda apuntando a keys muertas.

**Patrón pineado** (S123):
1. Back expone `GET /api/v3/<resource>/<listing>` que retorna array de strings (distinct values del user autenticado).
2. Front fetcha en `useEffect` y usa la response en vez de constante.
3. Fallback opcional: si el endpoint falla, la front puede usar `KNOWN_TYPES` como fallback (defensa).

Aplica a TODO dropdown que el back expone (categories, modules, types, roles, etc.).

## Cross-IA

Mario, este PR es el front companion del back #210. Después de mergear AMBOS:

1. `git pull` (back + front)
2. `composer dump-autoload` + `php artisan optimize:clear` (back)
3. `sudo systemctl restart php8.4-fpm` (o `valet restart`)
4. Verificar:
   - `curl /api/v3/users` con token → 200 (no 404)
   - `curl /api/v3/reports/types` con token → 200 con array de types
   - Front: abrir "Historial" → el dropdown muestra los types reales del back, no los hardcoded

## Refs

- S84 (MME migration bug heredado) — Users routes sin v3
- S119 (PR #644 MERGED) — pineó el `DownloadHistory` con filter dropdown
- S123 (back PR #210) — fix Users routes + endpoint `/v3/reports/types`
- S123 (front, este PR) — consume el endpoint nuevo
- HALLAZGO-NEW-21 (multi-tenant / Bearer)
- HALLAZGO-NEW-22 (canónico `/v3/`)
- HALLAZGO-NEW-32 (binding cross-project nuevo: derivá keys del back)