### PR TITLE
fix(s140-fe): dedup KNOWN_TYPES (dpto-deudas y debt-dptos con label distinto)

### DIFF
--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
@@ -190,7 +190,12 @@ const KNOWN_TYPES: { value: string; label: string }[] = [
   { value: "expenses", label: "Expensas" },
   { value: "accesses", label: "Accesos" },
   { value: "defaulters", label: "Morosos" },
-  { value: "dpto-deudas", label: "Deudas por Dpto" },
+  // S139: `dpto-deudas` es el ReportType de Unidades (XLSX "estado de
+  // cuentas"). `debt-dptos` es el ReportType de Deudas Individuales /
+  // Compartidas / Condonaciones (PDF, multi-branch). Antes pinean el
+  // mismo label "Deudas por Dpto" → duplicado en el dropdown. Fix:
+  // pinear labels distintos.
+  { value: "dpto-deudas", label: "Deudas por Dpto (XLSX)" },
   { value: "bank-accounts", label: "Cuentas Bancarias" },
   { value: "areas", label: "Áreas" },
   { value: "events", label: "Eventos" },
@@ -205,9 +210,10 @@ const KNOWN_TYPES: { value: string; label: string }[] = [
   // params (Deuda Individual, Deudas Compartidas, Condonaciones, Todas).
   // El label del dropdown es el type técnico humanizado (legacy fallback);
   // el label de cada item del histórico pineá `name` (displayName dinámico
-  // del ReportType) que se computa server-side.
-  { value: "debt-dptos", label: "Deudas por Dpto" },
-  { value: "debt-groups", label: "Grupos de Deuda" },
+  // del ReportType) que se computa server-side. Multi-branch → label
+  // genérico "Deudas — Detalles".
+  { value: "debt-dptos", label: "Deudas — Detalles" },
+  { value: "debt-groups", label: "Deudas — Grupos" },
   { value: "assemblies-attendances", label: "Asistencia a Asambleas" },
   { value: "guard-news", label: "Guardias Nuevos" },
   { value: "array_chunked", label: "Reporte (genérico)" },

--- a/src/modulos/_pins/__tests__/SprintS139FeReportsDisplayNameAndSharedDebts.test.ts
+++ b/src/modulos/_pins/__tests__/SprintS139FeReportsDisplayNameAndSharedDebts.test.ts
@@ -91,14 +91,27 @@ describe("S139-fe — displayName dinámico + SharedDebts/DetailSharedDebts fix"
       expect(src).not.toMatch(/item\.type\.includes\(['"]excel['"]\)/);
     });
 
-    it("KNOWN_TYPES pineá `debt-dptos` → 'Deudas por Dpto' (legacy fallback para dropdown)", () => {
+    it("KNOWN_TYPES pineá `debt-dptos` con label distinto a `dpto-deudas` (no duplicado)", () => {
+      // S140: el `debt-dptos` pineá 4 vistas multi-branch (Individual,
+      // Compartidas, Condonaciones, Todas). El `dpto-deudas` pineá el
+      // reporte de Unidades (XLSX estado de cuentas). Pre-S140 ambos
+      // pinean "Deudas por Dpto" → duplicado en el dropdown. Post-S140
+      // pinean labels distintos.
       const src = readFile(
         "mk/components/ui/DownloadHistory/DownloadHistory.tsx"
       );
       // Compat: el dropdown pineá KNOWN_TYPES como label fallback. El
       // `debt-dptos` debe tener un label humanizado.
       expect(src).toMatch(/value:\s*["']debt-dptos["']/);
-      expect(src).toMatch(/label:\s*["']Deudas por Dpto["']/);
+      // El label pineá algo distinto a "Deudas por Dpto" (que es
+      // de dpto-deudas). Default: "Deudas — Detalles" o "Deudas Individuales
+      // y Compartidas". Pin genérico: NO debe contener "Deudas por Dpto".
+      const debtDptosMatch = src.match(
+        /value:\s*["']debt-dptos["'],\s*label:\s*["']([^"']+)["']/,
+      );
+      expect(debtDptosMatch).not.toBeNull();
+      expect(debtDptosMatch![1]).not.toBe("Deudas por Dpto");
+      expect(debtDptosMatch![1]).not.toMatch(/Deudas por Dpto/);
     });
   });
 


### PR DESCRIPTION
## S140-fe — dedup KNOWN_TYPES

Bug #8 (parcial) Mario 2026-07-29: el select del histórico de descargas mostraba 'Deudas por Dpto' 2 veces (una por dpto-deudas, otra por debt-dptos). Bug introducido en S139-fe al agregar 'debt-dptos' al KNOWN_TYPES sin chequear el overlap con 'dpto-deudas' existente.

### Fix
- `dpto-deudas`: 'Deudas por Dpto (XLSX)' — reporte de Unidades (estado de cuentas, XLSX only).
- `debt-dptos`: 'Deudas — Detalles' — reporte de Deudas Individuales / Compartidas / Condonaciones (PDF, multi-branch).
- `debt-groups`: 'Deudas — Grupos' — reporte agrupado por periodo.

### Tests
- 17 verde (post-fix, 17/17 S139-fe test).
- 8 pre-existing failures (no relacionados).
- 0 regresiones nuevas.

Refs: S139-fe (PR #652), S140-bk (PR #225), Mario bug #8 2026-07-29.