### PR TITLE
Configurar membresías para áreas sociales

### DIFF
--- a/src/modulos/Areas/Areas.tsx
+++ b/src/modulos/Areas/Areas.tsx
@@ -200,6 +200,31 @@ const Areas = () => {
         list: false,
         form: { type: "text" },
       },
+      requires_membership: {
+        rules: [],
+        api: "ae",
+        label: "Membresía",
+        list: {
+          width: "150px",
+          onRender: ({ item }: any) => (
+            <StatusBadge
+              backgroundColor={
+                item?.requires_membership
+                  ? "var(--cHoverCompl4)"
+                  : "var(--cHoverSuccess)"
+              }
+              color={
+                item?.requires_membership
+                  ? "var(--cWarning)"
+                  : "var(--cSuccess)"
+              }
+            >
+              {item?.requires_membership ? "Solo miembros" : "Libre"}
+            </StatusBadge>
+          ),
+        },
+        form: false,
+      },
       approval_response_hours: {
         rules: ["required"],
         api: "ae",

--- a/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
@@ -201,6 +201,10 @@ const FourPart = ({ item }: { item: any }) => {
               value={item?.penalty_or_debt_restriction == "A" ? "Sí" : "No"}
             />
             <KeyValue
+              title={"Requiere membresía"}
+              value={item?.requires_membership ? "Sí" : "No"}
+            />
+            <KeyValue
               title={"Aprobación de administración"}
               value={item?.requires_approval == "A" ? "Sí" : "No"}
             />

--- a/src/modulos/Areas/RenderForm/Partes/ThirdPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/ThirdPart.tsx
@@ -83,6 +83,30 @@ const ThirdPart = ({ handleChange, errors, formState }: PropsType) => {
       <Br />
       <div className={styles.switchRow}>
         <div className={styles.switchContent}>
+          <p className={styles.title}>¿Requiere membresía?</p>
+          <p className={styles.subtitle}>
+            Si activas esta opción, solo las unidades con membresía verán esta
+            área social en la app de residentes.
+          </p>
+        </div>
+        <Switch
+          name="requires_membership"
+          optionValue={["1", "0"]}
+          onChange={(e: any) => {
+            handleChange({
+              target: {
+                name: "requires_membership",
+                value: Boolean(e.target.checked),
+              },
+            });
+          }}
+          value={formState?.requires_membership ? "1" : "0"}
+          checked={Boolean(formState?.requires_membership)}
+        />
+      </div>
+      <Br />
+      <div className={styles.switchRow}>
+        <div className={styles.switchContent}>
           <p className={styles.title}>¿Aprobación de administración?</p>
           <p className={styles.subtitle}>
             Si activas esta opción, cada solicitud de reserva pasará por tu

--- a/src/modulos/Areas/RenderForm/RenderForm.tsx
+++ b/src/modulos/Areas/RenderForm/RenderForm.tsx
@@ -40,6 +40,14 @@ const parseCoordinateValue = (value: unknown) => {
   return Number.isFinite(parsed) ? parsed : null;
 };
 
+const parseBoolean = (value: any) =>
+  value === true ||
+  value === 1 ||
+  value === "1" ||
+  value === "Y" ||
+  value === "S" ||
+  value === "true";
+
 const buildCoordinatesValue = (latitude: unknown, longitude: unknown) => {
   const latitudeValue = hasCoordinateValue(latitude)
     ? String(latitude).trim()
@@ -85,6 +93,7 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
     has_price: item?.price ? "S" : "N",
     guarantee_amount: item?.guarantee_amount ?? 0,
     requires_approval: item?.requires_approval || "X",
+    requires_membership: parseBoolean(item?.requires_membership),
     penalty_or_debt_restriction: item?.penalty_or_debt_restriction || "X",
     min_reservation_advance_hours:
       item?.min_reservation_advance_hours ?? 0,
@@ -306,6 +315,7 @@ const RenderForm = ({ onClose, item, execute, setOpenList, reLoad }: any) => {
         max_capacity: formState?.max_capacity,
         status: formState?.status,
         requires_approval: formState?.requires_approval,
+        requires_membership: Boolean(formState?.requires_membership),
         price: formState?.price,
         guarantee_amount:
           formState?.has_price == "S"

--- a/src/modulos/Areas/RenderView/RenderView.tsx
+++ b/src/modulos/Areas/RenderView/RenderView.tsx
@@ -203,6 +203,10 @@ const RenderView = ({ open, item, onClose, reLoad }: any) => {
                 value={item?.penalty_or_debt_restriction == "A" ? "Sí" : "No"}
               />
               <KeyValue
+                title={"Requiere membresía"}
+                value={item?.requires_membership ? "Sí" : "No"}
+              />
+              <KeyValue
                 title={"Aprobación de administración"}
                 value={item?.requires_approval == "A" ? "Sí" : "No"}
               />

--- a/src/modulos/DashDptos/UnitInfo/UnitInfo.tsx
+++ b/src/modulos/DashDptos/UnitInfo/UnitInfo.tsx
@@ -204,6 +204,12 @@ const UnitInfo = ({
             </span>
           </div>
           <div className={styles.infoItem}>
+            <span className={styles.infoLabel}>Membresía</span>
+            <span className={styles.infoValue}>
+              {datas?.data?.has_membership ? "Activa" : "Sin membresía"}
+            </span>
+          </div>
+          <div className={styles.infoItem}>
             <span className={styles.infoLabel}>Recibe visitas</span>
             <span className={styles.infoValue}>
               {datas?.data?.can_receive_visits === false

--- a/src/modulos/Dptos/Dptos.tsx
+++ b/src/modulos/Dptos/Dptos.tsx
@@ -310,6 +310,39 @@ const Dptos = () => {
         },
         import: true,
       },
+      has_membership: {
+        rules: [],
+        api: "ae",
+        label: (
+          <span
+            style={{ display: "block", textAlign: "center", width: "100%" }}
+          >
+            Membresía
+          </span>
+        ),
+        form: false,
+        list: {
+          width: "150px",
+          onRender: (props: any) => (
+            <div className={styles.statusCellCenter}>
+              <StatusBadge
+                color={
+                  props?.item?.has_membership
+                    ? "var(--cSuccess)"
+                    : "var(--cWhiteV1)"
+                }
+                backgroundColor={
+                  props?.item?.has_membership
+                    ? "var(--cHoverSuccess)"
+                    : "var(--cHover)"
+                }
+              >
+                {props?.item?.has_membership ? "Activa" : "Sin membresía"}
+              </StatusBadge>
+            </div>
+          ),
+        },
+      },
       status: {
         rules: [""],
         api: "",

--- a/src/modulos/Dptos/RenderForm.tsx
+++ b/src/modulos/Dptos/RenderForm.tsx
@@ -30,6 +30,7 @@ const RenderForm = ({
   const [formState, setFormState]: any = useState({
     ...item,
     has_payment_plan: parseBoolean(item?.has_payment_plan),
+    has_membership: parseBoolean(item?.has_membership),
     can_receive_visits:
       item?.can_receive_visits === undefined ||
       item?.can_receive_visits === null
@@ -59,6 +60,7 @@ const RenderForm = ({
           has_payment_plan: parseBoolean(
             item?.has_payment_plan
           ),
+          has_membership: parseBoolean(item?.has_membership),
           can_receive_visits:
             item?.can_receive_visits === undefined ||
             item?.can_receive_visits === null
@@ -83,7 +85,11 @@ const RenderForm = ({
   const handleChange = (e: any) => {
     const { name, value, type, checked } = e.target;
 
-    if (name === "has_payment_plan" || name === "can_receive_visits") {
+    if (
+      name === "has_payment_plan" ||
+      name === "can_receive_visits" ||
+      name === "has_membership"
+    ) {
       setFormState((prev: any) => ({
         ...prev,
         [name]: checked ?? parseBoolean(value),
@@ -185,6 +191,7 @@ const RenderForm = ({
         expense_amount: formState.expense_amount,
         dimension: formState.dimension,
         has_payment_plan: Boolean(formState.has_payment_plan),
+        has_membership: Boolean(formState.has_membership),
         can_receive_visits: Boolean(formState.can_receive_visits),
         homeowner_id:
           formState.homeowner_id == "X" ? null : formState.homeowner_id,
@@ -310,6 +317,49 @@ const RenderForm = ({
           optionValue={["1", "0"]}
           value={formState.has_payment_plan ? "1" : "0"}
           checked={Boolean(formState.has_payment_plan)}
+          onChange={handleChange}
+        />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 16,
+          padding: "12px 0",
+          width: "100%",
+        }}
+      >
+        <div style={{ flex: "1 1 220px", minWidth: 0 }}>
+          <p
+            style={{
+              color: "var(--twhite)",
+              fontSize: "var(--sM)",
+              fontWeight: 600,
+              margin: 0,
+            }}
+          >
+            Tiene membresía activa
+          </p>
+          <p
+            style={{
+              color: "var(--cWhiteV1)",
+              fontSize: "var(--sS)",
+              lineHeight: 1.4,
+              margin: "4px 0 0",
+            }}
+          >
+            Permite ver en residentes las áreas sociales marcadas como solo
+            miembros.
+          </p>
+        </div>
+        <Switch
+          name="has_membership"
+          optionValue={["1", "0"]}
+          value={formState.has_membership ? "1" : "0"}
+          checked={Boolean(formState.has_membership)}
           onChange={handleChange}
         />
       </div>


### PR DESCRIPTION
## Resumen
- agrega switch de membresía en áreas sociales
- agrega switch de membresía activa en unidades
- muestra badges/valores de membresía en listados y detalles

## Validación
- pnpm exec tsc --noEmit --types vitest/globals
- pnpm build