### PR TITLE
fix(s_front): pin front status enum contra char legacy (14 lugares)

### DIFF
--- a/src/modulos/Areas/Areas.tsx
+++ b/src/modulos/Areas/Areas.tsx
@@ -294,8 +294,8 @@ const Areas = () => {
         },
         onRender: (props: any) => {
           let status = "";
-          if ((props?.item?.status === AreaStatus.ACTIVE || props?.item?.status === 1 || props?.item?.status === "A")) status = "Activa";
-          if ((props?.item?.status === 0 || props?.item?.status === "X")) status = "Inactiva";
+          if (props?.item?.status === AreaStatus.ACTIVE) status = "Activa";
+          if (props?.item?.status === AreaStatus.MAINTENANCE) status = "Inactiva";
 
           return (
             <StatusBadge

--- a/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
@@ -169,7 +169,7 @@ const FourPart = ({ item }: { item: any }) => {
               title={"Estado"}
               value={status[item?.status]}
               colorValue={
-                item?.status == "A" ? "var(--cSuccess)" : "var(--cError)"
+                item?.status === AreaStatus.ACTIVE ? "var(--cSuccess)" : "var(--cError)"
               }
             />
             <KeyValue

--- a/src/modulos/Condominios/Condominios.tsx
+++ b/src/modulos/Condominios/Condominios.tsx
@@ -7,6 +7,7 @@ import RenderForm from "./RenderForm/RenderForm";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
 import { getDateTimeStrMes } from "@/mk/utils/date";
 import RenderDel from "./RenderDel/RenderDel";
+import { ClientStatus } from "@/modulos/Payments/Type/PaymentType";
 
 const paramsInitial = {
   perPage: 20,
@@ -24,7 +25,7 @@ const mod: ModCrudType = {
   extraData: true,
   onHideActions: (item: any) => {
     return {
-      hideDel: item.privacy == "P" || item.status == "I",
+      hideDel: item.privacy == "P" || item.status === ClientStatus.INACTIVE,
     };
   },
   hideActions: {

--- a/src/modulos/CreateReserva/CreateReserva.tsx
+++ b/src/modulos/CreateReserva/CreateReserva.tsx
@@ -599,12 +599,12 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
                         <KeyValue
                           title={"Estado"}
                           value={
-                            Number(selectedAreaDetails.status) === AreaStatus.ACTIVE || selectedAreaDetails.status === "A"
+                            Number(selectedAreaDetails.status) === AreaStatus.ACTIVE
                               ? "Disponible"
                               : "No Disponible"
                           }
                           colorValue={
-                            Number(selectedAreaDetails.status) === AreaStatus.ACTIVE || selectedAreaDetails.status === "A"
+                            Number(selectedAreaDetails.status) === AreaStatus.ACTIVE
                               ? "var(--cSuccess)"
                               : "var(--cError)"
                           }

--- a/src/modulos/HomeOwners/HomeOwners.tsx
+++ b/src/modulos/HomeOwners/HomeOwners.tsx
@@ -65,7 +65,7 @@ const HomeOwners = () => {
                 />
                 <KeyValue
                   title="Estado"
-                  value={(dpto.status === DptoStatus.ACTIVE || dpto.status === 1 || dpto.status === "A") ? "Activo" : "Inactivo"}
+                  value={dpto.status === DptoStatus.ACTIVE ? "Activo" : "Inactivo"}
                 />
                 {index < homeowner.dptos.length - 1 && (
                   <hr className={styles.unitDivider} />

--- a/src/modulos/Outlays/RenderView/RenderView.tsx
+++ b/src/modulos/Outlays/RenderView/RenderView.tsx
@@ -152,8 +152,8 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
   const parsedDescription = parseExpenseDescription(item?.description);
 
   const getStatusStyle = (status: number | string) => {
-    if (status === ExpenseStatus.ACTIVE || status === 1 || status === "A") return styles.statusPaid;
-    if (status === ExpenseStatus.CANCELLED || status === 0 || status === "X") return styles.statusCancelled;
+    if (status === ExpenseStatus.ACTIVE) return styles.statusPaid;
+    if (status === ExpenseStatus.CANCELLED) return styles.statusCancelled;
     return "";
   };
 

--- a/src/modulos/Owners/Owners.tsx
+++ b/src/modulos/Owners/Owners.tsx
@@ -24,6 +24,7 @@ import RenderForm from "../Owners/RenderForm/RenderForm";
 import ActiveOwner from "@/components/ActiveOwner/ActiveOwner";
 import RenderView from "./RenderView/RenderView";
 import { useAuth } from "@/mk/contexts/AuthProvider";
+import { DptoStatus, OwnerStatus } from "@/modulos/Payments/Type/PaymentType";
 
 const paramsInitial = {
   perPage: 20,
@@ -79,7 +80,7 @@ const Owners = () => {
                 />
                 <KeyValue
                   title="Estado"
-                  value={dpto.status === "A" ? "Activo" : "Inactivo"}
+                  value={dpto.status === DptoStatus.ACTIVE ? "Activo" : "Inactivo"}
                 />
                 {index < homeowner.dptos.length - 1 && (
                   <hr className={styles.unitDivider} />
@@ -128,7 +129,7 @@ const Owners = () => {
       extraData?: Record<string, any>;
       reLoad?: any;
     }) =>
-      props?.item.status === "W" && props?.item.type_owner !== "Dependiente" ? (
+      props?.item.status === OwnerStatus.WAITING && props?.item.type_owner !== "Dependiente" ? (
         <RenderView {...props} />
       ) : (
         <ProfileModal
@@ -359,7 +360,7 @@ const Owners = () => {
               <span
                 style={{
                   color:
-                    item?.status === "W"
+                    item?.status === OwnerStatus.WAITING
                       ? "var(--cWarning)"
                       : "var(--cWhiteV1)",
                 }}

--- a/src/modulos/Owners/RenderView/RenderView.tsx
+++ b/src/modulos/Owners/RenderView/RenderView.tsx
@@ -7,6 +7,7 @@ import Button from "@/mk/components/forms/Button/Button";
 import ActiveOwner from "@/components/ActiveOwner/ActiveOwner";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/mk/contexts/AuthProvider";
+import { ClientOwnerStatus } from "@/modulos/Payments/Type/PaymentType";
 
 const RenderView = (props: any) => {
   const { open, onClose, item: data, reLoad, execute, showToast } = props;
@@ -141,7 +142,7 @@ const RenderView = (props: any) => {
             </div>
           )}
 
-          {client?.pivot?.status === "W" && (
+          {client?.pivot?.status === ClientOwnerStatus.WAITING && (
             <div className={styles.boxButtons}>
               <Button
                 onClick={() => openModal("X")}

--- a/src/modulos/OwnersManager/OwnerManagers.tsx
+++ b/src/modulos/OwnersManager/OwnerManagers.tsx
@@ -326,7 +326,7 @@ const OwnerManager = () => {
             />
             <div>
               Usuario esta activo?:{" "}
-              <span>{(formState.status === ClientOwnerStatus.WAITING || formState.status === 2 || formState.status === "W") ? "No" : "Sí"}</span>
+              <span>{formState.status === ClientOwnerStatus.WAITING ? "No" : "Sí"}</span>
             </div>
             <br />
             El usuario esta vinculado a las siguientes Unidades:
@@ -344,7 +344,7 @@ const OwnerManager = () => {
             {formState.clients?.map((client: any) => (
               <div key={client.id}>
                 {client.client.name} (
-                {(client.status === ClientOwnerStatus.WAITING || client.status === 2 || client.status === "W") ? "No Activado" : "Activado"}) Rol:{" "}
+                {client.status === ClientOwnerStatus.WAITING ? "No Activado" : "Activado"}) Rol:{" "}
                 {getRol(client.type)}{" "}
                 {client.titular &&
                   " su Titular es: " + getFullName(client.titular) + " "}

--- a/src/modulos/Payments/Type/PaymentType.tsx
+++ b/src/modulos/Payments/Type/PaymentType.tsx
@@ -55,9 +55,23 @@ export enum AreaStatus {
  * S18.5a — DptoStatus numeric enum.
  *
  * Sincronizado con backend `App\Models\Enums\DptoStatus` (PHP):
+ * - INACTIVE = 0 (legacy 'X') — S_front + S135 pineado
  * - ACTIVE = 1 (legacy 'A')
  */
 export enum DptoStatus {
+  INACTIVE = 0,
+  ACTIVE = 1,
+}
+
+/**
+ * S_front — ClientStatus numeric enum.
+ *
+ * Sincronizado con backend `App\Modules\Clients\Enums\ClientStatus` (PHP):
+ * - INACTIVE = 0 (legacy 'I') — S135 pineado
+ * - ACTIVE = 1 (legacy 'A')
+ */
+export enum ClientStatus {
+  INACTIVE = 0,
   ACTIVE = 1,
 }
 
@@ -66,9 +80,15 @@ export enum DptoStatus {
  *
  * Sincronizado con backend `App\Modules\HomeOwner\Enums\OwnerStatus` (PHP):
  * - ACTIVE = 1 (legacy 'A')
+ * - WAITING = 2 (legacy 'W') — S_front + S132 pineado
+ * - PASSWORD_CHANGE_REQUIRED = 3 (legacy 'P') — S132 pineado
+ * - DISABLED = 4 (legacy 'X') — S132 pineado
  */
 export enum OwnerStatus {
   ACTIVE = 1,
+  WAITING = 2,
+  PASSWORD_CHANGE_REQUIRED = 3,
+  DISABLED = 4,
 }
 
 /**

--- a/src/modulos/_pins/__tests__/SprintSFrontStatusEnumPinning.test.ts
+++ b/src/modulos/_pins/__tests__/SprintSFrontStatusEnumPinning.test.ts
@@ -1,0 +1,105 @@
+/**
+ * S_front (front) - Source-parsing pin para HALLAZGO-NEW-39 (front variant).
+ *
+ * Problema: el front pineaba `item?.status === '<char>'` (char legacy 'A'/'I'/'X'/'W')
+ * contra Models del back con enum cast TINYINT (S17-T3/S6.5). Pre-S17 (cuando
+ * la columna era CHAR(1)), el char matcheaba. Post-S17, el back serializa el
+ * int (e.g. `AreaStatus::ACTIVE` = 1) y el char nunca matchea en `===`.
+ *
+ * HALLAZGO-NEW-39 variant front: pines `status === '<char>'` o `status == '<char>'`
+ * con Models del back que tienen enum cast TINYINT int-backed NUNCA matchean.
+ * El label/UI muestra siempre el fallback (e.g. "Inactivo" en vez de "Activo").
+ *
+ * Patrón pineado: el back devuelve int 1/2/3 (no char 'A'/'W'/'X'/'I'). El
+ * front debe comparar con el enum numérico (`AreaStatus.ACTIVE` = 1, no `'A'`).
+ *
+ * HALLAZGO-NEW-29: vitest con S118 S118b no los detecta. Usar SprintSFront*.
+ *
+ * HALLAZGO-NEW-03: source-parsing pinea INTENCIÓN. Los e2e con RTL pinean
+ * EFECTIVIDAD. Este test es source-parsing puro.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const SRC_ROOT = path.resolve(__dirname, "../../..");
+
+function readFile(relPath: string): string {
+  return fs.readFileSync(path.join(SRC_ROOT, relPath), "utf-8");
+}
+
+describe("S_front — Status enum pinning (HALLAZGO-NEW-39 front variant)", () => {
+  it("Areas.tsx: usa AreaStatus.ACTIVE/MAINTENANCE enum, NO char 'A'/'X'", () => {
+    const src = readFile("modulos/Areas/Areas.tsx");
+    // Debe pinear enum
+    expect(src).toMatch(/AreaStatus\.ACTIVE/);
+    expect(src).toMatch(/AreaStatus\.MAINTENANCE/);
+    // NO debe pinear char 'A'/'X' en status comparison
+    expect(src).not.toMatch(/status\s*===?\s*['"]A['"]/);
+    expect(src).not.toMatch(/status\s*===?\s*['"]X['"]/);
+  });
+
+  it("Areas/FourPart.tsx: usa AreaStatus.ACTIVE enum, NO char 'A'", () => {
+    const src = readFile("modulos/Areas/RenderForm/Partes/FourPart.tsx");
+    expect(src).toMatch(/AreaStatus\.ACTIVE/);
+    expect(src).not.toMatch(/status\s*==\s*['"]A['"]/);
+  });
+
+  it("CreateReserva.tsx: usa AreaStatus.ACTIVE enum, NO char 'A'", () => {
+    const src = readFile("modulos/CreateReserva/CreateReserva.tsx");
+    expect(src).toMatch(/AreaStatus\.ACTIVE/);
+    expect(src).not.toMatch(/status\s*===\s*['"]A['"]/);
+  });
+
+  it("Outlays/RenderView.tsx: usa ExpenseStatus enum, NO char 'A'/'X'", () => {
+    const src = readFile("modulos/Outlays/RenderView/RenderView.tsx");
+    expect(src).toMatch(/ExpenseStatus\.ACTIVE/);
+    expect(src).toMatch(/ExpenseStatus\.CANCELLED/);
+    expect(src).not.toMatch(/status\s*===\s*['"]A['"]/);
+    expect(src).not.toMatch(/status\s*===\s*['"]X['"]/);
+  });
+
+  it("HomeOwners.tsx: usa DptoStatus.ACTIVE enum, NO char 'A'", () => {
+    const src = readFile("modulos/HomeOwners/HomeOwners.tsx");
+    expect(src).toMatch(/DptoStatus\.ACTIVE/);
+    expect(src).not.toMatch(/status\s*===\s*['"]A['"]/);
+  });
+
+  it("Owners.tsx: usa DptoStatus.ACTIVE + OwnerStatus.WAITING enum, NO char 'A'/'W'", () => {
+    const src = readFile("modulos/Owners/Owners.tsx");
+    expect(src).toMatch(/DptoStatus\.ACTIVE/);
+    expect(src).toMatch(/OwnerStatus\.WAITING/);
+    expect(src).not.toMatch(/status\s*===\s*['"]A['"]/);
+    expect(src).not.toMatch(/status\s*===\s*['"]W['"]/);
+  });
+
+  it("OwnerManagers.tsx: usa ClientOwnerStatus.WAITING enum, NO char 'W'", () => {
+    const src = readFile("modulos/OwnersManager/OwnerManagers.tsx");
+    expect(src).toMatch(/ClientOwnerStatus\.WAITING/);
+    expect(src).not.toMatch(/status\s*===\s*['"]W['"]/);
+  });
+
+  it("Owners/RenderView/RenderView.tsx: usa ClientOwnerStatus.WAITING enum, NO char 'W'", () => {
+    const src = readFile("modulos/Owners/RenderView/RenderView.tsx");
+    expect(src).toMatch(/ClientOwnerStatus\.WAITING/);
+    expect(src).not.toMatch(/pivot\?\.status\s*===\s*['"]W['"]/);
+  });
+
+  it("Condominios.tsx: usa ClientStatus.INACTIVE enum (S135), NO char 'I'", () => {
+    const src = readFile("modulos/Condominios/Condominios.tsx");
+    expect(src).toMatch(/ClientStatus\.INACTIVE/);
+    expect(src).not.toMatch(/status\s*==\s*['"]I['"]/);
+  });
+
+  it("PaymentType.tsx: enums extendidos con cases del back (S132, S135)", () => {
+    const src = readFile("modulos/Payments/Type/PaymentType.tsx");
+    // OwnerStatus: 4 cases (S132 pineó WAITING, PASSWORD_CHANGE_REQUIRED, DISABLED)
+    expect(src).toMatch(/WAITING\s*=\s*2/);
+    expect(src).toMatch(/PASSWORD_CHANGE_REQUIRED\s*=\s*3/);
+    expect(src).toMatch(/DISABLED\s*=\s*4/);
+    // DptoStatus: INACTIVE = 0 (S135 pineó)
+    expect(src).toMatch(/INACTIVE\s*=\s*0/);
+    // ClientStatus: creado en S_front (NUEVO, no existía en front)
+    expect(src).toMatch(/export\s+enum\s+ClientStatus/);
+  });
+});


### PR DESCRIPTION
## HALLAZGO-NEW-39 variant 9 (front)

Pines `status === '<char>'` o `status == '<char>'` con Models del back que tienen enum cast TINYINT int-backed NUNCA matchean post-S17. El front debe comparar con el enum numérico.

## 14 lugares fixeados

| Archivo | Cambio |
|---|---|
| `Areas.tsx` | 2 lugares (AreaStatus.ACTIVE/MAINTENANCE) |
| `FourPart.tsx` | AreaStatus.ACTIVE |
| `CreateReserva.tsx` | 2 lugares (AreaStatus.ACTIVE) |
| `Outlays/RenderView.tsx` | 2 lugares (ExpenseStatus.ACTIVE/CANCELLED) |
| `HomeOwners.tsx` | DptoStatus.ACTIVE |
| `Owners.tsx` | 3 lugares (DptoStatus.ACTIVE + OwnerStatus.WAITING) |
| `OwnerManagers.tsx` | 2 lugares (ClientOwnerStatus.WAITING) |
| `Owners/RenderView/RenderView.tsx` | ClientOwnerStatus.WAITING |
| `Condominios.tsx` | ClientStatus.INACTIVE (post-S135) |

## Enums front extendidos

- `OwnerStatus`: 4 cases (S132 pineó en back)
- `DptoStatus`: INACTIVE = 0 (S135 pineó en back)
- `ClientStatus`: NUEVO creado (S135 pineó INACTIVE=0 en back)

## Bug latente severidad media activa

`Condominios.tsx:27` `item.status == 'I'` para `hideDel`. La condición NUNCA matcheaba → botón delete se mostraba incluso para clientes inactivos (bug latente desde S17-T4).

## Pin front source-parsing (10 tests)

`SprintSFrontStatusEnumPinning.test.ts` pineá cada uno de los 9 archivos + PaymentType.tsx. Sintaxis vitest `Sprint*` (NO S118* — HALLAZGO-NEW-29).

## Tests

- 10 nuevos tests verde
- 408 total verde (+10 S_front)
- 8 pre-existing failures (7 useAsyncExport + 1 AssemblyStatusActions flaky, no relacionados)
- 0 regresiones nuevas

## HALLAZGO-NEW-39 pineado en 9 variantes finales

S_front agrega la **variante 9** (front) a la serie S127-S136.

Refs: S127-S136 (NEW-39 8 variantes back), S_front (NEW-39 variant 9 front).