### PR TITLE
fix(s139-fe): displayName en DownloadHistory + SharedDebts/DetailSharedDebts fix

### DIFF
--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
@@ -100,6 +100,19 @@ export type DownloadHistoryItem = {
   id: number;
   uuid: string;
   type: string;
+  /**
+   * S139 (HALLAZGO-NEW-48): displayName del ReportType pineado según
+   * params (e.g. "Deuda Individual", "Deudas Compartidas", "Condonaciones",
+   * "Reporte de Expensas"). Si el back retorna `name`, se pineá en el
+   * render del item + en el filename del download. Si NO se pineá
+   * (ReportType legacy sin override), fallback a `humanizeType(type)`.
+   *
+   * Multi-branch pineado: el mismo `type` (e.g. "debt-dptos") pinea
+   * 4 vistas distintas — el `name` permite distinguir en el dropdown
+   * del histórico y en el filename del archivo bajado.
+   */
+  name?: string | null;
+  format: string;
   status: DownloadHistoryStatus;
   created_at: string | null;
   download_url: string | null;
@@ -188,6 +201,12 @@ const KNOWN_TYPES: { value: string; label: string }[] = [
   { value: "invitations", label: "Invitaciones" },
   { value: "budgets", label: "Presupuesto" },
   { value: "bank-entities", label: "Entidades Bancarias" },
+  // S139 (HALLAZGO-NEW-48): `debt-dptos` pineá 4 vistas distintas según
+  // params (Deuda Individual, Deudas Compartidas, Condonaciones, Todas).
+  // El label del dropdown es el type técnico humanizado (legacy fallback);
+  // el label de cada item del histórico pineá `name` (displayName dinámico
+  // del ReportType) que se computa server-side.
+  { value: "debt-dptos", label: "Deudas por Dpto" },
   { value: "debt-groups", label: "Grupos de Deuda" },
   { value: "assemblies-attendances", label: "Asistencia a Asambleas" },
   { value: "guard-news", label: "Guardias Nuevos" },
@@ -432,7 +451,22 @@ export default function DownloadHistory({
         const blobUrl = window.URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = blobUrl;
-        link.download = `${item.type}-${item.uuid}.${item.type.includes("xlsx") || item.type.includes("excel") ? "xlsx" : "pdf"}`;
+        // S139 (HALLAZGO-NEW-48 + HALLAZGO-NEW-49): filename pinea
+        // displayName (legible) + format normalizado ('excel'→'xlsx').
+        // El back ya pinea esto en Content-Disposition, pero algunos
+        // browsers reescriben el filename al hacer Blob download — pineamos
+        // también acá para que el archivo bajado se llame "deuda_individual-XXXX.xlsx"
+        // en vez de "debt-dptos-XXXX.excel".
+        const downloadFormat =
+          item.format === "excel" ? "xlsx" : (item.format || "pdf");
+        const downloadName = item.name || humanizeType(item.type);
+        const sanitizedName = downloadName
+          .toLowerCase()
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "")
+          .replace(/[^a-z0-9_\-]+/g, "_")
+          .replace(/^_+|_+$/g, "");
+        link.download = `${sanitizedName || "reporte"}-${item.uuid}.${downloadFormat}`;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
@@ -594,8 +628,14 @@ export default function DownloadHistory({
       ) : (
         <ul className={styles.list} data-testid="download-history-list">
           {items.map((item) => {
-            const isXlsx =
-              item.type.includes("xlsx") || item.type.includes("excel");
+            // S139 (HALLAZGO-NEW-48): pinea `item.name` (displayName del
+            // ReportType según params) si está pineado. Fallback a
+            // `humanizeType(item.type)` (legacy) para ReportTypes sin
+            // override. Esto permite distinguir "Deuda Individual",
+            // "Deudas Compartidas", "Condonaciones" — todos con type
+            // "debt-dptos".
+            const displayLabel = item.name || humanizeType(item.type);
+            const isXlsx = item.format === "xlsx" || item.format === "excel";
             const Icon = isXlsx ? FileSpreadsheet : FileText;
             const isCompleted = item.status === "completed";
             return (
@@ -610,7 +650,9 @@ export default function DownloadHistory({
                   aria-hidden="true"
                 />
                 <div className={styles.itemBody}>
-                  <p className={styles.itemTitle}>{humanizeType(item.type)}</p>
+                  <p className={styles.itemTitle} data-testid="download-history-item-title">
+                    {displayLabel}
+                  </p>
                   <p className={styles.itemMeta}>
                     <span>{formatDate(item.created_at)}</span>
                     {item.size_bytes !== null && item.size_bytes > 0 && (

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
@@ -246,27 +246,35 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
   }, []);
 
   const mod: ModCrudType = {
-    modulo: "v3/debt-dptos",
+    // S139 (HALLAZGO-NEW-48 + Bug #2 Mario 2026-07-29): el DETALLE de una
+    // deuda compartida (vista que se abre al hacer click en una fila de
+    // SharedDebts) pineá el REPORTE AGRUPADO del periodo (DebtGroupReportType
+    // EXPENSE branch — 7 cols agregado por periodo, año, mes).
+    //
+    // Pre-S139: pineá `type: "debt-dptos"` + `type: 1` → DebtDptoReportType
+    // EXPENSE branch → 8 cols por deuda individual del periodo. Pero el
+    // usuario esperaba el REPORTE DEL GRUPO (7 cols agregado), no las
+    // deudas individuales. El label y las columnas no matcheaban.
+    //
+    // Post-S139: pineá `type: "debt-groups"` + `extraParams: { type: 1, debt_id: X }`
+    // → DebtGroupReportType EXPENSE branch → "Listado de EXPENSAS"
+    // (7 cols agregado por `debt_id, year, month`).
+    //
+    // Cross-IA: `debt-dptos` se conserva para las vistas que pineá
+    // deudas individuales (IndividualDebts, SharedDebts lista, Forgiveness,
+    // AllDebts). `debt-groups` se pineá para el detalle de periodo y la
+    // lista CRUD de expensas (Expenses.tsx).
+    modulo: "v3/debt-groups",
     singular: "Detalle",
     plural: "Detalles",
-    // S47.5: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
-    // - export: false → kill legacy GET /api/v3/debt-dptos?_export=pdf.
-    // - exportAsync: {...} → slot async que useCrud auto-renderea via
-    //   AsyncExportButton (S36.5 pattern, idéntico a S41 BankAccounts,
-    //   S43 Outlays, S45 Areas).
-    // - type: "debt-dptos" → matchea el DebtDptoReportType pineado en
-    //   S47 backend (ReportTypeRegistry.auto-discovery, 11 tipos).
-    // - extraParams.type: 1 (EXPENSE) + debt_id dinámico → branch EXPENSE
-    //   del ReportType (8 cols: unidad, fecha_pago_date3, fecha_plazo_date3,
-    //   estado, monto_cur, multa_cur, mv_cur, total_sum_cur).
-    //   El debtId es un PROP del componente (SharedDebts → DetailSharedDebts
-    //   navega con el debt_id específico de la shared debt seleccionada).
-    //   Como el mod se declara en el render, extraParams lee `debtId` del
-    //   closure del componente — funciona en cada render.
-    // - format: "pdf" (S47 pineá PDF only, no XLSX — D-47-3).
+    // S48-T01 pattern: exportAsync slot para el reporte AGRUPADO del periodo.
+    // - type: "debt-groups" → DebtGroupReportType branch EXPENSE (7 cols).
+    // - extraParams.type: 1 (EXPENSE) + debt_id dinámico → filtra por el
+    //   periodo específico seleccionado en SharedDebts.
+    // - format: "pdf" (PDF only — XLSX pineá `dpto-deudas` para Unidades).
     export: false,
     exportAsync: {
-      type: "debt-dptos",
+      type: "debt-groups",
       format: "pdf",
       label: "Exportar PDF",
       extraParams: { type: 1, debt_id: debtId },

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
@@ -448,27 +448,40 @@ const SharedDebts: React.FC<SharedDebtsProps> = ({ onExtraDataChange }) => {
   }, []);
 
   const mod: ModCrudType = {
-    modulo: "debt-groups",
+    // S139 (HALLAZGO-NEW-48 + Bug #2 Mario 2026-07-29): la lista de
+    // "Deudas Compartidas" pineá las DEUDAS INDIVIDUALES tipo SHARED,
+    // NO el reporte agrupado de expensas.
+    //
+    // Pre-S139: pineá `type: "debt-groups"` → DebtGroupReportType
+    // EXPENSE branch → "Listado de EXPENSAS" (7 cols agregado por periodo).
+    // Eso era el reporte de la lista CRUD de expensas, NO las deudas
+    // compartidas. El usuario veía el reporte equivocado.
+    //
+    // Post-S139: pineá `type: "debt-dptos"` + `extraParams: { type: 4 }`
+    // → DebtDptoReportType NORMAL branch → "TODAS LAS DEUDAS COMPARTIDAS"
+    // (6 cols por deuda individual tipo SHARED).
+    //
+    // Cross-IA: el `DebtGroupReportType` (type="debt-groups") se conserva
+    // para el detalle del periodo (DetailSharedDebts) y para la lista CRUD
+    // de expensas (Expenses.tsx, módulo "v3/debt-groups"). Ver S139-fe.
+    modulo: "v3/debt-dptos",
     singular: "Deuda Compartida",
     plural: "",
     // S48: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
-    // - export: false → kill legacy GET /api/v3/debt-groups?_export=pdf.
+    // - export: false → kill legacy GET /api/v3/debt-dptos?_export=pdf.
     // - exportAsync: {...} → slot async que useCrud auto-renderea via
-    //   AsyncExportButton (S36.5 pattern, idéntico a S41 BankAccounts,
-    //   S43 Outlays, S45 Areas, S47.5 DebtDpto).
-    // - type: "debt-groups" → matchea el DebtGroupReportType pineado en
-    //   S48-T01 backend (PR #133, ReportTypeRegistry.auto-discovery,
-    //   12 tipos).
-    // - extraParams.type: undefined → branch EXPENSE del ReportType
-    //   (7 cols agregado por debt_id/year/month). Si el usuario pinea
-    //   type=4 (SHARED), el branch cambia automáticamente (S48-T01
-    //   detectBranch).
-    // - format: "pdf" (S48-T01 pineá PDF only, no XLSX — D-48-3).
+    //   AsyncExportButton (S36.5 pattern).
+    // - type: "debt-dptos" + extraParams.type: 4 (SHARED) → branch NORMAL
+    //   de DebtDptoReportType → 6 cols por deuda individual tipo SHARED,
+    //   "TODAS LAS DEUDAS COMPARTIDAS". Filtra por `debt_dptos.type = 4`.
+    // - format: "pdf" (PDF only — XLSX pineá `dpto-deudas` para el reporte
+    //   de Unidades, no este).
     export: false,
     exportAsync: {
-      type: "debt-groups",
+      type: "debt-dptos",
       format: "pdf",
       label: "Exportar PDF",
+      extraParams: { type: 4 },
     },
     filter: true,
     permiso: "expense",

--- a/src/modulos/_pins/__tests__/SprintS139FeReportsDisplayNameAndSharedDebts.test.ts
+++ b/src/modulos/_pins/__tests__/SprintS139FeReportsDisplayNameAndSharedDebts.test.ts
@@ -1,0 +1,249 @@
+/**
+ * S139 (HALLAZGO-NEW-48 + HALLAZGO-NEW-49) — front pin
+ *
+ * Cubre los fixes de 2 bugs reportados por Mario post-S137 (2026-07-29):
+ *
+ * **Bug #1 (deuda_individual label)**: el select del histórico de
+ * descargas y el filename del download mostraban "debt-dptos" (type
+ * técnico) para los 4 vistas distintas que pinean este type (Individual,
+ * Compartidas, Condonaciones, Todas). Fix: el back ahora retorna
+ * `name` (displayName del ReportType según params) en cada item del
+ * `GET /api/v3/reports`. El front pineá `item.name` en el render del
+ * item y en el filename del download.
+ *
+ * **Bug #2 (Deudas Compartidas vs Expensas)**: SharedDebts (lista)
+ * pineá `type: "debt-groups"` → DebtGroupReportType EXPENSE branch
+ * ("Listado de EXPENSAS", 7 cols agregado). Debería pinear
+ * `type: "debt-dptos"` con `extraParams: { type: 4 }` →
+ * DebtDptoReportType NORMAL branch ("TODAS LAS DEUDAS COMPARTIDAS",
+ * 6 cols por deuda individual). DetailSharedDebts (click en fila)
+ * pineá el reporte equivocado. Fix: cambiar el `mod.exportAsync.type`
+ * + `extraParams` de SharedDebts y DetailSharedDebts.
+ *
+ * **Bug #3 (XLSX unidades → PDF malformado)**: el back normaliza
+ * 'excel' → 'xlsx' (HALLAZGO-NEW-49). El download pinea
+ * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+ * y filename con extensión `.xlsx`. El front hace defense-in-depth
+ * normalizando format en el default download flow.
+ *
+ * Patrón source-parsing + render: HALLAZGO-NEW-03 (binding, cross-project).
+ * Diff in scope: 0 BC break (S138 fix de login pineado).
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FRONT_ROOT = path.resolve(__dirname, "../../..");
+const BACK_TS_ROOT = path.resolve(__dirname, "..");
+
+const readFile = (relPath: string): string => {
+  const abs = path.join(FRONT_ROOT, relPath);
+  return fs.readFileSync(abs, "utf8");
+};
+
+const stripComments = (source: string): string => {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+};
+
+const loadSourceWithoutComments = (relPath: string): string => {
+  return stripComments(readFile(relPath));
+};
+
+describe("S139-fe — displayName dinámico + SharedDebts/DetailSharedDebts fix", () => {
+  // ────────────────────────────────────────────────────────────────────
+  // Bug #1 — displayName en DownloadHistory
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("DownloadHistory pinea `name` (displayName) del back", () => {
+    it("DownloadHistoryItem type incluye `name` opcional", () => {
+      const src = readFile(
+        "mk/components/ui/DownloadHistory/DownloadHistory.tsx"
+      );
+      // El type DownloadHistoryItem pineá `name` opcional.
+      expect(src).toMatch(/name\?:\s*string\s*\|\s*null/);
+      // HALLAZGO-NEW-48 pineado en el docblock.
+      expect(src).toMatch(/S139 \(HALLAZGO-NEW-48\)/);
+    });
+
+    it("DownloadHistory pinea `item.name` cuando está pineado, fallback a `humanizeType(item.type)`", () => {
+      const src = readFile(
+        "mk/components/ui/DownloadHistory/DownloadHistory.tsx"
+      );
+      // El render del item pineá `item.name` si está disponible.
+      expect(src).toMatch(/item\.name\s*\|\|\s*humanizeType\(item\.type\)/);
+      // El displayName pineá en `itemTitle` con data-testid.
+      expect(src).toMatch(/data-testid="download-history-item-title"/);
+    });
+
+    it("DownloadHistory filename pinea name sanitizado + format normalizado (excel→xlsx)", () => {
+      const src = readFile(
+        "mk/components/ui/DownloadHistory/DownloadHistory.tsx"
+      );
+      // Format pineá 'excel' → 'xlsx' (defense in depth — el back ya normaliza).
+      expect(src).toMatch(/item\.format === "excel"\s*\?\s*"xlsx"/);
+      // Filename pineá `sanitizedName` (displayName) en lugar de `item.type`.
+      expect(src).toMatch(/sanitizedName\s*\|\|\s*"reporte"/);
+      // El filename format pineá 'xlsx'|'pdf' (no 'excel').
+      expect(src).toMatch(/\$\{downloadFormat\}/);
+      // No debe pinear `item.type.includes("excel")` legacy (post-S139).
+      expect(src).not.toMatch(/item\.type\.includes\(['"]excel['"]\)/);
+    });
+
+    it("KNOWN_TYPES pineá `debt-dptos` → 'Deudas por Dpto' (legacy fallback para dropdown)", () => {
+      const src = readFile(
+        "mk/components/ui/DownloadHistory/DownloadHistory.tsx"
+      );
+      // Compat: el dropdown pineá KNOWN_TYPES como label fallback. El
+      // `debt-dptos` debe tener un label humanizado.
+      expect(src).toMatch(/value:\s*["']debt-dptos["']/);
+      expect(src).toMatch(/label:\s*["']Deudas por Dpto["']/);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Bug #2 — SharedDebts pinea `debt-dptos` (no `debt-groups`)
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("SharedDebts lista pinea `debt-dptos` + type=4 (no `debt-groups`)", () => {
+    it("SharedDebts.tsx pineá modulo: 'v3/debt-dptos' + exportAsync.type: 'debt-dptos'", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx"
+      );
+      // modulo pineá 'v3/debt-dptos' (no 'debt-groups').
+      expect(src).toMatch(/modulo:\s*["']v3\/debt-dptos["']/);
+      // exportAsync.type pineá 'debt-dptos' (no 'debt-groups').
+      expect(src).toMatch(/type:\s*["']debt-dptos["']/);
+      // extraParams.type = 4 (SHARED) para DebtDptoReportType NORMAL branch.
+      expect(src).toMatch(/extraParams:\s*\{\s*type:\s*4\s*\}/);
+    });
+
+    it("SharedDebts NO pineá `debt-groups` (regression pin)", () => {
+      // loadSourceWithoutComments ya pineó comentarios. Pero el `modulo: "debt-groups"`
+      // NO debe estar en el archivo (regression pin).
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx"
+      );
+      // El modulo pineá 'v3/debt-dptos', no 'debt-groups'.
+      expect(src).not.toMatch(/modulo:\s*["']debt-groups["']/);
+      // El exportAsync.type NO pineá 'debt-groups' tampoco.
+      expect(src).not.toMatch(/type:\s*["']debt-groups["']/);
+    });
+
+    it("SharedDebts.tsx pineá docblock S139 con contexto del fix", () => {
+      const src = readFile(
+        "modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx"
+      );
+      // El docblock explica el cambio S139 + HALLAZGO-NEW-48.
+      expect(src).toMatch(/S139/);
+      expect(src).toMatch(/HALLAZGO-NEW-48/);
+      expect(src).toMatch(/Deuda Compartida/);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Bug #2 — DetailSharedDebts pinea `debt-groups` (no `debt-dptos`)
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("DetailSharedDebts pinea `debt-groups` + type=1 (no `debt-dptos`)", () => {
+    it("DetailSharedDebts.tsx pineá modulo: 'v3/debt-groups' + exportAsync.type: 'debt-groups'", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx"
+      );
+      // modulo pineá 'v3/debt-groups' (no 'v3/debt-dptos').
+      expect(src).toMatch(/modulo:\s*["']v3\/debt-groups["']/);
+      // exportAsync.type pineá 'debt-groups' (no 'debt-dptos').
+      expect(src).toMatch(/type:\s*["']debt-groups["']/);
+      // extraParams.type = 1 (EXPENSE) + debt_id dinámico.
+      expect(src).toMatch(/extraParams:\s*\{\s*type:\s*1,\s*debt_id:\s*debtId\s*\}/);
+    });
+
+    it("DetailSharedDebts NO pineá `debt-dptos` (regression pin)", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx"
+      );
+      // El modulo pineá 'v3/debt-groups', no 'v3/debt-dptos'.
+      expect(src).not.toMatch(/modulo:\s*["']v3\/debt-dptos["']/);
+      // El exportAsync.type NO pineá 'debt-dptos' tampoco.
+      expect(src).not.toMatch(/type:\s*["']debt-dptos["']/);
+    });
+
+    it("DetailSharedDebts.tsx pineá docblock S139 con contexto del fix", () => {
+      const src = readFile(
+        "modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx"
+      );
+      expect(src).toMatch(/S139/);
+      expect(src).toMatch(/HALLAZGO-NEW-48/);
+      // Explica que pineá DebtGroupReportType (7 cols agregado por periodo).
+      expect(src).toMatch(/agrupado/i);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Cross-check: las 4 vistas de `debt-dptos` no pinean type=1 (EXPENSE)
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("Las 4 vistas de `debt-dptos` pinean tipos distintos (no EXPENSE)", () => {
+    it("IndividualDebts pineá type=0 (NORMAL)", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx"
+      );
+      expect(src).toMatch(/extraParams:\s*\{\s*type:\s*0\s*\}/);
+    });
+
+    it("SharedDebts pineá type=4 (SHARED) — verificado arriba", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx"
+      );
+      expect(src).toMatch(/extraParams:\s*\{\s*type:\s*4\s*\}/);
+    });
+
+    it("Forgiveness pineá type=5 (FORGIVENESS)", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx"
+      );
+      expect(src).toMatch(/extraParams:\s*\{\s*type:\s*5\s*\}/);
+    });
+
+    it("AllDebts NO pineá extraParams.type (default 'TODAS LAS DEUDAS')", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx"
+      );
+      // AllDebts NO pineá `extraParams.type` (el back detecta branch NORMAL
+      // con $isAllDebts = true).
+      expect(src).not.toMatch(/extraParams:\s*\{\s*type:/);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Cross-check: ninguna vista pineá modulo: 'v3/debt-groups' para
+  // deudas individuales (regression pin).
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("Regresión: vistas de deudas individuales pinean 'v3/debt-dptos', no 'v3/debt-groups'", () => {
+    it("IndividualDebts NO pineá modulo: 'v3/debt-groups'", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx"
+      );
+      expect(src).toMatch(/modulo:\s*["']v3\/debt-dptos["']/);
+      expect(src).not.toMatch(/modulo:\s*["']v3\/debt-groups["']/);
+    });
+
+    it("Forgiveness NO pineá modulo: 'v3/debt-groups'", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx"
+      );
+      expect(src).toMatch(/modulo:\s*["']v3\/debt-dptos["']/);
+      expect(src).not.toMatch(/modulo:\s*["']v3\/debt-groups["']/);
+    });
+
+    it("AllDebts NO pineá modulo: 'v3/debt-groups'", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx"
+      );
+      expect(src).toMatch(/modulo:\s*["']v3\/debt-dptos["']/);
+      expect(src).not.toMatch(/modulo:\s*["']v3\/debt-groups["']/);
+    });
+  });
+});


### PR DESCRIPTION
## S139-fe — displayName + SharedDebts vs Expensas

2 bugs del front reportados por Mario post-S137 (2026-07-29):

### Bug #1 — deuda_individual label
El select del histórico y el filename del download de 'Deuda Individual' mostraban 'debt-dptos' (type técnico). El mismo type pineá 4 vistas distintas — el usuario no podía distinguir.

### Bug #2 — Deudas Compartidas vs Expensas
SharedDebts (lista) exportaba el reporte de EXPENSAS en lugar de las deudas compartidas individuales. DetailSharedDebts (click en fila) exportaba las deudas individuales del periodo en vez del reporte del GRUPO (agregado por periodo).

### Cambios
- `SharedDebts`: type 'debt-groups' → 'debt-dptos' + extraParams: { type: 4 } (DebtDptoReportType NORMAL → 6 cols por deuda individual SHARED).
- `DetailSharedDebts`: type 'debt-dptos' → 'debt-groups' + extraParams: { type: 1, debt_id } (DebtGroupReportType EXPENSE → 7 cols agregado por periodo).
- `DownloadHistory`: pineá item.name (displayName del back) en el render del item y en el filename del download. Format 'excel' → 'xlsx' normalizado.
- `KNOWN_TYPES`: agregado 'debt-dptos' → 'Deudas por Dpto'.

### Tests
- 17 tests vitest nuevos (SprintS139FeReportsDisplayNameAndSharedDebts) — 4 DownloadHistory + 3 SharedDebts + 3 DetailSharedDebts + 4 cross-check tipos + 3 regresión.
- 429 verde total (post-S_front: 412 + 17 míos).
- 8 pre-existing failures (no relacionados).
- 0 regresiones nuevas.

Refs: S139-bk (PR #224, displayName + format normalize en back), S137-bk (PR #222, Critical fixes), S138-bk (PR #223, UserStatusCast BC).

### Post-merge verificación
1. Hard refresh del browser.
2. Verificar:
   - 'Deudas → Compartidas → Exportar PDF' baja 'TODAS LAS DEUDAS COMPARTIDAS' (6 cols por deuda individual).
   - 'Deudas → click en fila → Exportar PDF' baja 'Listado de EXPENSAS' (7 cols agregado por periodo).
   - 'Unidades → Estado de cuentas XLSX' baja un XLSX con Content-Type correcto.
   - Histórico muestra 'Deuda Individual' / 'Deudas Compartidas' / 'Condonaciones' en lugar de 'debt-dptos' genérico.
3. Filename: `deuda_individual-XXXX.pdf`, `deudas_compartidas-XXXX.pdf`, `reporte_de_expensas-XXXX.pdf`.