### PR TITLE
fix(payments): require income amount and reorder payment form fields

### DIFF
--- a/src/modulos/Payments/RenderForm/RenderForm.tsx
+++ b/src/modulos/Payments/RenderForm/RenderForm.tsx
@@ -245,18 +245,33 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
           </div>
 
           <div className={styles.section}>
-            <div className={styles["input-container"]}>
-              <Select
-                name="type"
-                label="Tipo"
-                required={true}
-                value={formState.type}
-                onChange={handleChangeInput}
-                options={TYPE_OPTIONS}
-                error={errors}
-                optionLabel="name"
-                optionValue="id"
-              />
+            <div className={styles["input-row"]}>
+              <div className={styles["input-half"]}>
+                <Select
+                  name="type"
+                  label="Tipo"
+                  required={true}
+                  value={formState.type}
+                  onChange={handleChangeInput}
+                  options={TYPE_OPTIONS}
+                  error={errors}
+                  optionLabel="name"
+                  optionValue="id"
+                />
+              </div>
+              <div className={styles["input-half"]}>
+                <Select
+                  name="method"
+                  label="Método de pago"
+                  value={formState.method}
+                  onChange={handleChangeInput}
+                  options={FORM_PAYMENT_METHODS}
+                  error={errors}
+                  required
+                  optionLabel="name"
+                  optionValue="id"
+                />
+              </div>
             </div>
           </div>
 
@@ -297,48 +312,6 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
 
           <div className={styles.section}>
             <div>
-              <div className={styles["payment-section"]}>
-                <div className={styles["input-row"]}>
-                  <div className={styles["input-half"]}>
-                    <Input
-                      type="currency"
-                      name="amount"
-                      label="Monto del ingreso"
-                      onChange={handleChangeInput}
-                      onBlur={formState.isAmountLocked ? undefined : handleAmountBlur}
-                      value={formState.amount}
-                      required={false}
-                      error={errors}
-                      disabled={formState.isAmountLocked}
-                      maxLength={20}
-                    />
-                    {isSimulating && (
-                      <span style={{ fontSize: "12px", color: "var(--cWhiteV3)" }}>
-                        Calculando...
-                      </span>
-                    )}
-                    {simulateError && (
-                      <span style={{ fontSize: "12px", color: "var(--cError, #f44)" }}>
-                        {simulateError}
-                      </span>
-                    )}
-                  </div>
-                  <div className={styles["input-half"]}>
-                    <Select
-                      name="method"
-                      label="Método de pago"
-                      value={formState.method}
-                      onChange={handleChangeInput}
-                      options={FORM_PAYMENT_METHODS}
-                      error={errors}
-                      required
-                      optionLabel="name"
-                      optionValue="id"
-                    />
-                  </div>
-                </div>
-              </div>
-
               {isDebtBasedPayment && (
                 <div>
                   {deudasContent}
@@ -349,6 +322,31 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
                   )}
                 </div>
               )}
+
+              <div className={styles["input-container"]} style={{ marginTop: isDebtBasedPayment ? 8 : 0 }}>
+                <Input
+                  type="currency"
+                  name="amount"
+                  label="Monto del ingreso"
+                  onChange={handleChangeInput}
+                  onBlur={formState.isAmountLocked ? undefined : handleAmountBlur}
+                  value={formState.amount}
+                  required={true}
+                  error={errors}
+                  disabled={formState.isAmountLocked}
+                  maxLength={20}
+                />
+                {isSimulating && (
+                  <span style={{ fontSize: "12px", color: "var(--cWhiteV3)" }}>
+                    Calculando...
+                  </span>
+                )}
+                {simulateError && (
+                  <span style={{ fontSize: "12px", color: "var(--cError, #f44)" }}>
+                    {simulateError}
+                  </span>
+                )}
+              </div>
 
               <div className={styles["supporting-fields"]}>
                 <div className={styles["upload-section"]}>

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -775,6 +775,18 @@ export const usePaymentsForm = (
       if (!formState.amount) {
         err.amount = "Este campo es requerido";
       }
+    } else {
+      // Pago basado en deudas: el monto sigue siendo obligatorio. Si el usuario
+      // no escribió nada, el submit usa el periodoTotal como fallback para
+      // no romper el flujo, pero el error bloquea el guardado para forzar
+      // confirmación explícita del monto a registrar.
+      if (
+        !formState.amount ||
+        (typeof formState.amount === "string" && formState.amount.trim() === "") ||
+        (typeof formState.amount === "number" && formState.amount <= 0)
+      ) {
+        err.amount = "Este campo es requerido";
+      }
     }
 
     if (!formState.paid_at) {


### PR DESCRIPTION
## Summary
Ajustes de UX/validación al formulario de **Crear Ingreso (Payment)** del admin. Solo front — el API no se toca.

## Cambios
- **Layout**: "Método de pago" ahora va **al lado de "Tipo"** en un `input-row` con dos `input-half` (mismo patrón visual que Categoría/Subcategoría).
- **Layout**: el input "Monto del ingreso" se **movió debajo del label "Total a pagar"**. Cuando es pago basado en deudas, primero aparece el `deudasContent` (que ya tiene el "Total a pagar: Bs X") y debajo queda el input. Cuando no hay deudas (pago directo), el input queda como su propia sección.
- **Validación**: "Monto del ingreso" es ahora **obligatorio en todos los tipos de pago** (antes era opcional para pagos basados en deudas, donde caía a `periodoTotal` por defecto). `validar()` en `usePaymentsForm` rechaza amount vacío, string en blanco o número <= 0.

## Archivos tocados
- `src/modulos/Payments/RenderForm/RenderForm.tsx`
- `src/modulos/Payments/hooks/usePaymentsForm.ts`

## Lo que NO se tocó
- `condaty-api/` — sin cambios. Payload de submit intacto (`amount` siempre se envía, antes o después del cambio).
- CSS del módulo ni otros componentes.

## Verificación
- ✅ Tests del módulo Payments: **23/23 verde** (`usePaymentsForm.test.ts`, `RenderForm.test.tsx`, `RenderView.test.tsx`, `Payments.test.tsx`, `usePayments.test.ts`, `usePayments.categoriesButton.test.tsx`).
- ✅ `tsc --noEmit` sobre los 2 archivos modificados: 0 errores nuevos (los 2 errores preexistentes en `RenderForm.test.tsx` ya estaban antes de mis cambios, verificado con `git stash` + typecheck).
- ✅ Hook pre-commit del repo: PASS (0 errors, 0 warnings).