### PR TITLE
fix(perfiles): endpoints users/owners/guards/homeowners con prefijo v3

### DIFF
--- a/src/components/ProfileModal/GuardEditForm/GuardEditForm.tsx
+++ b/src/components/ProfileModal/GuardEditForm/GuardEditForm.tsx
@@ -79,7 +79,7 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
       if (e.target.value.trim() === "") return;
 
       const { data } = await execute(
-        "/guards",
+        "/v3/guards",
         "GET",
         {
           fullType: "EXIST",
@@ -138,7 +138,7 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
         return;
 
       const { data } = await execute(
-        "/guards",
+        "/v3/guards",
         "GET",
         {
           fullType: "EXIST",
@@ -229,7 +229,7 @@ const GuardEditForm: React.FC<GuardEditFormProps> = ({
       return;
     }
 
-    const url = formState.id ? `/guards/${formState.id}` : "/guards";
+    const url = formState.id ? `/v3/guards/${formState.id}` : "/v3/guards";
     const method = formState.id ? "PUT" : "POST";
 
     const params = {

--- a/src/components/ProfileModal/ProfileModal.tsx
+++ b/src/components/ProfileModal/ProfileModal.tsx
@@ -122,10 +122,10 @@ const ProfileModal = ({
   const IconType = getIconType();
 
   const getUrl = () => {
-    if (type === "admin") return `/users`;
-    if (type === "owner") return `/owners`;
-    if (type === "homeOwner") return `/homeowners`;
-    return `/guards`;
+    if (type === "admin") return `/v3/users`;
+    if (type === "owner") return `/v3/owners`;
+    if (type === "homeOwner") return `/v3/homeowners`;
+    return `/v3/guards`;
   };
 
   const url = getUrl();

--- a/src/modulos/Assemblies/components/AssemblyAttendanceForm/AssemblyAttendanceForm.tsx
+++ b/src/modulos/Assemblies/components/AssemblyAttendanceForm/AssemblyAttendanceForm.tsx
@@ -88,7 +88,7 @@ const AssemblyAttendanceForm: React.FC<AssemblyAttendanceFormProps> = ({
 
     try {
       const { data: response, error } = await fetchResidents(
-        `/owners`,
+        `/v3/owners`,
         "GET",
         params,
         false,

--- a/src/modulos/Guards/RenderForm/RenderForm.tsx
+++ b/src/modulos/Guards/RenderForm/RenderForm.tsx
@@ -95,7 +95,7 @@ const RenderForm = ({ open, onClose, item, execute, reLoad }: any) => {
     if (hasErrors(validate())) return;
     let method = formState.id ? "PUT" : "POST";
     const { data } = await execute(
-      "/guards" + (formState.id ? "/" + formState.id : ""),
+      "/v3/guards" + (formState.id ? "/" + formState.id : ""),
       method,
       {
         ci: formState.ci,
@@ -121,7 +121,7 @@ const RenderForm = ({ open, onClose, item, execute, reLoad }: any) => {
   const onBlurCi = async () => {
     // if (e.target.value.trim() == "") return;
     const { data } = await execute(
-      "/guards",
+      "/v3/guards",
       "GET",
       {
         fullType: "EXIST",
@@ -168,7 +168,7 @@ const RenderForm = ({ open, onClose, item, execute, reLoad }: any) => {
   };
   const onBlurEmail = useCallback(async () => {
     const { data } = await execute(
-      "/guards",
+      "/v3/guards",
       "GET",
       {
         fullType: "EXIST",

--- a/src/modulos/HomeOwners/HomeOwners.tsx
+++ b/src/modulos/HomeOwners/HomeOwners.tsx
@@ -138,7 +138,7 @@ const HomeOwners = () => {
   const onBlurCi = useCallback(async (e: any, props: any) => {
     if (e.target.value.trim() == "") return;
     const { data, error } = await execute(
-      "/homeowners",
+      "/v3/homeowners",
       "GET",
       {
         fullType: "EXIST",
@@ -192,7 +192,7 @@ const HomeOwners = () => {
       return;
 
     const { data, error } = await execute(
-      "/homeowners",
+      "/v3/homeowners",
       "GET",
       {
         fullType: "EXIST",

--- a/src/modulos/Owners/Owners.tsx
+++ b/src/modulos/Owners/Owners.tsx
@@ -161,7 +161,7 @@ const Owners = () => {
   const onBlurCi = useCallback(async (e: any, props: any) => {
     if (e.target.value.trim() == "") return;
     const { data, error } = await execute(
-      "/owners",
+      "/v3/owners",
       "GET",
       {
         fullType: "EXIST",

--- a/src/modulos/Owners/RenderForm/RenderForm.tsx
+++ b/src/modulos/Owners/RenderForm/RenderForm.tsx
@@ -316,7 +316,7 @@ const RenderForm = ({
 
     try {
       const { data } = await execute(
-        "/owners",
+        "/v3/owners",
         "GET",
         {
           fullType: "EXIST",
@@ -374,7 +374,7 @@ const RenderForm = ({
 
     try {
       const { data } = await execute(
-        "/owners",
+        "/v3/owners",
         "GET",
         {
           fullType: "EXIST",
@@ -441,7 +441,7 @@ const RenderForm = ({
         is_homeowner: formState.type_owner === "Propietario" ? "Y" : "N",
       };
 
-      const endpoint = formState.id ? `/owners/${formState.id}` : "/owners";
+      const endpoint = formState.id ? `/v3/owners/${formState.id}` : "/v3/owners";
       const method = formState.id ? "PUT" : "POST";
 
       const { data: response } = await execute(endpoint, method, payload, true);

--- a/src/modulos/Owners/RenderView/RenderView.tsx
+++ b/src/modulos/Owners/RenderView/RenderView.tsx
@@ -27,7 +27,7 @@ const RenderView = (props: any) => {
   const getDataDetail = async () => {
     setLoading(true);
     const { data: dataDetail, error } = await execute(
-      "/owners",
+      "/v3/owners",
       "GET",
       {
         fullType: "DET",

--- a/src/modulos/OwnersManager/OwnerManagers.tsx
+++ b/src/modulos/OwnersManager/OwnerManagers.tsx
@@ -52,7 +52,7 @@ const OwnerManager = () => {
     }
     try {
       const { data } = await execute(
-        "/owners",
+        "/v3/owners",
         "GET",
         {
           fullType: "EXIST",
@@ -136,7 +136,7 @@ const OwnerManager = () => {
 
     try {
       const { data } = await execute(
-        "/owners",
+        "/v3/owners",
         "GET",
         {
           fullType: "EXIST",
@@ -254,7 +254,7 @@ const OwnerManager = () => {
         payload.password = formState.newCi;
       }
 
-      const endpoint = `/owners/${formState.id}`;
+      const endpoint = `/v3/owners/${formState.id}`;
       const method = "PUT";
 
       const { data: response } = await execute(endpoint, method, payload, true);

--- a/src/modulos/OwnersManager/RenderForm.tsx
+++ b/src/modulos/OwnersManager/RenderForm.tsx
@@ -316,7 +316,7 @@ const RenderForm = ({
 
     try {
       const { data } = await execute(
-        "/owners",
+        "/v3/owners",
         "GET",
         {
           fullType: "EXIST",
@@ -374,7 +374,7 @@ const RenderForm = ({
 
     try {
       const { data } = await execute(
-        "/owners",
+        "/v3/owners",
         "GET",
         {
           fullType: "EXIST",
@@ -441,7 +441,7 @@ const RenderForm = ({
         is_homeowner: formState.type_owner === "Propietario" ? "Y" : "N",
       };
 
-      const endpoint = formState.id ? `/owners/${formState.id}` : "/owners";
+      const endpoint = formState.id ? `/v3/owners/${formState.id}` : "/v3/owners";
       const method = formState.id ? "PUT" : "POST";
 
       const { data: response } = await execute(endpoint, method, payload, true);

--- a/src/modulos/Profile/Authentication.tsx
+++ b/src/modulos/Profile/Authentication.tsx
@@ -190,7 +190,7 @@ const Authentication = ({
       setIsDisabled(false);
       return;
     }
-    const { data: response } = await execute("/users", "GET", {
+    const { data: response } = await execute("/v3/users", "GET", {
       searchBy: formState.newEmail,
       fullType: "EXIST",
       type: "email",

--- a/src/modulos/Profile/Profile.tsx
+++ b/src/modulos/Profile/Profile.tsx
@@ -103,7 +103,7 @@ const Profile = () => {
     };
 
     const { data, error: err } = await execute(
-      "/users/" + user.id,
+      "/v3/users/" + user.id,
       "PUT",
       newUser,
     );

--- a/src/modulos/Superadmins/RenderForm/RenderForm.tsx
+++ b/src/modulos/Superadmins/RenderForm/RenderForm.tsx
@@ -95,7 +95,7 @@ const RenderForm = ({
     }
     let method = formState.id ? "PUT" : "POST";
     const { data } = await execute(
-      "/users" + (formState.id ? "/" + formState.id : ""),
+      "/v3/users" + (formState.id ? "/" + formState.id : ""),
       method,
       {
         name: formState?.name || "",
@@ -122,7 +122,7 @@ const RenderForm = ({
       return false;
     }
     const { data: response } = await execute(
-      "/users",
+      "/v3/users",
       "GET",
       {
         searchBy: formState.email,

--- a/src/modulos/Tasks/Tasks.tsx
+++ b/src/modulos/Tasks/Tasks.tsx
@@ -862,21 +862,21 @@ const Tasks = () => {
   const loadAssignablePeople = async () => {
     const [usersResponse, guardsResponse, ownersResponse] = await Promise.all([
       execute(
-        "/users",
+        "/v3/users",
         "GET",
         { page: 1, perPage: 300, fullType: "L" },
         false,
         true,
       ),
       execute(
-        "/guards",
+        "/v3/guards",
         "GET",
         { page: 1, perPage: 300, fullType: "L" },
         false,
         true,
       ),
       execute(
-        "/owners",
+        "/v3/owners",
         "GET",
         { page: 1, perPage: 300, fullType: "L" },
         false,

--- a/src/modulos/Users/RenderForm/RenderForm.tsx
+++ b/src/modulos/Users/RenderForm/RenderForm.tsx
@@ -88,7 +88,7 @@ const RenderForm = ({
       return;
     }
     const { data: response } = await execute(
-      "/users",
+      "/v3/users",
       "GET",
       {
         searchBy: formState.email,
@@ -106,7 +106,7 @@ const RenderForm = ({
   const onSave = async () => {
     if (hasErrors(validate())) return;
     const { data: response } = await execute(
-      "/users/" + formState.id,
+      "/v3/users/" + formState.id,
       "PUT",
       {
         name: formState.name,

--- a/src/modulos/Users/Users.tsx
+++ b/src/modulos/Users/Users.tsx
@@ -113,7 +113,7 @@ const Users = () => {
       return;
 
     const { data, error } = await execute(
-      "/users",
+      "/v3/users",
       "GET",
       {
         fullType: "EXIST",
@@ -136,7 +136,7 @@ const Users = () => {
   const onBlurCi = useCallback(async (e: any, props: any) => {
     if (e.target.value.trim() == "") return;
     const { data, error } = await execute(
-      "/users",
+      "/v3/users",
       "GET",
       {
         fullType: "EXIST",


### PR DESCRIPTION
## Contexto

Mario reportó (2026-07-31) que los perfiles de users, owners, guards y homeowners (y el propio del usuario logueado) salían vacíos en el front, mostrando casi todo sin datos.

## Causa raíz

La S123 pineó `prefix('v3')` en el backend (`app/Modules/Users/Routes/api.php`, S76 Guards, S3-T2 HomeOwner/Owners) y **eliminó los legacy sin deprecation layer**. El front quedó parcialmente migrado: los listados que pasan por `useCrud` con `modulo: 'v3/users'` funcionan, pero los `execute()` hardcodeados con `/users`, `/owners`, `/guards`, `/homeowners` quedaron rotos → 404 → datos vacíos.

Verificación en vivo contra API local:
```
/api/users      → 404 ❌   |   /api/v3/users      → 401 ✓
/api/owners     → 404 ❌   |   /api/v3/owners     → 401 ✓
/api/guards     → 404 ❌   |   /api/v3/guards     → 401 ✓
/api/homeowners → 404 ❌   |   /api/v3/homeowners → 401 ✓
```

## Fix (16 archivos, 35 insertions / 35 deletions, net-zero)

| Archivo | Cambio |
|---|---|
| `components/ProfileModal/ProfileModal.tsx` | `getUrl()` retorna `/v3/users\|owners\|homeowners\|guards` (era el bug del ReportView) |
| `components/ProfileModal/GuardEditForm/GuardEditForm.tsx` | onBlurCi/onBlurEmail EXIST + POST/PUT → `/v3/guards` |
| `modulos/Owners/RenderView/RenderView.tsx` | detalle de WAITING → `/v3/owners` |
| `modulos/Profile/Profile.tsx` | self-update PUT → `/v3/users/{id}` |
| `modulos/Profile/Authentication.tsx` | EXIST email → `/v3/users` |
| `modulos/Users/Users.tsx` | onBlurCi/onBlurEmail → `/v3/users` |
| `modulos/Users/RenderForm/RenderForm.tsx` | EXIST + PUT → `/v3/users` |
| `modulos/Owners/Owners.tsx` | onBlurCi → `/v3/owners` |
| `modulos/Owners/RenderForm/RenderForm.tsx` | EXIST (ci/email) + POST/PUT → `/v3/owners` |
| `modulos/OwnersManager/OwnerManagers.tsx` | EXIST (ci/email) + PUT → `/v3/owners` |
| `modulos/OwnersManager/RenderForm.tsx` | EXIST (ci/email) + POST/PUT → `/v3/owners` |
| `modulos/HomeOwners/HomeOwners.tsx` | onBlurCi/onBlurEmail → `/v3/homeowners` |
| `modulos/Guards/RenderForm/RenderForm.tsx` | EXIST (ci/email) + POST/PUT → `/v3/guards` |
| `modulos/Superadmins/RenderForm/RenderForm.tsx` | EXIST email + POST/PUT → `/v3/users` |
| `modulos/Tasks/Tasks.tsx` | loadAssignablePeople → `/v3/users|guards|owners` |
| `modulos/Assemblies/components/AssemblyAttendanceForm/AssemblyAttendanceForm.tsx` | fetchResidents → `/v3/owners` |

## Validación

- `npx tsc --noEmit` sin nuevos errores (los errores restantes son pre-existentes en `Areas/RenderView/RenderView.tsx` y artifacts stale de `.next/`).
- `grep "execute(..../users|owners|guards|homeowners)"` → 0 matches.
- `git diff --stat` → 35/35 simétrico (solo strings cambiados, no lógica).
- ESLint no se pudo correr: bug pre-existente del setup (`@rushstack/eslint-patch` incompatible con ESLint 9 — falla en `next lint` también). No relacionado con el fix.

## Caveat cross-IA

El API (`condaty-api`) tiene cambios sin commitear (`ExportService.php` + 2 deletes) que NO me corresponden. **No toqué nada del API**, solo el front. Si el otro agente mergea primero cambios en su rama, este PR queda limpio (16 archivos, ninguno tocado por el otro agente según su scope actual de export PDF/XLSX).

## Pendiente post-merge (no es bloqueante)

- Verificar en runtime que el back devuelve los campos `ci`, `phone`, `address`, `email`, `url_avatar`, `dptos[]`, `clients[]`, `role[]` en `/v3/users/.../DET` — son los que consume ProfileModal. Si falta alguno, hay que pedirle al agente del API que lo agregue al resource/transformer.

## Verificación visual pendiente (Mario)

1. Login → ir a Perfil propio → deben verse ci, phone, address, email con datos.
2. Users → click en un admin → ProfileModal debe mostrar todos los datos (no vacíos).
3. Owners → click en un residente (no WAITING) → ProfileModal debe mostrar datos.
4. Owners con WAITING + no Dependiente → RenderView debe mostrar datos.
5. Guards → click en un guardia → ProfileModal debe mostrar datos.
6. HomeOwners → click en un homeowner → ProfileModal debe mostrar datos.

cc @mariogfos