### PR TITLE
fix(s140-fe-2): 6 UI/UX fixes (#1, #3, #5, #10, #13, #14)

### DIFF
--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
@@ -596,9 +596,8 @@ export default function DownloadHistory({
         </label>
 
         {!hideClearButton && items.length > 0 && (
-          <button
-            type="button"
-            className={styles.clearBtn}
+          <Button
+            variant="primary"
             onClick={() => {
               setClearError(null);
               setShowClearConfirm(true);
@@ -609,7 +608,7 @@ export default function DownloadHistory({
           >
             <Trash2 size={14} />
             Limpiar historial
-          </button>
+          </Button>
         )}
       </div>
 

--- a/src/mk/utils/utils.tsx
+++ b/src/mk/utils/utils.tsx
@@ -140,10 +140,26 @@ export let lIdeologies = [
   { id: "25", name: "Herrerismo" },
 ];
 export const lStatusActive: any = {
-  A: { name: "Activo" },
-  X: { name: "Inactivo" },
-  W: { name: "Por activar" },
-  P: { name: "Debe cambiar contraseña" },
+  // S140 (HALLAZGO-NEW-39 variant): el back pinea `OwnerStatus` enum
+  // numérico (post-S132). Las keys legacy CHAR ('A', 'X', 'W', 'P') ya
+  // no matchean — todo caía en "Desconocido". Fix: pinear keys numéricas
+  // 1-4 que matchean el enum del back (src/modulos/Payments/Type/PaymentType.tsx).
+  //
+  // Pre-S140 (legacy, char):
+  //   A: Activo
+  //   X: Inactivo
+  //   W: Por activar
+  //   P: Debe cambiar contraseña
+  //
+  // Post-S140 (numeric, post-S132):
+  //   1 (OwnerStatus.ACTIVE): Activo
+  //   2 (OwnerStatus.WAITING): Por activar
+  //   3 (OwnerStatus.PASSWORD_CHANGE_REQUIRED): Debe cambiar contraseña
+  //   4 (OwnerStatus.DISABLED): Inactivo
+  1: { name: "Activo" },
+  2: { name: "Por activar" },
+  3: { name: "Debe cambiar contraseña" },
+  4: { name: "Inactivo" },
   // en un futuro el estado inactivo se manejara de acuerdo al campo delete_at
 };
 export const lComDestinies: any = [

--- a/src/modulos/Assemblies/config/assemblies.config.tsx
+++ b/src/modulos/Assemblies/config/assemblies.config.tsx
@@ -28,6 +28,17 @@ export const getAssemblyConfig = (
     search: true,
     filter: true,
     titleAdd: "Crear",
+    // S140 (bug #10 backlog Mario 2026-07-28): faltaba slot `exportAsync`
+    // en la lista de Asambleas. Pineamos `assembly-attendances`
+    // (AssemblyAttendancesReportType, S110 pre-existente) que es el
+    // ReportType más cercano a "asambleas" en el back. useCrud
+    // auto-renderea el AsyncExportButton (S36.5 pattern).
+    export: false,
+    exportAsync: {
+      type: "assembly-attendances",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
     hideActions: {
       view: false,
       edit: false,

--- a/src/modulos/Contents/Contents.tsx
+++ b/src/modulos/Contents/Contents.tsx
@@ -135,7 +135,11 @@ const Contents = () => {
     singular: "publicación",
     plural: "",
     permiso: "contents",
-    titleAdd: "Nueva",
+    // S140 (bug #14 backlog Mario 2026-07-28): el botón "Agregar" del
+    // módulo Publicaciones se renderizaba con label "Nueva" (genérico).
+    // Fix: pinear label explícito "Nueva publicación" para que el
+    // user sepa qué tipo de contenido va a crear.
+    titleAdd: "Nueva publicación",
     export: false,
     extraData: true,
     filter: true,

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
@@ -460,7 +460,18 @@ const AllDebts: React.FC<AllDebtsProps> = ({ onExtraDataChange }) => {
     modulo: "v3/debt-dptos",
     singular: "Deuda",
     plural: "",
-    // export: true,
+    // S140 (HALLAZGO-NEW-39 variant + bug #5 backlog Mario 2026-07-28):
+    // faltaba slot `exportAsync` en la tab "Deudas" (default "Todas las
+    // Deudas" post-S139). Slot pineado apuntando a `debt-dptos` sin
+    // extraParams.type (default "Todas las Deudas" pineado por
+    // `DebtDptoReportType::displayName`). useCrud auto-renderea el
+    // AsyncExportButton (S36.5 pattern).
+    export: false,
+    exportAsync: {
+      type: "debt-dptos",
+      format: "pdf",
+      label: "Exportar PDF",
+    },
     filter: true,
     permiso: "expense",
     extraData: true,

--- a/src/modulos/Outlays/Outlays.tsx
+++ b/src/modulos/Outlays/Outlays.tsx
@@ -264,15 +264,28 @@ const Outlays = () => {
             }
 
             const statusConfig: StatusConfig = {
-              A: {
-                label: "Pagado",
-                color: "var(--cSuccess)",
-                bgColor: "var(--cHoverCompl2)",
-              },
-              X: {
+              // S140 (HALLAZGO-NEW-39 variant): el back pinea `ExpenseStatus`
+              // enum numérico (post-S2-T2). Las keys legacy CHAR ('A', 'X')
+              // ya no matchean — todo caía en "Desconocido". Fix: pinear
+              // keys numéricas que matchean el enum del back
+              // (app/Modules/Expenses/Enums/ExpenseStatus.php).
+              //
+              // Pre-S140 (legacy, char):
+              //   A: Pagado
+              //   X: Anulado
+              //
+              // Post-S140 (numeric, post-ExpenseStatus enum):
+              //   0 (ExpenseStatus.CANCELLED): Anulado
+              //   1 (ExpenseStatus.ACTIVE): Pagado
+              0: {
                 label: "Anulado",
                 color: "var(--cWhite)",
                 bgColor: "var(--cHoverCompl1)",
+              },
+              1: {
+                label: "Pagado",
+                color: "var(--cSuccess)",
+                bgColor: "var(--cHoverCompl2)",
               },
             };
 
@@ -282,7 +295,10 @@ const Outlays = () => {
               bgColor: "var(--cHoverCompl1)",
             };
 
-            const status = props.item.status as keyof typeof statusConfig;
+            // Coerce to number (back pinea int, pero el JSON a veces
+            // viene como string — defensa en profundidad).
+            const rawStatus = props.item.status;
+            const status = typeof rawStatus === "string" ? parseInt(rawStatus, 10) : rawStatus;
             const { label, color, bgColor } =
               statusConfig[status] || defaultConfig;
 

--- a/src/modulos/_pins/__tests__/SprintS140Fe2StatusEnumMismatchPin.test.ts
+++ b/src/modulos/_pins/__tests__/SprintS140Fe2StatusEnumMismatchPin.test.ts
@@ -1,0 +1,131 @@
+/**
+ * S140-fe-2 (HALLAZGO-NEW-39 variant) — front pin
+ *
+ * Fixes 2 bugs del backlog Mario 2026-07-28 (PRIORIDAD 2):
+ *
+ * **Bug #3 — Egresos "Estado Desconocido" en lista** (Outlays.tsx):
+ * el front pineá `statusConfig` con keys CHAR legacy ('A', 'X') pero
+ * el back pinea `ExpenseStatus` enum numérico (0=CANCELLED, 1=ACTIVE)
+ * post-S2-T2. Mismatch → todo caía en "Desconocido".
+ *
+ * **Bug #13 — Residentes "Tipo/estado Desconocido"** (Owners.tsx +
+ * utils.tsx lStatusActive): el front pineá `lStatusActive` con keys
+ * CHAR legacy ('A', 'X', 'W', 'P') pero el back pinea `OwnerStatus`
+ * enum numérico (1-4) post-S132. Mismatch → todo caía en "Desconocido".
+ *
+ * Fix: cambiar las keys de ambos maps a numéricas para que matcheen
+ * los enums del back. Defense in depth: el front coerce string→int
+ * para tolerar respuestas JSON que vienen como string.
+ *
+ * Patrón source-parsing: HALLAZGO-NEW-03 (binding, cross-project).
+ * Diff in scope: 0 BC break (S139 displayName pineado, S140-bk #12 MERGED).
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FRONT_ROOT = path.resolve(__dirname, "../../..");
+
+const readFile = (relPath: string): string => {
+  const abs = path.join(FRONT_ROOT, relPath);
+  return fs.readFileSync(abs, "utf8");
+};
+
+const stripComments = (source: string): string => {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+};
+
+const loadSourceWithoutComments = (relPath: string): string => {
+  return stripComments(readFile(relPath));
+};
+
+describe("S140-fe-2 — fix mismatch status enum numérico", () => {
+  // ────────────────────────────────────────────────────────────────────
+  // Bug #3 — Outlays statusConfig con keys numeric
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("Outlays.tsx statusConfig con keys numéricas (ExpenseStatus enum)", () => {
+    it("statusConfig tiene keys numéricas 0 y 1 (no CHAR 'A'/'X')", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/Outlays/Outlays.tsx"
+      );
+      // Post-S140: pineá keys numéricas que matchean el enum del back.
+      expect(src).toMatch(/0:\s*\{\s*label:\s*["']Anulado["']/);
+      expect(src).toMatch(/1:\s*\{\s*label:\s*["']Pagado["']/);
+      // Regression pin: NO debe tener keys CHAR 'A' ni 'X' en este statusConfig.
+      // (Los comments pueden mencionarlas, pero el código no debe pinearlas).
+      const statusConfigMatch = src.match(
+        /const statusConfig[^=]*=\s*\{([\s\S]*?)\n\s*\};/,
+      );
+      expect(statusConfigMatch).not.toBeNull();
+      const statusConfigBody = statusConfigMatch![1];
+      // El body del statusConfig no debe tener keys 'A' o 'X' con el formato `A: {`
+      expect(statusConfigBody).not.toMatch(/^\s*A:\s*\{/m);
+      expect(statusConfigBody).not.toMatch(/^\s*X:\s*\{/m);
+    });
+
+    it("Outlays.tsx pineá HALLAZGO-NEW-39 variant comment", () => {
+      const src = readFile("modulos/Outlays/Outlays.tsx");
+      expect(src).toMatch(/S140/);
+      expect(src).toMatch(/HALLAZGO-NEW-39 variant/);
+    });
+
+    it("Outlays.tsx coerce string→int (defense in depth)", () => {
+      const src = loadSourceWithoutComments(
+        "modulos/Outlays/Outlays.tsx"
+      );
+      // El cast pineá coerción explícita: typeof string → parseInt.
+      expect(src).toMatch(/parseInt\(rawStatus,\s*10\)/);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Bug #13 — lStatusActive con keys numéricas
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("utils.tsx lStatusActive con keys numéricas (OwnerStatus enum)", () => {
+    it("lStatusActive tiene keys numéricas 1-4 (no CHAR 'A'/'X'/'W'/'P')", () => {
+      const src = loadSourceWithoutComments("mk/utils/utils.tsx");
+      // Post-S140: pineá keys numéricas que matchean el enum del back.
+      expect(src).toMatch(/1:\s*\{\s*name:\s*["']Activo["']/);
+      expect(src).toMatch(/2:\s*\{\s*name:\s*["']Por activar["']/);
+      expect(src).toMatch(/3:\s*\{\s*name:\s*["']Debe cambiar contraseña["']/);
+      expect(src).toMatch(/4:\s*\{\s*name:\s*["']Inactivo["']/);
+
+      // Regression pin: el lStatusActive NO debe tener keys CHAR.
+      // Match el bloque exacto `{ ... }` después de `lStatusActive: any = {`.
+      const lStatusMatch = src.match(
+        /lStatusActive:\s*any\s*=\s*\{([\s\S]*?)\n\};/,
+      );
+      expect(lStatusMatch).not.toBeNull();
+      const body = lStatusMatch![1];
+      expect(body).not.toMatch(/^\s*A:\s*\{/m);
+      expect(body).not.toMatch(/^\s*X:\s*\{/m);
+      expect(body).not.toMatch(/^\s*W:\s*\{/m);
+      expect(body).not.toMatch(/^\s*P:\s*\{/m);
+    });
+
+    it("utils.tsx pineá S140 docblock con contexto del fix", () => {
+      const src = readFile("mk/utils/utils.tsx");
+      expect(src).toMatch(/S140/);
+      expect(src).toMatch(/HALLAZGO-NEW-39 variant/);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Cross-check: lStatusActive no se usa con keys CHAR en otros consumers
+  // ────────────────────────────────────────────────────────────────────
+
+  describe("Regresión: lStatusActive pineá enum numérico en todos los consumers", () => {
+    it("Owners.tsx pinea `lStatusActive[item?.status]` con status numérico (sin cambios)", () => {
+      // Owners.tsx ya importaba OwnerStatus enum. El cambio está en lStatusActive.
+      // Acá pineamos que el consumer pineá el map directo.
+      const src = loadSourceWithoutComments("modulos/Owners/Owners.tsx");
+      expect(src).toMatch(/lStatusActive\[item\?\.status\]/);
+      // El OwnerStatus enum se importa (sanity).
+      expect(src).toMatch(/import\s*\{[^}]*OwnerStatus[^}]*\}\s*from/);
+    });
+  });
+});


### PR DESCRIPTION
## S140-fe-2 — 6 UI/UX fixes

Fixes 6 issues del backlog Mario 2026-07-28 (PRIORIDAD 2):

- **#1**: 'Limpiar historial' del DownloadHistory — pineá `<Button variant='primary'>` (más prominente).
- **#3**: Egresos 'Desconocido' — `statusConfig` con keys numéricas (0=CANCELLED, 1=ACTIVE) en Outlays.tsx.
- **#5**: Deudas tab 'Deudas' sin exportar — slot `exportAsync: { type: 'debt-dptos' }` agregado en AllDebts.tsx.
- **#10**: Asambleas lista sin exportar — slot `exportAsync: { type: 'assembly-attendances' }` agregado en assemblies.config.tsx.
- **#13**: Residentes 'Desconocido' — `lStatusActive` con keys numéricas (1-4, OwnerStatus enum) en utils.tsx.
- **#14**: Publicaciones 'Nueva publicación' — `titleAdd: 'Nueva publicación'` en Contents.tsx.

Bug #11 (Asistentes modal atrapado) queda pendiente — HALLAZGO-NEW-51, requiere server-side debug.

### Tests
- 6 tests vitest nuevos (SprintS140Fe2StatusEnumMismatchPin) — todos verde.
- 435 verde total (post-S139-fe: 412 + 6 + 17).
- 8 pre-existing failures (no relacionados).
- 0 regresiones nuevas.

### HALLAZGOS nuevos
- HALLAZGO-NEW-39 variant (front): status enum numeric mismatch.
- HALLAZGO-NEW-51: Asistentes modal atrapado (pendiente server-side debug).

Refs: S139 (PR #224, #652), S140-bk #12 (PR #225), S140-fe dedup (PR #653).