### PR TITLE
feat(payments): inline create expense for advance payment

### DIFF
--- a/src/modulos/Payments/RenderForm/RenderForm.tsx
+++ b/src/modulos/Payments/RenderForm/RenderForm.tsx
@@ -312,7 +312,43 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
 
           <div className={styles.section}>
             <div>
-              {isDebtBasedPayment && (
+              {formState.type === FormPaymentType.EXPENSE && (
+                <div
+                  className={styles["select-all-container"]}
+                  style={{ marginBottom: 12 }}
+                >
+                  <label
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      cursor: "pointer",
+                      color: "var(--cWhite)",
+                      fontSize: "0.95rem",
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      data-testid="create-expense-toggle"
+                      checked={Boolean(formState.createExpense)}
+                      onChange={(e) =>
+                        setFormState((prev: any) => ({
+                          ...prev,
+                          createExpense: e.target.checked,
+                          // Si activamos el flag, limpiamos selección de deudas
+                          // pre-existentes (no aplica en este modo).
+                          ...(e.target.checked
+                            ? { amount: "" }
+                            : {}),
+                        }))
+                      }
+                    />
+                    Crear expensa nueva (pago adelantado)
+                  </label>
+                </div>
+              )}
+
+              {isDebtBasedPayment && !formState.createExpense && (
                 <div>
                   {deudasContent}
                   {errors.selectedPeriodo && (
@@ -323,11 +359,98 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
                 </div>
               )}
 
+              {formState.createExpense && formState.type === FormPaymentType.EXPENSE && (
+                <div
+                  className={styles["payment-section"]}
+                  style={{ marginBottom: 12 }}
+                >
+                  <div className={styles["input-row"]}>
+                    <div className={styles["input-half"]}>
+                      <Select
+                        name="expenseMonth"
+                        label="Mes de la expensa"
+                        value={String(formState.expenseMonth ?? "")}
+                        onChange={(e: any) =>
+                          setFormState((prev: any) => ({
+                            ...prev,
+                            expenseMonth: Number(e.target.value),
+                          }))
+                        }
+                        options={[
+                          { id: 1, name: "Enero" },
+                          { id: 2, name: "Febrero" },
+                          { id: 3, name: "Marzo" },
+                          { id: 4, name: "Abril" },
+                          { id: 5, name: "Mayo" },
+                          { id: 6, name: "Junio" },
+                          { id: 7, name: "Julio" },
+                          { id: 8, name: "Agosto" },
+                          { id: 9, name: "Septiembre" },
+                          { id: 10, name: "Octubre" },
+                          { id: 11, name: "Noviembre" },
+                          { id: 12, name: "Diciembre" },
+                        ]}
+                        required
+                        error={errors}
+                        optionLabel="name"
+                        optionValue="id"
+                      />
+                    </div>
+                    <div className={styles["input-half"]}>
+                      <Input
+                        type="number"
+                        name="expenseYear"
+                        label="Año de la expensa"
+                        value={String(formState.expenseYear ?? "")}
+                        onChange={(e) => {
+                          const raw = (e.target.value || "").replace(/\D/g, "").slice(0, 4);
+                          setFormState((prev: any) => ({
+                            ...prev,
+                            expenseYear: raw,
+                          }));
+                        }}
+                        required
+                        error={errors}
+                        maxLength={4}
+                      />
+                    </div>
+                  </div>
+                  <div className={styles["input-container"]} style={{ marginTop: 8 }}>
+                    <Input
+                      type="text"
+                      name="expenseDescription"
+                      label="Descripción (opcional)"
+                      placeholder="Expensa Agosto 2026"
+                      value={formState.expenseDescription || ""}
+                      onChange={(e) =>
+                        setFormState((prev: any) => ({
+                          ...prev,
+                          expenseDescription: e.target.value.substring(0, 100),
+                        }))
+                      }
+                      error={errors}
+                      maxLength={100}
+                    />
+                  </div>
+                  <p
+                    style={{
+                      fontSize: "0.8rem",
+                      color: "var(--cWhiteV1)",
+                      marginTop: 6,
+                    }}
+                  >
+                    Se creará la deuda para la unidad seleccionada y se pagará
+                    en la misma operación. La descripción por defecto es
+                    &quot;Expensa [Mes] [Año]&quot;.
+                  </p>
+                </div>
+              )}
+
               <div className={styles["input-container"]} style={{ marginTop: isDebtBasedPayment ? 8 : 0 }}>
                 <Input
                   type="currency"
                   name="amount"
-                  label="Monto del ingreso"
+                  label={formState.createExpense ? "Monto de la expensa y del pago" : "Monto del ingreso"}
                   onChange={handleChangeInput}
                   onBlur={formState.isAmountLocked ? undefined : handleAmountBlur}
                   value={formState.amount}

--- a/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
+++ b/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
@@ -357,4 +357,151 @@ describe("usePaymentsForm", () => {
 
     expect(concept).toBe("-/-");
   });
+
+  it("S86 inline-create-expense: pinea create_expense + expense_data y deuda vacía", async () => {
+    const localExecute = vi.fn().mockResolvedValue({ data: { success: true, data: "payment-s86" } });
+
+    const props = {
+      item: {
+        paid_at: "2026-08-01",
+        type: FormPaymentType.EXPENSE,
+        dpto_id: "101",
+        method: String(PaymentMethod.CASH),
+        amount: "",
+        // Pineamos el flag S86 directamente en el state inicial
+        createExpense: true,
+        expenseMonth: 8,
+        expenseYear: 2026,
+        expenseDescription: "Pago adelantado Agosto",
+      },
+      extraData: {
+        dptos: [{ id: 5, nro: "101", description: "Dpto 101", homeowner: { id: 9, name: "Mario" } }],
+        categories: [],
+        client_config: { cat_expensas: 100, cat_reservations: 200, cat_forgiveness: 300 },
+        bankAccounts: [{ id: 7, is_expense: 1 }],
+        subcategories: [],
+      },
+      execute: localExecute,
+      showToast: mockShowToast,
+      reLoad: mockReLoad,
+      onClose: mockOnClose,
+    } as any;
+
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    // El form debe aceptar crear expensa sin deudas pre-existentes:
+    // isExpensasWithoutDebt debe estar en false.
+    expect(result.current.formState.createExpense).toBe(true);
+
+    await act(async () => {
+      result.current.handleChangeInput({ target: { name: "amount", value: "1500", type: "text" } } as any);
+    });
+
+    await act(async () => {
+      await result.current._onSavePago();
+    });
+
+    const createCall = localExecute.mock.calls.find((c: any[]) => c[0] === paymentsApi.create);
+    expect(createCall).toBeDefined();
+    const payload = createCall![2];
+
+    // create_expense + expense_data pineados
+    expect(payload.create_expense).toBe(true);
+    expect(payload.expense_data).toBeDefined();
+    expect(payload.expense_data.month).toBe(8);
+    expect(payload.expense_data.year).toBe(2026);
+    expect(payload.expense_data.description).toBe("Pago adelantado Agosto");
+    expect(payload.expense_data.amount).toBe(1500);
+    // due_at = último día del mes pineado
+    expect(payload.expense_data.due_at).toBe("2026-08-31");
+    // subcategory_id pinea cat_expensas automáticamente
+    expect(payload.expense_data.subcategory_id).toBe(100);
+    // debt_dpto_ids vacío (la deuda se crea dentro de la transacción)
+    expect(payload.debt_dpto_ids).toEqual([]);
+    // amount = mismo que expense_data.amount
+    expect(payload.amount).toBe(1500);
+    // bank_account_id de la cuenta de expensas
+    expect(payload.bank_account_id).toBe(7);
+  });
+
+  it("S86 inline-create-expense: validación rechaza mes/año inválido", async () => {
+    const localExecute = vi.fn().mockResolvedValue({ data: { success: true } });
+
+    const props = {
+      item: {
+        paid_at: "2026-08-01",
+        type: FormPaymentType.EXPENSE,
+        dpto_id: "101",
+        method: String(PaymentMethod.CASH),
+        amount: "100",
+        createExpense: true,
+        expenseMonth: 13, // inválido
+        expenseYear: 2026,
+        expenseDescription: "",
+      },
+      extraData: {
+        dptos: [{ id: 5, nro: "101", description: "Dpto 101", homeowner: { id: 9, name: "Mario" } }],
+        categories: [],
+        client_config: { cat_expensas: 100, cat_reservations: 200, cat_forgiveness: 300 },
+        bankAccounts: [{ id: 7, is_expense: 1 }],
+        subcategories: [],
+      },
+      execute: localExecute,
+      showToast: mockShowToast,
+      reLoad: mockReLoad,
+      onClose: mockOnClose,
+    } as any;
+
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    await act(async () => {
+      await result.current._onSavePago();
+    });
+
+    // No debe haberse pineado el endpoint porque la validación falló
+    const createCall = localExecute.mock.calls.find((c: any[]) => c[0] === paymentsApi.create);
+    expect(createCall).toBeUndefined();
+  });
+
+  it("S86: cambiar de tipo resetea createExpense", async () => {
+    const localExecute = vi.fn().mockResolvedValue({ data: { success: true } });
+
+    const props = {
+      item: {
+        paid_at: "2026-08-01",
+        type: FormPaymentType.EXPENSE,
+        dpto_id: "101",
+        method: String(PaymentMethod.CASH),
+        amount: "",
+        createExpense: true,
+        expenseMonth: 8,
+        expenseYear: 2026,
+      },
+      extraData: {
+        dptos: [{ id: 5, nro: "101", description: "Dpto 101", homeowner: { id: 9, name: "Mario" } }],
+        categories: [],
+        client_config: { cat_expensas: 100, cat_reservations: 200, cat_forgiveness: 300 },
+        bankAccounts: [],
+        subcategories: [],
+      },
+      execute: localExecute,
+      showToast: mockShowToast,
+      reLoad: mockReLoad,
+      onClose: mockOnClose,
+    } as any;
+
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    expect(result.current.formState.createExpense).toBe(true);
+
+    // Cambio a DIRECT
+    await act(async () => {
+      result.current.handleChangeInput({
+        target: { name: "type", value: FormPaymentType.DIRECT, type: "text" },
+      } as any);
+    });
+
+    expect(result.current.formState.createExpense).toBe(false);
+    expect(result.current.formState.amount).toBe("");
+  });
 });

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -174,6 +174,14 @@ export interface FormState {
   amount?: number | string;
   type?: FormPaymentType;
   owner_id?: string | number;
+  // S86 inline-create-expense: cuando type === EXPENSE y el admin quiere
+  // registrar una expensa que aún no fue creada (pago adelantado, etc.),
+  // pineá createExpense=true + expenseMonth/Year/Description. El backend
+  // crea la DebtDpto en la misma transacción que el pago.
+  createExpense?: boolean;
+  expenseMonth?: number | string;
+  expenseYear?: number | string;
+  expenseDescription?: string;
 }
 
 export interface Errors {
@@ -188,6 +196,8 @@ export interface Errors {
   file?: string;
   paid_at?: string;
   type?: string;
+  expenseMonth?: string;
+  expenseYear?: string;
   [key: string]: string | undefined;
 }
 
@@ -237,6 +247,12 @@ export const usePaymentsForm = (
       obs: item?.obs || "",
       amount: item?.amount || "",
       owner_id: item?.owner_id || "",
+      // S86 inline-create-expense: si el item entrante ya tiene el flag (caso
+      // deep-link / re-edición), lo respetamos; si no, default false.
+      createExpense: item?.createExpense || false,
+      expenseMonth: item?.expenseMonth ?? new Date().getMonth() + 1,
+      expenseYear: item?.expenseYear ?? new Date().getFullYear(),
+      expenseDescription: item?.expenseDescription || "",
     };
   });
 
@@ -258,8 +274,11 @@ export const usePaymentsForm = (
   const isDebtBasedPayment = Boolean(formState.type && formState.type !== FormPaymentType.DIRECT);
 
   const isExpensasWithoutDebt = useMemo(() => {
+    // S86 inline-create-expense: si el flag está activo, vamos a crear la
+    // deuda AHORA, así que "no hay deudas" ya no es un estado de error.
+    if (formState.createExpense) return false;
     return formState.type === FormPaymentType.EXPENSE && deudas.length === 0 && !isLoadingDeudas;
-  }, [formState.type, deudas.length, isLoadingDeudas]);
+  }, [formState.type, formState.createExpense, deudas.length, isLoadingDeudas]);
 
   const isReservationsWithoutDebt = useMemo(() => {
     return formState.type === FormPaymentType.RESERVATION && deudas.length === 0 && !isLoadingDeudas;
@@ -619,10 +638,16 @@ export const usePaymentsForm = (
           category_id: "",
           subcategory_id: "",
           subcategories: [],
+          // Cambio de tipo → reset del flag createExpense y del amount (si era
+          // debt-based con periodoTotal pre-rellenado, ya no aplica).
+          createExpense: false,
+          amount: "",
         }));
         setDeudas([]);
         setSelectedPeriodo([]);
         setPeriodoTotal(0);
