### PR TITLE
fix(s130): Areas/RenderView label + onSaveStatus pinea enum (mata label invertido)

### DIFF
--- a/src/modulos/Areas/RenderView/RenderView.tsx
+++ b/src/modulos/Areas/RenderView/RenderView.tsx
@@ -18,9 +18,16 @@ import { useAuth } from "@/mk/contexts/AuthProvider";
 import Br from "@/components/Detail/Br";
 import { AreaStatus } from "@/modulos/Payments/Type/PaymentType";
 
-const status: any = {
-  A: "Activa",
-  X: "Inactiva",
+// S130 (HALLAZGO-NEW-39, binding cross-project): areas.status ahora
+// es TINYINT enum (AreaStatus::ACTIVE=1, MAINTENANCE=2), post S17-T3
+// (back). El mapa legacy `status = { A: "Activa", X: "Inactiva" }`
+// se reemplaza con el enum canónico. NOTA: el back `AreaController
+// ::statusArea` pineá un `$statusMap` que acepta tanto chars legacy
+// ('A'/'M') como enum values (1/2) en el input — pineamos enum
+// value (1 o 2) por consistencia.
+const AREA_STATUS_LABEL: Record<number, string> = {
+  [AreaStatus.ACTIVE]: "Activa",
+  [AreaStatus.MAINTENANCE]: "En mantenimiento",
 };
 
 const formatCoordinateValue = (value: any) => {
@@ -173,9 +180,11 @@ const RenderView = ({ open, item, onClose, reLoad }: any) => {
               <p className={styles.title}>Datos generales</p>
               <KeyValue
                 title={"Estado"}
-                value={status[item?.status]}
+                value={AREA_STATUS_LABEL[item?.status as number]}
                 colorValue={
-                  item?.status == "A" ? "var(--cSuccess)" : "var(--cError)"
+                  item?.status === AreaStatus.ACTIVE
+                    ? "var(--cSuccess)"
+                    : "var(--cError)"
                 }
               />
               <KeyValue
@@ -323,7 +332,9 @@ const RenderView = ({ open, item, onClose, reLoad }: any) => {
         <Button
           variant="secondary"
           onClick={() =>
-            item?.status == "A" ? setOpenConfirm(true) : onSaveStatus("A")
+            item?.status === AreaStatus.ACTIVE
+              ? setOpenConfirm(true)
+              : onSaveStatus(AreaStatus.ACTIVE)
           }
           style={{
             width: 150,
@@ -333,7 +344,9 @@ const RenderView = ({ open, item, onClose, reLoad }: any) => {
             color: "var(--cWhite)",
           }}
         >
-          {item?.status == "A" ? "Desactivar área" : "Activar área"}
+          {item?.status === AreaStatus.ACTIVE
+            ? "Desactivar área"
+            : "Activar área"}
         </Button>
 
         {openConfirm && (
@@ -344,7 +357,7 @@ const RenderView = ({ open, item, onClose, reLoad }: any) => {
             buttonText="Desactivar"
             buttonCancel="Cancelar"
             onSave={async () => {
-              onSaveStatus("X");
+              onSaveStatus(AreaStatus.MAINTENANCE);
             }}
           >
             <p>

--- a/src/modulos/Areas/RenderView/__tests__/Sprint130AreasRenderViewStatusPin.test.tsx
+++ b/src/modulos/Areas/RenderView/__tests__/Sprint130AreasRenderViewStatusPin.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * S130 (front) - Source-parsing pin + e2e test para HALLAZGO-NEW-39 (front).
+ *
+ * Problema: `Areas/RenderView/RenderView.tsx` pineaba `item?.status == "A"`
+ * (char legacy) para decidir el label del botón toggle ("Activar" vs
+ * "Desactivar área") y el flujo de onSaveStatus. Post-S17-T3 (back),
+ * `areas.status` es TINYINT enum (`AreaStatus::ACTIVE=1`, `MAINTENANCE=2`).
+ * El char `'A'` no matcheaba nada → el label siempre decía "Activar área"
+ * + el botón siempre llamaba `onSaveStatus("A")` (activar) + el modal
+ * de confirmación pineaba `onSaveStatus("X")` (que el back no entiende
+ * — `$statusMap` solo acepta 'A'/'M'/'1'/'2').
+ *
+ * Mario reportó: "en el detalle de las areas sociales, me aparece un
+ * boton que dice, activar area, aunque la area ya esta activa, y al
+ * dar click quiere desactivar, me parece que el label del boton esta mal".
+ *
+ * Es la **versión front** de HALLAZGO-NEW-31 (S122) + HALLAZGO-NEW-39 (S129).
+ * S130 pinea el consumer que renderiza el label.
+ *
+ * HALLAZGO-NEW-29: vitest con S118 S118b no los detecta. Usar Sprint130*.
+ *
+ * HALLAZGO-NEW-03: source-parsing pinea INTENCIÓN. Los e2e con RTL
+ * pinean EFECTIVIDAD. Ambos deben correr juntos.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import fs from "fs";
+import path from "path";
+
+const RENDER_VIEW_PATH = path.resolve(__dirname, "../RenderView.tsx");
+const RENDER_VIEW_SRC = fs.readFileSync(RENDER_VIEW_PATH, "utf-8");
+
+/**
+ * Mock useAxios para no pinear axios en tests. El mock retorna
+ * `{ data: { status: true, msg: "ok" } }` para que el código del
+ * componente no pinee unhandled errors al destructurar.
+ */
+const mockExecute = vi.fn().mockResolvedValue({
+  data: { status: true, msg: "ok" },
+});
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({ execute: mockExecute }),
+}));
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    showToast: vi.fn(),
+  }),
+}));
+
+import RenderView from "../RenderView";
+
+describe("S130 (front) - Areas RenderView status enum pin (HALLAZGO-NEW-39)", () => {
+  // --- SOURCE-PARSING PINE ESPECÍFICO ---
+
+  describe("source-parsing pines (intención)", () => {
+    beforeAll(() => {
+      // sanity check
+      expect(RENDER_VIEW_SRC.length).toBeGreaterThan(0);
+    });
+
+    it("RenderView.tsx pinea comparación con AreaStatus.ACTIVE (no char 'A')", () => {
+      // El fix de raíz: pinear `item?.status === AreaStatus.ACTIVE` en
+      // vez de `item?.status == "A"`. El test busca el patrón correcto
+      // Y rechaza el patrón incorrecto en el archivo.
+      expect(RENDER_VIEW_SRC).toMatch(/item\?\.status\s*===\s*AreaStatus\.ACTIVE/);
+      // No debe haber `== "A"` (char legacy) en comparaciones de status
+      // (en ninguna parte del archivo).
+      const matches = RENDER_VIEW_SRC.match(/status\s*==\s*["']A["']/g) ?? [];
+      expect(matches).toEqual([]);
+    });
+
+    it("RenderView.tsx pinea AREA_STATUS_LABEL map (no legacy const status)", () => {
+      // El label map debe pinear el enum canónico. Si alguien vuelve a
+      // pinear `const status = { A: ..., X: ... }`, falla.
+      expect(RENDER_VIEW_SRC).toMatch(/AREA_STATUS_LABEL\s*:/);
+      expect(RENDER_VIEW_SRC).toMatch(/\[AreaStatus\.ACTIVE\]\s*:/);
+      expect(RENDER_VIEW_SRC).toMatch(/\[AreaStatus\.MAINTENANCE\]\s*:/);
+      // El mapa legacy con chars 'A'/'X' no debe existir
+      expect(RENDER_VIEW_SRC).not.toMatch(/=\s*\{\s*['"]A['"]\s*:/);
+      expect(RENDER_VIEW_SRC).not.toMatch(/=\s*\{\s*['"]X['"]\s*:/);
+    });
+
+    it("RenderView.tsx pinea onSaveStatus con AreaStatus enum (no char 'A'/'X'/'M')", () => {
+      // onSaveStatus debe pinear AreaStatus enum values, no chars.
+      // El back `AreaController::statusArea` pineá $statusMap que acepta
+      // tanto chars legacy ('A'/'M') como enum values (1/2). Pineamos
+      // enum value por consistencia.
+      expect(RENDER_VIEW_SRC).toMatch(/onSaveStatus\(AreaStatus\.ACTIVE\)/);
+      expect(RENDER_VIEW_SRC).toMatch(/onSaveStatus\(AreaStatus\.MAINTENANCE\)/);
+      // onSaveStatus NO debe pinear chars legacy 'A'/'X'/'M'
+      expect(RENDER_VIEW_SRC).not.toMatch(/onSaveStatus\(["']A["']\)/);
+      expect(RENDER_VIEW_SRC).not.toMatch(/onSaveStatus\(["']X["']\)/);
+      expect(RENDER_VIEW_SRC).not.toMatch(/onSaveStatus\(["']M["']\)/);
+    });
+
+    it("RenderView.tsx pinea docblock S130 explicando el fix", () => {
+      // Si alguien borra el comentario S130, no se pierde el contexto.
+      expect(RENDER_VIEW_SRC).toContain("S130");
+      expect(RENDER_VIEW_SRC).toContain("HALLAZGO-NEW-39");
+    });
+  });
+
+  // --- E2E PINE (efectividad) ---
+
+  describe("e2e pines (efectividad)", () => {
+    beforeEach(() => {
+      // Reset pineando el return value por defecto (necesario porque
+      // el componente pineá `const { data } = await execute(...)` y si
+      // mockExecute retorna undefined, falla el destructuring).
+      mockExecute.mockReset();
+      mockExecute.mockResolvedValue({
+        data: { status: true, msg: "ok" },
+      });
+    });
+
+    afterEach(() => {
+      cleanup();
+    });
+
+    it("e2e: area ACTIVA muestra label 'Desactivar área' y abre modal de confirmación al click", async () => {
+      const item = { id: 1, status: 1, title: "Salon Test" }; // 1 = AreaStatus.ACTIVE
+      render(
+        <RenderView
+          open={true}
+          item={item}
+          onClose={() => {}}
+          reLoad={() => {}}
+        />,
+      );
+
+      // El label debe decir "Desactivar área" (NO "Activar área")
+      const button = screen.getByRole("button", { name: /Desactivar área/i });
+      expect(button).toBeInTheDocument();
+
+      // Click en el botón → debe abrir el modal de confirmación
+      // (NO llamar onSaveStatus directo)
+      fireEvent.click(button);
+
+      // El modal de confirmación debe aparecer
+      await waitFor(() => {
+        expect(screen.getByText(/Desactivar área social/i)).toBeInTheDocument();
+      });
+
+      // onSaveStatus NO debe haberse llamado todavía
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it("e2e: area INACTIVA (MAINTENANCE) muestra label 'Activar área' y llama onSaveStatus directo al click", async () => {
+      const item = { id: 2, status: 2, title: "Salon Inactivo" }; // 2 = AreaStatus.MAINTENANCE
+      render(
+        <RenderView
+          open={true}
+          item={item}
+          onClose={() => {}}
+          reLoad={() => {}}
+        />,
+      );
+
+      // El label debe decir "Activar área"
+      const button = screen.getByRole("button", { name: /Activar área/i });
+      expect(button).toBeInTheDocument();
+
+      // Click en el botón → debe llamar onSaveStatus(ACTIVE) directo
+      // (NO abrir modal de confirmación)
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockExecute).toHaveBeenCalledWith(
+          "/status-area",
+          "POST",
+          expect.objectContaining({
+            status: 1, // AreaStatus.ACTIVE
+            area_id: 2,
+          }),
+        );
+      });
+
+      // El modal de confirmación NO debe aparecer
+      expect(screen.queryByText(/Desactivar área social/i)).not.toBeInTheDocument();
+    });
+
+    it("e2e: el KeyValue 'Estado' muestra el label correcto del enum", () => {
+      const item = { id: 3, status: 1, title: "Salon Activo" };
+      render(
+        <RenderView
+          open={true}
+          item={item}
+          onClose={() => {}}
+          reLoad={() => {}}
+        />,
+      );
+
+      // El label debe ser "Activa" (no "Inactiva")
+      expect(screen.getByText("Activa")).toBeInTheDocument();
+      expect(screen.queryByText("Inactiva")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## S130 — `Areas/RenderView` label + `onSaveStatus` pinea enum (no char legacy)

### Problema (reportado por Mario 2026-07-28)

> "en el detalle de las areas sociales, me aparece un boton que dice, activar area, aunque la area ya esta activa, y al dar click quiere desactivar, me parece que el label del boton esta mal"

### Causa raíz

`src/modulos/Areas/RenderView/RenderView.tsx` pineaba `item?.status == "A"` (char legacy) en 3 lugares. Post-S17-T3 (back), `areas.status` es TINYINT enum (`AreaStatus::ACTIVE=1`, `MAINTENANCE=2`). El char `'A'` no matcheaba nada →:

1. **Label siempre decía "Activar área"** (match siempre falso)
2. **onClick siempre llamaba `onSaveStatus("A")`** (que es "activar", no "desactivar")
3. **Modal de confirmación pineaba `onSaveStatus("X")`** que el back `AreaController::statusArea` NO entiende (su `$statusMap` solo acepta `'A'/'M'/'1'/'2'`) → error silencioso

### Fix de raíz

Pinear `AreaStatus.ACTIVE` / `AreaStatus.MAINTENANCE` en todas las comparaciones y llamadas a `onSaveStatus`. Drop del mapa legacy `status = { A, X }` → `AREA_STATUS_LABEL` con enum.

### Cambios en `src/modulos/Areas/RenderView/RenderView.tsx`

| Línea | Antes | Después |
|---|---|---|
| 21-24 | `const status = { A: "Activa", X: "Inactiva" }` | `const AREA_STATUS_LABEL: Record<number, string> = { [AreaStatus.ACTIVE]: "Activa", [AreaStatus.MAINTENANCE]: "En mantenimiento" }` |
| 183 | `status[item?.status]` | `AREA_STATUS_LABEL[item?.status as number]` |
| 185 | `item?.status == "A" ? "var(--cSuccess)" : "var(--cError)"` | `item?.status === AreaStatus.ACTIVE ? "var(--cSuccess)" : "var(--cError)"` |
| 326 | `item?.status == "A" ? setOpenConfirm(true) : onSaveStatus("A")` | `item?.status === AreaStatus.ACTIVE ? setOpenConfirm(true) : onSaveStatus(AreaStatus.ACTIVE)` |
| 336 | `item?.status == "A" ? "Desactivar área" : "Activar área"` | `item?.status === AreaStatus.ACTIVE ? "Desactivar área" : "Activar área"` |
| 347 | `onSaveStatus("X")` | `onSaveStatus(AreaStatus.MAINTENANCE)` |

### Es la versión front de HALLAZGO-NEW-31 + HALLAZGO-NEW-39

- **S122** (HALLAZGO-NEW-31) pineó el bug en **ReportType** del back (cast `(int) $model->enumField`).
- **S129** (HALLAZGO-NEW-39) pineó el bug en **controllers** del back (`where('status', 'A')`).
- **S130** pinea el bug en **consumers del enum** del front (RenderView pineaba `item.status == "A"`).

### Tests (HALLAZGO-NEW-03: source-parsing + e2e)

**4 source-parsing pines**:
- Pinea `item?.status === AreaStatus.ACTIVE` (no char legacy)
- Pinea `AREA_STATUS_LABEL` map con enum (no legacy `const status`)
- Pinea `onSaveStatus(AreaStatus.ACTIVE/MAINTENANCE)` (no chars)
- Pinea docblock S130 + HALLAZGO-NEW-39 presente

**3 e2e RTL pines**:
- Area ACTIVA → label "Desactivar área" + click abre confirm modal
- Area INACTIVA → label "Activar área" + click llama `onSaveStatus(ACTIVE)` directo
- KeyValue "Estado" muestra label correcto del enum ("Activa" no "Inactiva")

### Suite

- **398 verde** (eran 391 + 7 nuevos S130)
- **8 pre-existing failures** (mismas que S127/S128 snapshot — 7 useAsyncExport + 1 AssemblyStatusActions flaky)
- **0 regresiones nuevas**

### Verificación manual post-merge

1. Hard refresh browser
2. Login → menú "Áreas sociales" → detalle de un área ACTIVA
3. **Resultado esperado**:
   - Pre-S130: botón decía "Activar área" + click llamaba `onSaveStatus("A")` (no hacía nada o error silencioso)
   - **Post-S130: botón dice "Desactivar área" + click abre modal de confirmación "Desactivar área social"**
4. Confirmar en el modal → toast: "El área ha sido desactivada"
5. Repetir para área INACTIVA → botón debe decir "Activar área" + click activa directo (sin modal)

### Cross-project

Aplica a TODO consumer front de un Model Eloquent con enum cast. Cuando el back migra char→enum, los consumers del front que pinean el char se rompen silenciosamente. S130 pinea el caso reportado (Areas/RenderView).

**Pin genérico cross-project** (futuro, S131b front): barrer TODO el front pineando `item?.status == "A"` o comparaciones con chars legacy en otros componentes. S130 pinea solo Areas/RenderView.

### Refs

- **S122** (HALLAZGO-NEW-31 ReportType)
- **S129** (HALLAZGO-NEW-39 back controllers)
- **S128** (HALLAZGO-NEW-38 axios drop /api)
- **HALLAZGO-NEW-03** (source-parsing pinea intención)
- **HALLAZGO-NEW-39** (nuevo — este sprint)

---

Mavis — 2026-07-28
