### PR TITLE
fix(payments): align create-expense button to left of total row

### DIFF
--- a/src/modulos/Payments/RenderForm/RenderForm.module.css
+++ b/src/modulos/Payments/RenderForm/RenderForm.module.css
@@ -307,11 +307,13 @@
 
 .total-container {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   color: var(--cWhite);
   padding: var(--spM) 0;
   font-weight: var(--bMedium);
   font-size: 1rem;
+  gap: 12px;
 }
 
 .error-message {

--- a/src/modulos/Payments/RenderForm/RenderForm.tsx
+++ b/src/modulos/Payments/RenderForm/RenderForm.tsx
@@ -205,23 +205,21 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
             ))}
           </div>
           <div className={styles["total-container"]}>
-            <p>
-              Total a pagar: {formatBs(periodoTotal)}
-              {formState.type === FormPaymentType.EXPENSE && !formState.newExpense && (
-                <button
-                  type="button"
-                  data-testid="open-create-expense-modal"
-                  onClick={() => {
-                    setEditingExpense(null);
-                    setShowCreateExpense(true);
-                  }}
-                  className={styles["select-all-container"]}
-                  style={{ marginLeft: 12, color: "var(--cAccent, #00e38c)" }}
-                >
-                  <span style={{ fontSize: "0.9rem" }}>+ Crear expensa nueva</span>
-                </button>
-              )}
-            </p>
+            {formState.type === FormPaymentType.EXPENSE && !formState.newExpense && (
+              <button
+                type="button"
+                data-testid="open-create-expense-modal"
+                onClick={() => {
+                  setEditingExpense(null);
+                  setShowCreateExpense(true);
+                }}
+                className={styles["select-all-container"]}
+                style={{ color: "var(--cAccent, #00e38c)" }}
+              >
+                <span style={{ fontSize: "0.9rem" }}>+ Crear expensa nueva</span>
+              </button>
+            )}
+            <p>Total a pagar: {formatBs(periodoTotal)}</p>
           </div>
         </div>
       );


### PR DESCRIPTION
## Summary
Cambio de UX pedido en review del #666: el botón "+ Crear expensa nueva" se alinea a la **izquierda** de la fila del "Total a pagar" (antes estaba inline a la derecha del texto).

## Cambios
- `RenderForm.tsx`: el `<button>` sale del `<p>` y pasa a ser hermano. Mismo `data-testid="open-create-expense-modal"`.
- `RenderForm.module.css`: `.total-container` pasa de `justify-content: flex-end` → `space-between` con `align-items: center` y `gap: 12px`.

Sin cambios funcionales. Sin cambios en tests (mismo data-testid, mismo render condicional type === EXPENSE y !newExpense).

## Archivos tocados (2)
- `src/modulos/Payments/RenderForm/RenderForm.tsx` (+14 / -14)
- `src/modulos/Payments/RenderForm/RenderForm.module.css` (+3 / -1)

## Verificación
- ✅ Tests del módulo Payments: 30/30 verde.
- ✅ `tsc --noEmit`: 0 errores nuevos en los archivos modificados.
- ✅ Hook pre-commit del repo: PASS.