+        setSimulateResult(null);
+        setSimulateError(null);
         lastLoadedDeudas.current = "";
         if (typeValue && typeValue !== FormPaymentType.DIRECT && formState.dpto_id) {
           setTimeout(() => {
@@ -698,6 +723,10 @@ export const usePaymentsForm = (
 
   const runSimulate = useCallback(async () => {
     if (!isDebtBasedPayment || !formState.amount || selectedPeriodo.length === 0) return;
+    // S86 inline-create-expense: si la deuda todavía no existe (createExpense=true),
+    // no hay nada que simular — el backend la crea con el monto que mandemos y
+    // la cascade la paga en la misma transacción. Skip silencioso.
+    if (formState.createExpense) return;
 
     setIsSimulating(true);
     try {
@@ -726,7 +755,7 @@ export const usePaymentsForm = (
     } finally {
       setIsSimulating(false);
     }
-  }, [isDebtBasedPayment, formState.amount, selectedPeriodo, execute]);
+  }, [isDebtBasedPayment, formState.amount, formState.createExpense, selectedPeriodo, execute]);
 
   const handleAmountBlur = useCallback(() => {
     runSimulate();
@@ -749,8 +778,12 @@ export const usePaymentsForm = (
     if (
       isDebtBasedPayment &&
       deudas?.length > 0 &&
-      selectedPeriodo.length === 0
+      selectedPeriodo.length === 0 &&
+      !formState.createExpense
     ) {
+      // S86: si createExpense=true, la deuda todavía no existe; el backend
+      // la crea dentro de la misma transacción. selectedPeriodo queda vacío
+      // intencionalmente.
       err.selectedPeriodo = "Debe seleccionar al menos una deuda para pagar";
     }
 
@@ -791,6 +824,18 @@ export const usePaymentsForm = (
 
     if (!formState.paid_at) {
       err.paid_at = "Este campo es requerido";
+    }
+
+    // S86 inline-create-expense: validar mes/año si createExpense=true.
+    if (formState.createExpense) {
+      const month = Number(formState.expenseMonth);
+      const year = Number(formState.expenseYear);
+      if (!month || month < 1 || month > 12) {
+        err.expenseMonth = "Mes inválido (1-12)";
+      }
+      if (!year || year < 2000 || year > 2100) {
+        err.expenseYear = "Año inválido";
+      }
     }
 
     setErrors(err);
@@ -880,6 +925,13 @@ export const usePaymentsForm = (
     const selectedDpto = findSelectedDpto(formState.dpto_id || "");
     const dptoId = Number(selectedDpto?.id || formState.dpto_id);
 
+    // S86 inline-create-expense: si el flag está activo, dejamos debt_dpto_ids
+    // vacío y pineamos create_expense + expense_data. El backend crea la
+    // DebtDpto dentro de la misma transacción que el pago.
+    const shouldCreateExpense = Boolean(
+      formState.createExpense && formState.type === FormPaymentType.EXPENSE
+    );
+
     const params: any = {
       dpto_id: dptoId,
       paid_at: formState.paid_at,
@@ -889,12 +941,41 @@ export const usePaymentsForm = (
           ? formState.amount || periodoTotal
           : formState.amount || "0"
       )),
-      debt_dpto_ids: isDebtBasedPayment ? selectedPeriodo.map((p) => Number(p.id)) : [],
+      debt_dpto_ids:
+        shouldCreateExpense
+          ? []
+          : isDebtBasedPayment
+            ? selectedPeriodo.map((p) => Number(p.id))
+            : [],
       bank_account_id: bank_account_id,
       obs: formState.obs || "",
       voucher: formState.voucher || "",
       url_file: formState.url_file || [],
     };
+
+    if (shouldCreateExpense) {
+      const month = Number(formState.expenseMonth);
+      const year = Number(formState.expenseYear);
+      // due_at: fin del mes pineado. Si el usuario quiere otra fecha, podría
+      // agregarse después; por ahora usamos el último día del mes como
+      // convención consistente con el formato Y-m-d que espera el backend.
+      const lastDay = new Date(year, month, 0).getDate();
+      const dueAt = `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+
+      params.create_expense = true;
+      params.expense_data = {
+        dpto_id: dptoId,
+        amount: params.amount,
+        due_at: dueAt,
+        description: (formState.expenseDescription || "").trim(),
+        month: month,
+        year: year,
+        // pinear la subcategoría "expensas" del cliente si está disponible,
+        // para mantener la consistencia con el resto del módulo que usa
+        // client_config.cat_expensas como SSoT.
+        subcategory_id: extraData?.client_config?.cat_expensas ?? null,
+      };
+    }
 
     isSubmittingRef.current = true;
     setIsSubmitting(true);


### PR DESCRIPTION
## Summary
Activa el flow **S86 inline-create-expense** en el form de Crear Ingreso del admin. El backend ya lo soporta desde S86 (`PaymentFlowUnificationS86Test`, verde) — el admin actual no lo consumía. Esto permite cobrar **expensas nuevas que aún no existen en el sistema** (pagos adelantados) sin tener que ir a Expenses → crear → volver a Pagos (2 acciones → 1).

## Cambios

### Front (único scope — sin tocar API)

**`src/modulos/Payments/RenderForm/RenderForm.tsx`**
- Nuevo toggle "Crear expensa nueva (pago adelantado)" visible solo cuando `type === EXPENSE`.
- Al activarlo: se ocultan las deudas pre-existentes y aparecen 3 campos nuevos (Mes, Año, Descripción opcional).
- Label del input de monto cambia a "Monto de la expensa y del pago" cuando el toggle está activo.

**`src/modulos/Payments/hooks/usePaymentsForm.ts`**
- `FormState`: nuevos campos `createExpense`, `expenseMonth`, `expenseYear`, `expenseDescription`. Init respeta `item.createExpense` (deep-link / re-edición).
- `runSimulate`: skip silencioso cuando `createExpense=true` (la deuda aún no existe, no hay nada que simular).
- `isExpensasWithoutDebt`: desactivado cuando `createExpense=true`.
- `validar()`: rechaza month/year fuera de rango (1-12 / 2000-2100) cuando `createExpense=true`. Check de "selectedPeriodo vacío" no aplica en este modo.
- `_onSavePago`: pinea `create_expense: true` + `expense_data: { dpto_id, amount, due_at, description, month, year, subcategory_id }` con:
  - `due_at` = último día del mes pineado.
  - `description` opcional, default = "Expensa [Mes] [Año]".
  - `subcategory_id` = `client_config.cat_expensas` (SSoT, mismo patrón que usa el flujo DIRECT).
  - `debt_dpto_ids: []` (la deuda se crea dentro de la misma transacción).
- `handleChangeInput` (branch `type`): reset de `createExpense=false` + `amount=""` cuando cambia el tipo. Limpia `simulateResult`/`simulateError` también.

**`src/modulos/Payments/__tests__/usePaymentsForm.test.ts`**
- 3 tests nuevos:
  1. `S86 inline-create-expense: pinea create_expense + expense_data y deuda vacía` — verifica el payload completo (incluye `due_at=2026-08-31`, `subcategory_id=cat_expensas`, `debt_dpto_ids=[]`, `bank_account_id` desde cuenta de expensas).
  2. `S86 inline-create-expense: validación rechaza mes/año inválido` — confirma que con `expenseMonth=13` el submit NO se pineá al endpoint.
  3. `S86: cambiar de tipo resetea createExpense` — toggle se limpia al cambiar `type` de EXPENSE a DIRECT.

## Lo que NO se tocó
- `condaty-api/` — sin cambios. El endpoint `POST /api/v3/payments` ya pineaba `create_expense` + `expense_data` desde S86.
- CSS del módulo ni otros componentes.

## Decisiones de diseño (según informe previo)
- **Sin check de duplicados** (si el admin crea la misma expensa 2 veces, se crean 2 `DebtDpto`). Si te molesta, se pinea en sprint aparte con un endpoint de pre-check.
- **Skip simulación** cuando `createExpense=true` (en lugar de simular contra deuda sintética). Más simple; la cascade del backend ya pinea el resultado correcto.
- **`subcategory_id = cat_expensas` automático** (mantiene consistencia con el flujo DIRECT). Si querés que sea seleccionable, lo cambiamos.

## Verificación
- ✅ Tests del módulo Payments: **26/26 verde** (23 previos + 3 nuevos).
- ✅ `tsc --noEmit` sobre los 3 archivos modificados: 0 errores nuevos (los 2 errores preexistentes en `RenderForm.test.tsx` ya estaban antes de mis cambios, verificado con `git stash` + typecheck).
- ✅ Hook pre-commit del repo: PASS (0 errors, 0 warnings).

## Caveat
- Caveat inter-IA: mi scope default es mk-director + RETO. Este PR toca el admin de Condaty (territorio habitual de Claude Code) pero Mario me lo pidió explícitamente en esta sesión. Sin impacto en otros PRs en vuelo.