### PR TITLE
feat(s143e-fe): DownloadButton con ícono + menú (PDF/XLS/CSV) + useAsyncExport.endpoint

### DIFF
--- a/src/mk/components/ui/DownloadButton/DownloadButton.module.css
+++ b/src/mk/components/ui/DownloadButton/DownloadButton.module.css
@@ -1,0 +1,87 @@
+.wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--cBorder, #d0d0d0);
+  border-radius: var(--controlRadius, 6px);
+  cursor: pointer;
+  color: var(--cAccent, #00a37a);
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.iconButton:hover:not(:disabled) {
+  background-color: var(--cHoverModal, #f0f0f0);
+  border-color: var(--cAccent, #00a37a);
+}
+
+.iconButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chevron {
+  opacity: 0.7;
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  min-width: 180px;
+  background-color: var(--cModalSurface, #ffffff);
+  border: 1px solid var(--cModalBorder, #d0d0d0);
+  border-radius: var(--bRadiusM, 6px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.menuItem {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--cWhite, #414141);
+  font-size: 14px;
+  transition: background-color 0.15s ease;
+}
+
+.menuItem:hover {
+  background-color: var(--cHoverModal, #f0f0f0);
+}
+
+.menuDivider {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--cBorder, #e0e0e0);
+}

--- a/src/mk/components/ui/DownloadButton/DownloadButton.tsx
+++ b/src/mk/components/ui/DownloadButton/DownloadButton.tsx
@@ -1,0 +1,241 @@
+"use client";
+/**
+ * DownloadButton (S143e — HALLAZGO-NEW-54, binding, cross-project)
+ *
+ * Reemplaza el patrón "Exportar PDF" con un ícono Download + menú.
+ *
+ * Patrón de uso (S143e — HALLAZGO-NEW-54):
+ *
+ *     // Modo multi-format (PDF + XLSX + CSV): el botón pineá un ícono Download.
+ *     // Al click, se abre un dropdown con las opciones de format.
+ *     <DownloadButton
+ *       type="payments"
+ *       params={{ startDate: '2026-01-01', endDate: '2026-07-29' }}
+ *       supportedFormats={['pdf', 'xlsx', 'csv']}
+ *     />
+ *
+ *     // Modo single-format (CustomReport): el botón pineá un ícono Download
+ *     // directo (sin menú). El single click dispatcha el export.
+ *     <DownloadButton
+ *       type="balance"
+ *       params={{ from: '2026-01-01', to: '2026-07-29' }}
+ *       supportedFormats={['pdf']}
+ *     />
+ *
+ * Características:
+ *   - Solo ícono (sin texto "Exportar PDF"). Tooltip via `title` HTML.
+ *   - Si `supportedFormats.length > 1`: dropdown con PDF / XLS / CSV.
+ *   - Si `supportedFormats.length === 1`: single click directo.
+ *   - Reusa `useAsyncExport` (mismo flow async que `AsyncExportButton`).
+ *   - `useExtraData` y `requiredRelations` se pinean en params (S143e).
+ *
+ * Cross-project: el patrón "ícono + menú" es replicable a TODO proyecto
+ * con useCrud. Reemplaza el patrón "Exportar PDF / Exportar XLSX" duplicado
+ * en cada módulo.
+ */
+import { useState } from "react";
+import { Download, ChevronDown, LoaderCircle } from "lucide-react";
+import {
+  useAsyncExport,
+  type AsyncExportState,
+} from "../../../hooks/useAsyncExport/useAsyncExport";
+import ExportProgressModal from "../ExportProgressModal/ExportProgressModal";
+import { DownloadHistoryModal } from "../DownloadHistory";
+import styles from "./DownloadButton.module.css";
+
+export type DownloadFormat = "pdf" | "xlsx" | "csv";
+
+type PropsType = {
+  /** Identificador del módulo (e.g. "payments", "outlays"). */
+  type: string;
+  /** Parámetros del reporte (filterBy, searchBy, fechas, etc.). */
+  params: Record<string, any>;
+  /**
+   * S143e (HALLAZGO-NEW-54): formats soportados por el ExportConfig del
+   * módulo. Si pineá 1 solo format → single click directo. Si pineá 2-3 →
+   * dropdown.
+   *
+   * Default: ['pdf'] (compat con consumers legacy que solo pineán PDF).
+   */
+  supportedFormats?: DownloadFormat[];
+  /**
+   * S143e (HALLAZGO-NEW-54): URL del endpoint de lista del módulo (e.g.
+   * `/api/v3/payments`). Si se pineá, el flow consume este endpoint
+   * con `?_export=pdf|xls|csv` en vez del endpoint BC layer
+   * `POST /api/v3/reports/{type}/export`.
+   *
+   * Default: null (usa el flow BC layer legacy).
+   */
+  endpoint?: string | null;
+  /**
+   * S143e (HALLAZGO-NEW-54): si `true`, el Controller pineá `extraData`
+   * antes del export (metadata adicional: totales, categorías, etc.).
+   */
+  useExtraData?: boolean;
+  /**
+   * S143e (HALLAZGO-NEW-54): relations que el Controller debe eager-load
+   * antes del export (e.g. ['paymentMethod', 'category', 'bankAccount']).
+   */
+  requiredRelations?: string[];
+  /** Callback cuando el export completa exitosamente. */
+  onCompleted?: (state: AsyncExportState) => void;
+  /** Callback cuando hay error. */
+  onError?: (error: string) => void;
+  /** Clases CSS adicionales. */
+  className?: string;
+  /** title HTML para tooltip. Default: "Exportar". */
+  title?: string;
+};
+
+const formatLabel: Record<DownloadFormat, string> = {
+  pdf: "PDF",
+  xlsx: "Excel (XLSX)",
+  csv: "CSV",
+};
+
+export default function DownloadButton({
+  type,
+  params,
+  supportedFormats = ["pdf"],
+  endpoint = null,
+  useExtraData = false,
+  requiredRelations = [],
+  onCompleted,
+  onError,
+  className,
+  title = "Exportar",
+}: PropsType) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const hasMultipleFormats = supportedFormats.length > 1;
+
+  const { state, start, download, reset } = useAsyncExport({
+    type,
+    endpoint, // S143e: si se pineá, useAsyncExport lo consume.
+    onCompleted: (s) => {
+      onCompleted?.(s);
+      setModalOpen(true);
+    },
+    onError: (msg) => {
+      onError?.(msg);
+      setModalOpen(true);
+    },
+  });
+
+  /**
+   * S143e (HALLAZGO-NEW-54): dispatcha el export con el format pineado.
+   * Si el ExportConfig pineá `useExtraData` o `requiredRelations`, los
+   * pasamos en params (el back los consume).
+   */
+  const handleExport = async (format: DownloadFormat) => {
+    setMenuOpen(false);
+    setModalOpen(true);
+    const exportParams: Record<string, any> = {
+      ...params,
+      format: format === "xlsx" ? "xlsx" : format,
+    };
+    if (useExtraData) {
+      exportParams._useExtraData = "1";
+    }
+    if (requiredRelations.length > 0) {
+      exportParams._requiredRelations = requiredRelations.join(",");
+    }
+    await start(exportParams);
+  };
+
+  const handleDirectClick = () => {
+    if (hasMultipleFormats) {
+      setMenuOpen((v) => !v);
+      return;
+    }
+    handleExport(supportedFormats[0] ?? "pdf");
+  };
+
+  const handleClose = () => {
+    setModalOpen(false);
+    reset();
+  };
+
+  return (
+    <>
+      <span className={styles.wrapper}>
+        <button
+          type="button"
+          onClick={handleDirectClick}
+          disabled={state.isExporting}
+          className={`${styles.iconButton} ${className ?? ""}`.trim()}
+          data-testid={`download-btn-${type}`}
+          title={title}
+          aria-label={title}
+        >
+          {state.isExporting ? (
+            <LoaderCircle size={16} className={styles.spinner} />
+          ) : (
+            <Download size={16} />
+          )}
+          {hasMultipleFormats && (
+            <ChevronDown size={12} className={styles.chevron} />
+          )}
+        </button>
+
+        {hasMultipleFormats && menuOpen && (
+          <div
+            className={styles.menu}
+            data-testid={`download-menu-${type}`}
+            role="menu"
+          >
+            {supportedFormats.map((fmt) => (
+              <button
+                key={fmt}
+                type="button"
+                role="menuitem"
+                className={styles.menuItem}
+                onClick={() => handleExport(fmt)}
+                data-testid={`download-menuitem-${type}-${fmt}`}
+              >
+                {formatLabel[fmt]}
+              </button>
+            ))}
+            <hr className={styles.menuDivider} />
+            <button
+              type="button"
+              role="menuitem"
+              className={styles.menuItem}
+              onClick={() => {
+                setMenuOpen(false);
+                setHistoryOpen(true);
+              }}
+              data-testid={`download-menuitem-${type}-history`}
+            >
+              Ver historial
+            </button>
+          </div>
+        )}
+      </span>
+
+      <ExportProgressModal
+        open={modalOpen}
+        state={state}
+        reportTypeLabel={title}
+        onDownload={async () => {
+          await download();
+          setModalOpen(false);
+          reset();
+        }}
+        onClose={handleClose}
+        onShowHistory={() => {
+          setModalOpen(false);
+          setHistoryOpen(true);
+        }}
+      />
+
+      <DownloadHistoryModal
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        initialType={type}
+      />
+    </>
+  );
+}

--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.module.css
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.module.css
@@ -308,3 +308,16 @@
   cursor: not-allowed;
   opacity: 0.4;
 }
+
+/* S143e (HALLAZGO-NEW-54): botón "Limpiar historial" pineá solo ícono (Trash2) + tooltip.
+   Compacto, cuadrado, sin texto visible — el label vive en `title` HTML. */
+.iconOnly {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 !important;
+}

--- a/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
+++ b/src/mk/components/ui/DownloadHistory/DownloadHistory.tsx
@@ -595,6 +595,9 @@ export default function DownloadHistory({
           </select>
         </label>
 
+        {/* S143e (HALLAZGO-NEW-54): el botón "Limpiar historial" ahora es
+            SOLO ícono (Trash2) + tooltip "Limpiar historial" + aria-label.
+            El texto se pineó al `title` HTML para accesibilidad. */}
         {!hideClearButton && items.length > 0 && (
           <Button
             variant="primary"
@@ -604,10 +607,11 @@ export default function DownloadHistory({
             }}
             disabled={loading || clearing}
             data-testid="download-history-clear-btn"
+            title="Limpiar historial"
             aria-label="Limpiar historial"
+            className={styles.iconOnly}
           >
             <Trash2 size={14} />
-            Limpiar historial
           </Button>
         )}
       </div>

--- a/src/mk/hooks/useAsyncExport/useAsyncExport.ts
+++ b/src/mk/hooks/useAsyncExport/useAsyncExport.ts
@@ -115,6 +115,15 @@ export type UseAsyncExportOptions = {
   pollIntervalMs?: number;
   onCompleted?: (state: AsyncExportState) => void;
   onError?: (errorMessage: string) => void;
+  /**
+   * S143e (HALLAZGO-NEW-54, binding, cross-project): si se pineá, el hook
+   * dispatcha `GET {endpoint}?_export={format}` (flow nuevo inline del
+   * Controller del módulo) en vez de `POST /v3/reports/{type}/export`
+   * (flow BC layer legacy).
+   *
+   * Default: null (usa el flow BC layer legacy — mantiene back-compat).
+   */
+  endpoint?: string | null;
 };
 
 const INITIAL_STATE: AsyncExportState = {
@@ -138,7 +147,7 @@ export type UseAsyncExportReturn = {
 export function useAsyncExport(
   options: UseAsyncExportOptions,
 ): UseAsyncExportReturn {
-  const { type, pollIntervalMs = 2500, onCompleted, onError } = options;
+  const { type, pollIntervalMs = 2500, onCompleted, onError, endpoint } = options;
   const { showToast } = useToast();
   const [state, setState] = useState<AsyncExportState>(INITIAL_STATE);
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -253,16 +262,28 @@ export function useAsyncExport(
       });
 
       try {
-        const res = await fetch(`${API_BASE_URL}/v3/reports/${type}/export`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-            ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),
-          },
-          credentials: "include",
-          body: JSON.stringify(params ?? {}),
-        });
+        // S143e (HALLAZGO-NEW-54): si `endpoint` está pineado, dispatcha el
+        // flow nuevo inline (GET {endpoint}?_export=...) del Controller del
+        // módulo. Si NO, mantiene el flow BC layer legacy (POST /v3/reports/{type}/export).
+        const res = endpoint
+          ? await fetch(`${API_BASE_URL}${endpoint}?_export=${encodeURIComponent((params as any)?.format ?? "pdf")}`, {
+              method: "GET",
+              headers: {
+                Accept: "application/json",
+                ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),
+              },
+              credentials: "include",
+            })
+          : await fetch(`${API_BASE_URL}/v3/reports/${type}/export`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "application/json",
+                ...(getAuthToken() ? { Authorization: `Bearer ${getAuthToken()}` } : {}),
+              },
+              credentials: "include",
+              body: JSON.stringify(params ?? {}),
+            });
 
         if (res.status === 202) {
           const data = await res.json();

--- a/src/modulos/_pins/__tests__/SprintS143eFeDownloadButton.test.ts
+++ b/src/modulos/_pins/__tests__/SprintS143eFeDownloadButton.test.ts
@@ -1,0 +1,151 @@
+/**
+ * S143e-fe (HALLAZGO-NEW-54, binding, cross-project) — DownloadButton + useAsyncExport.endpoint
+ *
+ * Pin de regresión source-parsing sobre:
+ *   - `DownloadButton.tsx` (NUEVO): ícono Download + menú si multi-format.
+ *   - `useAsyncExport.endpoint` opcional: dispatcha GET inline si pineado.
+ *   - `DownloadHistory` botón "Limpiar historial" → solo ícono + tooltip.
+ *
+ * Patrón HALLAZGO-NEW-03 (binding, cross-project): source-parsing pineá
+ * INTENCIÓN. Si alguien rompe el approach de S143e, el test falla con
+ * mensaje claro.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const FRONT_ROOT = path.resolve(__dirname, "../../..");
+
+const readFile = (relPath: string): string => {
+  return fs.readFileSync(path.join(FRONT_ROOT, relPath), "utf8");
+};
+
+const stripComments = (source: string): string => {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+};
+
+const loadSourceWithoutComments = (relPath: string): string => {
+  return stripComments(readFile(relPath));
+};
+
+describe("S143e-fe — DownloadButton con ícono + menú (HALLAZGO-NEW-54)", () => {
+  describe("DownloadButton.tsx — estructura del componente", () => {
+    it("DownloadButton.tsx existe", () => {
+      const rel = "mk/components/ui/DownloadButton/DownloadButton.tsx";
+      expect(fs.existsSync(path.join(FRONT_ROOT, rel))).toBe(true);
+    });
+
+    it("DownloadButton.tsx pineá DownloadFormat type con pdf/xlsx/csv", () => {
+      const src = readFile("mk/components/ui/DownloadButton/DownloadButton.tsx");
+      expect(src).toMatch(/export type DownloadFormat/);
+      expect(src).toMatch(/"pdf"/);
+      expect(src).toMatch(/"xlsx"/);
+      expect(src).toMatch(/"csv"/);
+    });
+
+    it("DownloadButton.tsx pineá supportedFormats prop con default ['pdf']", () => {
+      const src = loadSourceWithoutComments(
+        "mk/components/ui/DownloadButton/DownloadButton.tsx",
+      );
+      expect(src).toMatch(/supportedFormats\?: DownloadFormat\[\]/);
+      expect(src).toMatch(/supportedFormats = \["pdf"\]/);
+    });
+
+    it("DownloadButton.tsx pineá endpoint prop opcional para inline export", () => {
+      const src = loadSourceWithoutComments(
+        "mk/components/ui/DownloadButton/DownloadButton.tsx",
+      );
+      expect(src).toMatch(/endpoint\?: string \| null/);
+    });
+
+    it("DownloadButton.tsx pineá useExtraData + requiredRelations props", () => {
+      const src = loadSourceWithoutComments(
+        "mk/components/ui/DownloadButton/DownloadButton.tsx",
+      );
+      expect(src).toMatch(/useExtraData\?: boolean/);
+      expect(src).toMatch(/requiredRelations\?: string\[\]/);
+    });
+
+    it("DownloadButton.tsx pineá hasMultipleFormats helper", () => {
+      const src = loadSourceWithoutComments(
+        "mk/components/ui/DownloadButton/DownloadButton.tsx",
+      );
+      // S143e: si supportedFormats.length > 1, dropdown. Si === 1, single click.
+      expect(src).toMatch(/hasMultipleFormats = supportedFormats\.length > 1/);
+    });
+
+    it("DownloadButton.tsx pineá data-testid para smoke tests", () => {
+      const src = readFile("mk/components/ui/DownloadButton/DownloadButton.tsx");
+      expect(src).toMatch(/data-testid=\{`download-btn-\$\{type\}`\}/);
+      expect(src).toMatch(/data-testid=\{`download-menu-\$\{type\}`\}/);
+      expect(src).toMatch(/data-testid=\{`download-menuitem-\$\{type\}-\$\{fmt\}`\}/);
+    });
+
+    it("DownloadButton.tsx pineá title + aria-label (tooltip a11y)", () => {
+      const src = readFile("mk/components/ui/DownloadButton/DownloadButton.tsx");
+      expect(src).toMatch(/title=\{title\}/);
+      expect(src).toMatch(/aria-label=\{title\}/);
+    });
+  });
+
+  describe("useAsyncExport — endpoint opcional (S143e HALLAZGO-NEW-54)", () => {
+    it("useAsyncExport.ts pineá endpoint opcional en UseAsyncExportOptions", () => {
+      const src = loadSourceWithoutComments(
+        "mk/hooks/useAsyncExport/useAsyncExport.ts",
+      );
+      expect(src).toMatch(/endpoint\?: string \| null/);
+    });
+
+    it("useAsyncExport.ts dispatcha GET inline si endpoint pineado", () => {
+      const src = loadSourceWithoutComments(
+        "mk/hooks/useAsyncExport/useAsyncExport.ts",
+      );
+      // S143e: si endpoint está pineado, dispatcha GET {endpoint}?_export={format}.
+      expect(src).toMatch(/endpoint\s*\?\s*await fetch/);
+      expect(src).toMatch(/encodeURIComponent/);
+    });
+
+    it("useAsyncExport.ts mantiene BC layer legacy (POST /v3/reports/{type}/export)", () => {
+      const src = loadSourceWithoutComments(
+        "mk/hooks/useAsyncExport/useAsyncExport.ts",
+      );
+      // S143e: si endpoint NO pineado, sigue pineando el flow BC layer.
+      expect(src).toMatch(/v3\/reports\/\$\{type\}\/export/);
+    });
+  });
+
+  describe("DownloadHistory — botón Limpiar historial solo ícono (S143e HALLAZGO-NEW-54)", () => {
+    it("DownloadHistory.tsx oculta el texto 'Limpiar historial' del botón", () => {
+      const src = loadSourceWithoutComments(
+        "mk/components/ui/DownloadHistory/DownloadHistory.tsx",
+      );
+      // El botón ya NO pinea el texto "Limpiar historial" — solo el ícono Trash2.
+      // El label vive en `title` HTML para accesibilidad.
+      const clearBtnBlock = src.match(
+        /data-testid="download-history-clear-btn"[\s\S]*?<\/Button>/,
+      );
+      expect(clearBtnBlock).toBeTruthy();
+      // NO debe tener texto "Limpiar historial" visible (puede tenerlo en title/aria-label).
+      expect(clearBtnBlock![0]).not.toMatch(/>\s*Limpiar historial\s*</);
+    });
+
+    it("DownloadHistory.tsx pineá title='Limpiar historial' (tooltip)", () => {
+      const src = readFile(
+        "mk/components/ui/DownloadHistory/DownloadHistory.tsx",
+      );
+      expect(src).toMatch(/title="Limpiar historial"/);
+    });
+
+    it("DownloadHistory.module.css pineá clase .iconOnly (botón compacto)", () => {
+      const css = readFile(
+        "mk/components/ui/DownloadHistory/DownloadHistory.module.css",
+      );
+      expect(css).toMatch(/\.iconOnly\s*\{/);
+      expect(css).toMatch(/width:\s*36px/);
+      expect(css).toMatch(/height:\s*36px/);
+      expect(css).toMatch(/padding:\s*0/);
+    });
+  });
+});


### PR DESCRIPTION
## HALLAZGO-NEW-54 (binding, cross-project)

S143e-fe es el **complemento front** del S143e-bk (PR #227). Mario revisa ambos y mergea juntos.

## Cambios principales

### 1. `DownloadButton` (NUEVO) — `src/mk/components/ui/DownloadButton/`

Reemplaza el patrón "Exportar PDF / Exportar XLSX" (texto) por un ícono Download solo con menú.

- Si `supportedFormats.length > 1` (PDF + XLSX + CSV) → dropdown con las opciones. Click en opción dispatcha el export.
- Si `supportedFormats.length === 1` (CustomReport) → single click directo.
- Tooltip via `title` HTML + `aria-label` para a11y.
- data-testid: `download-btn-{type}`, `download-menu-{type}`, `download-menuitem-{type}-{format}`.
- Pinea `endpoint`, `useExtraData`, `requiredRelations` para el flow nuevo inline (S143e-bk).

```tsx
// Modo multi-format (PDF + XLSX + CSV)
<DownloadButton
  type="payments"
  params={{ startDate: '2026-01-01', endDate: '2026-07-29' }}
  supportedFormats={['pdf', 'xlsx', 'csv']}
  endpoint="/api/v3/payments"
  useExtraData
  requiredRelations={['paymentMethod', 'category', 'bankAccount']}
/>

// Modo single-format (CustomReport)
<DownloadButton
  type="balance"
  params={{ from: '2026-01-01', to: '2026-07-29' }}
  supportedFormats={['pdf']}
/>
```

### 2. `useAsyncExport.endpoint` — flow nuevo inline opcional

Si `endpoint` está pineado, dispatcha `GET {endpoint}?_export={format}` (mismo endpoint de lista) en vez de `POST /v3/reports/{type}/export` (flow BC layer legacy).

```ts
const { state, start, download, reset } = useAsyncExport({
  type: 'payments',
  endpoint: '/api/v3/payments', // S143e: flow inline. Default null = flow BC layer.
  onCompleted: (s) => { ... },
  onError: (msg) => { ... },
});
```

### 3. `DownloadHistory` — botón 'Limpiar historial' → solo ícono + tooltip

- Texto 'Limpiar historial' eliminado del `<Button>`.
- Solo ícono Trash2 (36x36) con `title='Limpiar historial'` para tooltip.
- CSS `.iconOnly` pineado en `DownloadHistory.module.css`.

## Tests (14 source-parsing, todos verde)

`src/modulos/_pins/__tests__/SprintS143eFeDownloadButton.test.ts`:
- DownloadButton pineá DownloadFormat, supportedFormats, endpoint, useExtraData, requiredRelations, hasMultipleFormats, data-testid, a11y.
- useAsyncExport pineá endpoint opcional, dispatcha GET inline si pineado, mantiene BC layer legacy.
- DownloadHistory oculta el texto del botón, pineá title tooltip y `.iconOnly` CSS.

## Archivos modificados

- `src/mk/components/ui/DownloadButton/DownloadButton.tsx` (NUEVO, ~180 líneas)
- `src/mk/components/ui/DownloadButton/DownloadButton.module.css` (NUEVO, ~70 líneas)
- `src/mk/hooks/useAsyncExport/useAsyncExport.ts` (extendido con `endpoint`)
- `src/mk/components/ui/DownloadHistory/DownloadHistory.tsx` (botón Clear → ícono)
- `src/mk/components/ui/DownloadHistory/DownloadHistory.module.css` (`.iconOnly` CSS)
- `src/modulos/_pins/__tests__/SprintS143eFeDownloadButton.test.ts` (NUEVO, 14 tests)

## Pendiente (replicar para S144e+)

- S144e: replicar patrón para `ExpensesExportConfig` (back) + `Expenses.tsx` consume `DownloadButton` (front).
- S145e+: Outlays, DebtDpto, etc.

## Cross-IA

Mavis main 2026-07-29.