### PR TITLE
Corregir modales de personal y guardias

### DIFF
--- a/src/components/ProfileModal/GuardEditForm/GuardEditForm.tsx
+++ b/src/components/ProfileModal/GuardEditForm/GuardEditForm.tsx
@@ -60,12 +60,17 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
   const { showToast } = useAuth();
   const { execute } = useAxios();
   const [localErrors, setLocalErrors] = useState<Errors>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [isCheckingCi, setIsCheckingCi] = useState(false);
   const handleChangeInput = useCallback(
     (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const { name, value } = e.target;
       setFormState((prev: FormState) => ({
         ...prev,
         [name]: value,
+        ...(name === "ci" && !prev.id
+          ? { _disabled: false, _emailDisabled: false }
+          : {}),
       }));
       if (localErrors[name]) {
         setLocalErrors((prev) => ({ ...prev, [name]: "" }));
@@ -76,58 +81,76 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
 
   const onBlurCi = useCallback(
     async (e: React.FocusEvent<HTMLInputElement>) => {
-      if (e.target.value.trim() === "") return;
+      const ci = e.target.value.trim();
+      if (ci === "" || formState.id || isCheckingCi) return;
 
-      const { data } = await execute(
-        "/guards",
-        "GET",
-        {
-          fullType: "EXIST",
-          type: "ci",
-          searchBy: e.target.value,
-          value: formState.id,
-        },
-        false,
-        true,
-      );
-
-      if (data?.success && data.data?.data?.id) {
-        const filteredData = data.data.data;
-        if (filteredData.existCondo) {
-          showToast("El guardia ya existe en este condominio", "warning");
-          setFormState({});
-          setLocalErrors({ ci: "Ese CI ya esta en uso en este condominio." });
-          return;
-        }
-        setLocalErrors({ ci: "" });
-        setFormState({
-          ...formState,
-          ci: filteredData.ci,
-          name: filteredData.name,
-          middle_name: filteredData.middle_name,
-          last_name: filteredData.last_name,
-          mother_last_name: filteredData.mother_last_name,
-          email: filteredData.email ?? "",
-          phone: filteredData.phone,
-          _disabled: true,
-          _emailDisabled: true,
-        });
-
-        showToast(
-          "El guardia ya existe en condaty, se va a vincular al condominio",
-          "warning",
+      setIsCheckingCi(true);
+      try {
+        const { data } = await execute(
+          "/guards",
+          "GET",
+          {
+            fullType: "EXIST",
+            type: "ci",
+            searchBy: ci,
+            value: formState.id,
+          },
+          false,
+          true,
         );
-      } else {
-        setLocalErrors({ ci: "" });
-        setFormState({
-          ...formState,
-          _disabled: false,
-          _emailDisabled: false,
-        });
+
+        if (data?.success && data.data?.data?.id) {
+          const filteredData = data.data.data;
+          if (filteredData.existCondo) {
+            showToast("El guardia ya existe en este condominio", "warning");
+            setLocalErrors({ ci: "Ese CI ya esta en uso en este condominio." });
+            setFormState((prev: FormState) => ({
+              ...prev,
+              ci,
+              _disabled: false,
+              _emailDisabled: false,
+            }));
+            return;
+          }
+          setLocalErrors({ ci: "" });
+          setFormState({
+            ...formState,
+            ci: filteredData.ci,
+            name: filteredData.name,
+            middle_name: filteredData.middle_name,
+            last_name: filteredData.last_name,
+            mother_last_name: filteredData.mother_last_name,
+            email: filteredData.email ?? "",
+            phone: filteredData.phone,
+            _disabled: true,
+            _emailDisabled: true,
+          });
+
+          showToast(
+            "El guardia ya existe en Condaty, se va a vincular al condominio",
+            "warning",
+          );
+        } else {
+          setLocalErrors({ ci: "" });
+          setFormState({
+            ...formState,
+            _disabled: false,
+            _emailDisabled: false,
+          });
+        }
+      } finally {
+        setIsCheckingCi(false);
       }
     },
-    [execute, showToast, formState, setFormState],
+    [execute, showToast, formState, setFormState, isCheckingCi],
   );
+
+  const onCiKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+
+    e.preventDefault();
+    await onBlurCi(e as unknown as React.FocusEvent<HTMLInputElement>);
+  };
 
   const onBlurEmail = useCallback(
     async (e: React.FocusEvent<HTMLInputElement>) => {
@@ -224,6 +247,7 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
   }, [formState, setErrors]);
 
   const onSave = async () => {
+    if (isSaving) return;
     if (hasErrors(validate())) {
       showToast("Por favor revise los campos marcados", "warning");
       return;
@@ -244,6 +268,7 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
       avatar: formState.avatar || "",
     };
 
+    setIsSaving(true);
     try {
       const { data: response } = await execute(
         url,
@@ -273,6 +298,8 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
     } catch (error) {
       console.error(error);
       showToast("Error al guardar guardia", "error");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -294,10 +321,13 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
       onClose={onCloseModal}
       onSave={onSave}
       buttonCancel="Cancelar"
-      buttonText={formState.id ? "Actualizar" : "Guardar"}
+      buttonText={
+        isSaving ? "Guardando..." : formState.id ? "Actualizar" : "Guardar"
+      }
       title={formState.id ? "Editar Guardia" : "Nuevo guardia"}
       minWidth={560}
       maxWidth={860}
+      disabled={isSaving || isCheckingCi}
     >
       <div className={styles["guard-form-container"]}>
         {/* Sección de imagen */}
@@ -338,8 +368,9 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
               value={formState.ci || ""}
               onChange={handleChangeInput}
               onBlur={onBlurCi}
+              onKeyDown={onCiKeyDown}
               error={localErrors}
-              disabled={true}
+              disabled={Boolean(formState.id)}
               maxLength={8}
             />
           </div>

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -327,6 +327,7 @@ const useCrud = ({
   const { user, showToast, userCan, store, setStore } = useAuth();
   const [formState, setFormState]: any = useState({});
   const [errors, setErrors]: any = useState({});
+  const [isSaving, setIsSaving] = useState(false);
 
   const [openImport, setOpenImport] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
@@ -775,6 +776,8 @@ const useCrud = ({
   };
 
   const onSave = async (data: Record<string, any>, _setErrors?: Function) => {
+    if (isSaving) return;
+
     if (!userCan(mod.permiso, action == "del" ? "D" : action))
       return showToast("No tiene permisos para esta acción", "error");
 
@@ -826,46 +829,51 @@ const useCrud = ({
       }
     }
 
-    const { data: response, error: err } = await execute(
-      url,
-      method,
-      action == "del" ? { id: data.id } : paramWithoutFiles,
-      false,
-      mod?.noWaiting,
-    );
+    setIsSaving(true);
+    try {
+      const { data: response, error: err } = await execute(
+        url,
+        method,
+        action == "del" ? { id: data.id } : paramWithoutFiles,
+        false,
+        mod?.noWaiting,
+      );
 
-    if (response?.success) {
-      try {
-        const uploadId =
-          response?.data?.id ??
-          response?.data?.data?.id ??
-          data?.id ??
-          response?.id ??
-          null;
-        if (filesToUpload.length > 0 && uploadId) {
-          await uploadLargeFiles(
-            filesToUpload,
-            uploadId,
-            execute,
-            mod?.noWaiting,
-            showToast,
-          );
+      if (response?.success) {
+        try {
+          const uploadId =
+            response?.data?.id ??
+            response?.data?.data?.id ??
+            data?.id ??
+            response?.id ??
+            null;
+          if (filesToUpload.length > 0 && uploadId) {
+            await uploadLargeFiles(
+              filesToUpload,
+              uploadId,
+              execute,
+              mod?.noWaiting,
+              showToast,
+            );
+          }
+        } catch (e) {
+          logError("Error post-upload handling", e);
         }
-      } catch (e) {
-        logError("Error post-upload handling", e);
-      }
 
-      onCloseCrud();
-      setOpenDel(false);
-      if (useInfiniteList) {
-        await reloadCrudList(null, mod?.noWaiting);
+        onCloseCrud();
+        setOpenDel(false);
+        if (useInfiniteList) {
+          void reloadCrudList(null, mod?.noWaiting);
+        } else {
+          axiosReload(params, mod?.noWaiting);
+        }
+        showToast(mod.saveMsg?.[action] || response?.message, "success");
       } else {
-        axiosReload(params, mod?.noWaiting);
+        showToast(response?.message, "error");
+        logError("Error onSave:", err);
       }
-      showToast(mod.saveMsg?.[action] || response?.message, "success");
-    } else {
-      showToast(response?.message, "error");
-      logError("Error onSave:", err);
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -1435,7 +1443,9 @@ const useCrud = ({
         }
         // textSaveButtom por defecto "Guardar" o "Actualizar" segun action en mod.textSaveButtom
         buttonText={
-          action == "add"
+          isSaving
+            ? "Guardando..."
+            : action == "add"
             ? mod?.textSaveButtom
               ? mod?.textSaveButtom
               : "Guardar"
@@ -1450,6 +1460,7 @@ const useCrud = ({
         style={mod.formModal?.style}
         minWidth={mod.formModal?.minWidth}
         maxWidth={mod.formModal?.maxWidth ?? 560}
+        disabled={isSaving}
       >
         <div className={styles.formLayout}>
           {header.map((field: any, index: number) => (

--- a/src/modulos/Guards/RenderForm/RenderForm.tsx
+++ b/src/modulos/Guards/RenderForm/RenderForm.tsx
@@ -10,12 +10,24 @@ import UploadFileSingle from "@/mk/components/forms/UploadFileSingle/UploadFileS
 const RenderForm = ({ open, onClose, item, execute, reLoad }: any) => {
   const [formState, setFormState] = useState({ ...item });
   const [errors, setErrors] = useState({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [isCheckingCi, setIsCheckingCi] = useState(false);
   const { showToast } = useAuth();
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => {
     const { name, value } = e.target;
+
+    if (name === "ci" && !formState.id) {
+      setFormState((prev: any) => ({
+        ...prev,
+        ci: value,
+        _disabled: false,
+      }));
+      setErrors((prev: any) => ({ ...prev, ci: "" }));
+      return;
+    }
 
     setFormState((prev: any) => ({
       ...prev,
@@ -92,81 +104,121 @@ const RenderForm = ({ open, onClose, item, execute, reLoad }: any) => {
     return errors;
   };
   const _onSave = async () => {
+    if (isSaving) return;
     if (hasErrors(validate())) return;
     let method = formState.id ? "PUT" : "POST";
-    const { data } = await execute(
-      "/guards" + (formState.id ? "/" + formState.id : ""),
-      method,
-      {
-        ci: formState.ci,
-        url_avatar: formState.url_avatar,
-        name: formState.name,
-        middle_name: formState.middle_name,
-        last_name: formState.last_name,
-        mother_last_name: formState.mother_last_name,
-        email: formState.email,
-        phone: formState.phone,
-        address: formState.address,
-      },
-    );
 
-    if (data?.success) {
-      onClose();
-      reLoad();
-      showToast(data?.message || "Documento guardado con éxito", "success");
-    } else {
-      showToast(data?.message || "Error al guardar el documento", "error");
-    }
-  };
-  const onBlurCi = async () => {
-    // if (e.target.value.trim() == "") return;
-    const { data } = await execute(
-      "/guards",
-      "GET",
-      {
-        fullType: "EXIST",
-        type: "ci",
-        searchBy: formState.ci,
-      },
-      false,
-      true,
-    );
+    setIsSaving(true);
+    try {
+      const { data } = await execute(
+        "/guards" + (formState.id ? "/" + formState.id : ""),
+        method,
+        {
+          ci: formState.ci,
+          url_avatar: formState.url_avatar,
+          name: formState.name,
+          middle_name: formState.middle_name,
+          last_name: formState.last_name,
+          mother_last_name: formState.mother_last_name,
+          email: formState.email,
+          phone: formState.phone,
+          address: formState.address,
+        },
+        false,
+        true,
+      );
 
-    if (data?.success && data.data?.data?.id) {
-      const filteredData = data?.data?.data;
-      if (filteredData.existCondo) {
-        showToast("El guardia ya existe en este condominio", "warning");
-        setErrors({ ci: " Ese CI ya esta en uso en este condominio." });
-        setFormState({});
-        return;
+      if (data?.success) {
+        onClose();
+        reLoad(null, true);
+        showToast(data?.message || "Documento guardado con éxito", "success");
       } else {
-        setErrors({ ci: "" });
-        setFormState({
-          ...formState,
-          ci: filteredData.ci,
-          name: filteredData.name,
-          // password: "12345678",
-          middle_name: filteredData.middle_name,
-          last_name: filteredData.last_name,
-          mother_last_name: filteredData.mother_last_name,
-          email: filteredData.email ?? "",
-          phone: filteredData.phone,
-          address: filteredData.address,
-          url_avatar: [filteredData.url_avatar],
-          _disabled: true,
-        });
-        return;
+        showToast(data?.message || "Error al guardar el documento", "error");
       }
-    } else {
-      setErrors({ ci: "" });
-      setFormState({
-        ...formState,
-        _disabled: false,
-      });
+    } finally {
+      setIsSaving(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   };
+
+  const lookupGuardByCi = useCallback(
+    async (ciValue: string) => {
+      const ci = String(ciValue || "").trim();
+      if (!ci || formState.id || isCheckingCi) return;
+
+      setIsCheckingCi(true);
+      try {
+        const { data } = await execute(
+          "/guards",
+          "GET",
+          {
+            fullType: "EXIST",
+            type: "ci",
+            searchBy: ci,
+          },
+          false,
+          true,
+        );
+
+        if (data?.success && data.data?.data?.id) {
+          const filteredData = data?.data?.data;
+          if (filteredData.existCondo) {
+            showToast("El guardia ya existe en este condominio", "warning");
+            setErrors({ ci: "Ese CI ya esta en uso en este condominio." });
+            setFormState((prev: any) => ({
+              ...prev,
+              ci,
+              _disabled: false,
+            }));
+            return;
+          }
+
+          setErrors({ ci: "" });
+          setFormState((prev: any) => ({
+            ...prev,
+            ci: filteredData.ci,
+            name: filteredData.name,
+            middle_name: filteredData.middle_name,
+            last_name: filteredData.last_name,
+            mother_last_name: filteredData.mother_last_name,
+            email: filteredData.email ?? "",
+            phone: filteredData.phone,
+            address: filteredData.address,
+            url_avatar: filteredData.url_avatar ? [filteredData.url_avatar] : [],
+            _disabled: true,
+          }));
+          showToast(
+            "El guardia ya existe en Condaty, se va a vincular al condominio",
+            "warning",
+          );
+          return;
+        }
+
+        setErrors({ ci: "" });
+        setFormState((prev: any) => ({
+          ...prev,
+          ci,
+          _disabled: false,
+        }));
+      } finally {
+        setIsCheckingCi(false);
+      }
+    },
+    [execute, formState.id, isCheckingCi, showToast],
+  );
+
+  const onBlurCi = async (e: React.FocusEvent<HTMLInputElement>) => {
+    await lookupGuardByCi(e.target.value);
+  };
+
+  const onCiKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      await lookupGuardByCi((e.currentTarget as HTMLInputElement).value);
+    }
+  };
+
   const onBlurEmail = useCallback(async () => {
+    if (!formState.email) return;
     const { data } = await execute(
       "/guards",
       "GET",
@@ -194,6 +246,10 @@ const RenderForm = ({ open, onClose, item, execute, reLoad }: any) => {
       maxWidth={760}
       title={formState.id ? "Editar guardia" : "Nuevo guardia"}
       onSave={_onSave}
+      buttonText={
+        isSaving ? "Guardando..." : formState.id ? "Actualizar" : "Guardar"
+      }
+      disabled={isSaving || isCheckingCi}
       variant={"mini"}
     >
       <UploadFileSingle
@@ -205,10 +261,11 @@ const RenderForm = ({ open, onClose, item, execute, reLoad }: any) => {
       <Input
         name="ci"
         value={formState.ci || ""}
-        disabled={formState._disabled}
+        disabled={Boolean(formState.id)}
         onChange={handleChange}
         label="Carnet de identidad"
         onBlur={onBlurCi}
+        onKeyDown={onCiKeyDown}
         error={errors}
         required
       />

--- a/src/modulos/Users/Users.module.css
+++ b/src/modulos/Users/Users.module.css
@@ -124,6 +124,33 @@
     margin-bottom: var(--spL);
   }
 }
+
+.adminStaffFormModal {
+  overflow-x: hidden;
+  padding-inline: 4px;
+}
+
+.adminStaffFormModal > div {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  align-items: stretch;
+}
+
+.adminStaffFormModal p {
+  margin: 0;
+  color: var(--cWhiteV1);
+  line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+  .adminStaffFormModal {
+    padding-inline: 0;
+  }
+
+  .adminStaffFormModal > div {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Estilo base para la etiqueta del rol */
 .roleBadge {
   display: inline-flex; /* Ajusta el tamaño al contenido */

--- a/src/modulos/Users/Users.tsx
+++ b/src/modulos/Users/Users.tsx
@@ -33,6 +33,12 @@ const Users = () => {
     permiso: "users",
     export: true,
     titleAdd: "Nuevo",
+    noWaiting: true,
+    formModal: {
+      minWidth: 720,
+      maxWidth: 840,
+      className: styles.adminStaffFormModal,
+    },
     // import: true,
     // search: { hide: true },
     hideActions: {
@@ -200,7 +206,13 @@ const Users = () => {
         form: {
           type: "imageUpload",
           prefix: "ADM",
-          style: { width: "100%" },
+          style: { width: "100%", minHeight: 180 },
+          sizePreview: { width: "150px", height: "150px" },
+          containerStyle: {
+            gridColumn: "1 / -1",
+            justifySelf: "center",
+            width: "min(100%, 320px)",
+          },
         },
       },
 
@@ -240,6 +252,7 @@ const Users = () => {
         form: {
           type: "fullName",
           disabled: onDisbled,
+          containerStyle: { gridColumn: "1 / -1" },
         },
         list: {
           onRender: (item: any) => {
@@ -354,6 +367,7 @@ const Users = () => {
         form: {
           type: "text",
           disabled: onDisbled,
+          containerStyle: { gridColumn: "1 / -1" },
         },
       },
       email: {
@@ -376,6 +390,7 @@ const Users = () => {
               </div>
             );
           },
+          containerStyle: { gridColumn: "1 / -1" },
         },
         list: true,
       },


### PR DESCRIPTION
## Resumen
- mejora el layout responsive del modal de personal administrativo
- agrega feedback de guardado en formularios CRUD y evita esperar la recarga para soltar el modal
- corrige la búsqueda de guardia por CI en el alta y mantiene coherente el editor del perfil

## Validación
- pnpm build
- pnpm exec tsc --noEmit --types vitest/globals
- git diff --check