### PR TITLE
feat(payments): S87 multi create_expenses in payment form

### DIFF
--- a/src/modulos/Payments/RenderForm/RenderForm.tsx
+++ b/src/modulos/Payments/RenderForm/RenderForm.tsx
@@ -394,9 +394,23 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
                       {formState.newExpenses!.map((ne) => (
                         <div key={ne.virtualId} className={styles["deuda-row"]}>
                           <div className={styles["deuda-cell"]}>Expensa</div>
-                          <div className={styles["deuda-cell"]}>
-                            {ne.description ||
-                              `Expensa ${MONTH_NAMES[ne.month - 1]} ${ne.year}`}
+                          <div
+                            className={styles["deuda-cell"]}
+                            style={{ display: "flex", flexDirection: "column", gap: 2 }}
+                          >
+                            <span style={{ fontWeight: "var(--bMedium)" }}>
+                              {`Expensa ${MONTH_NAMES[ne.month - 1]} ${ne.year}`}
+                            </span>
+                            {ne.description && (
+                              <span
+                                style={{
+                                  fontSize: "0.78rem",
+                                  color: "var(--cWhiteV1)",
+                                }}
+                              >
+                                {ne.description}
+                              </span>
+                            )}
                           </div>
                           <div
                             className={`${styles["deuda-cell"]} ${styles["amount-cell"]}`}

--- a/src/modulos/Payments/RenderForm/RenderForm.tsx
+++ b/src/modulos/Payments/RenderForm/RenderForm.tsx
@@ -53,6 +53,7 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
     addNewExpense,
     updateNewExpense,
     removeNewExpense,
+    newExpensesTotal,
   } = usePaymentsForm(props, open);
 
   // S86 inline-create-expense (modal): controla el modal de crear/editar
@@ -62,15 +63,24 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
     import("../hooks/usePaymentsForm").NewExpense | null
   >(null);
 
-  // Heurística: monto normal de la unidad = monto de la primera deuda
-  // pre-existente. Cuando el back pinee `dptos.expense_amount` (spec para
-  // Claude Code), esto se cambia a leer de la unidad seleccionada.
+  // S87: monto "normal" de la unidad. Pre-carga preferentemente el
+  // `expense_amount` del dpto (SSoT del back, pinea en `queryForExtraData`
+  // desde S87). Si no está disponible, cae a la heurística del front
+  // (monto de la primera deuda pre-existente).
   const suggestedAmount = useMemo(() => {
-    if (!formState.dpto_id || deudas.length === 0) return 0;
+    if (!formState.dpto_id) return 0;
+    const selectedDpto = lDptos.find(
+      (d) => String(d.id) === String(formState.dpto_id)
+    );
+    if (selectedDpto && selectedDpto.expense_amount) {
+      const n = Number(selectedDpto.expense_amount);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+    if (deudas.length === 0) return 0;
     const first = deudas[0];
     return getSubtotal(first) || 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formState.dpto_id, deudas.length]);
+  }, [formState.dpto_id, lDptos, deudas.length]);
 
   const deudasContent = useMemo(() => {
     if (!formState.dpto_id) {
@@ -205,7 +215,7 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
             ))}
           </div>
           <div className={styles["total-container"]}>
-            {formState.type === FormPaymentType.EXPENSE && !formState.newExpense && (
+            {formState.type === FormPaymentType.EXPENSE && (
               <button
                 type="button"
                 data-testid="open-create-expense-modal"
@@ -219,7 +229,7 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
                 <span style={{ fontSize: "0.9rem" }}>+ Crear expensa nueva</span>
               </button>
             )}
-            <p>Total a pagar: {formatBs(periodoTotal)}</p>
+            <p>Total a pagar: {formatBs(periodoTotal + newExpensesTotal)}</p>
           </div>
         </div>
       );
@@ -227,11 +237,12 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
   }, [
     formState.dpto_id,
     formState.type,
-    formState.newExpense,
+    formState.newExpenses,
     isLoadingDeudas,
     deudas,
     selectedPeriodo,
     periodoTotal,
+    newExpensesTotal,
     handleSelectAllPeriodos,
     handleSelectPeriodo,
     isBankAccountSame,
@@ -353,6 +364,99 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
 
           <div className={styles.section}>
             <div>
+              {/* S87 inline-create-expense: lista virtual de expensas nuevas.
+                  Aparece ARRIBA de la tabla de deudas pre-existentes. Cada
+                  item tiene botones Editar / Eliminar. Soporta N expensas
+                  (multi). Solo visible si type === EXPENSE. */}
+              {(formState.newExpenses?.length ?? 0) > 0 &&
+                formState.type === FormPaymentType.EXPENSE && (
+                  <div
+                    data-testid="new-expense-card"
+                    className={styles["deudas-container"]}
+                    style={{
+                      marginBottom: 12,
+                      border: "1px dashed var(--cAccent, #00e38c)",
+                      borderRadius: 8,
+                      padding: 12,
+                    }}
+                  >
+                    <div className={styles["deudas-title-row"]}>
+                      <p className={styles["deudas-title"]}>
+                        🆕 {formState.newExpenses!.length === 1
+                          ? "Expensa nueva (se creará al confirmar el pago)"
+                          : `Expensas nuevas (${formState.newExpenses!.length}, se crearán al confirmar el pago)`}
+                      </p>
+                    </div>
+                    <div
+                      className={styles["deudas-table"]}
+                      style={{ borderColor: "var(--cAccent, #00e38c)" }}
+                    >
+                      {formState.newExpenses!.map((ne) => (
+                        <div key={ne.virtualId} className={styles["deuda-row"]}>
+                          <div className={styles["deuda-cell"]}>Expensa</div>
+                          <div className={styles["deuda-cell"]}>
+                            {ne.description ||
+                              `Expensa ${MONTH_NAMES[ne.month - 1]} ${ne.year}`}
+                          </div>
+                          <div
+                            className={`${styles["deuda-cell"]} ${styles["amount-cell"]}`}
+                            style={{ gridColumn: "span 2" }}
+                          >
+                            {"Bs " + formatNumber(Number(ne.amount))}
+                          </div>
+                          <div
+                            className={`${styles["deuda-cell"]} ${styles["deuda-check"]}`}
+                          >
+                            <IconCheckSquare
+                              className={`${styles["check-icon"]} ${styles.selected}`}
+                            />
+                          </div>
+                          <div
+                            className={styles["deuda-cell"]}
+                            style={{ gap: 8, justifyContent: "flex-end" }}
+                          >
+                            <button
+                              type="button"
+                              data-testid="edit-new-expense"
+                              onClick={() => {
+                                setEditingExpense(ne);
+                                setShowCreateExpense(true);
+                              }}
+                              style={{
+                                background: "none",
+                                border: "1px solid var(--cWhiteV2)",
+                                color: "var(--cWhite)",
+                                padding: "4px 10px",
+                                borderRadius: 4,
+                                cursor: "pointer",
+                                fontSize: "0.8rem",
+                              }}
+                            >
+                              Editar
+                            </button>
+                            <button
+                              type="button"
+                              data-testid="remove-new-expense"
+                              onClick={() => removeNewExpense(ne.virtualId)}
+                              style={{
+                                background: "none",
+                                border: "1px solid var(--cError, #f44)",
+                                color: "var(--cError, #f44)",
+                                padding: "4px 10px",
+                                borderRadius: 4,
+                                cursor: "pointer",
+                                fontSize: "0.8rem",
+                              }}
+                            >
+                              Eliminar
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
               {isDebtBasedPayment && (
                 <div>
                   {deudasContent}
@@ -361,90 +465,6 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
                       {errors.selectedPeriodo}
                     </div>
                   )}
-                </div>
-              )}
-
-              {/* S86 inline-create-expense: lista virtual de la expensa nueva.
-                  Solo aparece si formState.newExpense está presente y type === EXPENSE.
-                  Cada item tiene botones Editar / Eliminar. */}
-              {formState.newExpense && formState.type === FormPaymentType.EXPENSE && (
-                <div
-                  data-testid="new-expense-card"
-                  className={styles["deudas-container"]}
-                  style={{ marginTop: 12, border: "1px dashed var(--cAccent, #00e38c)", borderRadius: 8, padding: 12 }}
-                >
-                  <div className={styles["deudas-title-row"]}>
-                    <p className={styles["deudas-title"]}>
-                      🆕 Expensa nueva (se creará al confirmar el pago)
-                    </p>
-                  </div>
-                  <div
-                    className={styles["deudas-table"]}
-                    style={{ borderColor: "var(--cAccent, #00e38c)" }}
-                  >
-                    <div className={styles["deuda-row"]}>
-                      <div className={styles["deuda-cell"]}>
-                        Expensa
-                      </div>
-                      <div className={styles["deuda-cell"]}>
-                        {formState.newExpense.description ||
-                          `Expensa ${MONTH_NAMES[formState.newExpense.month - 1]} ${formState.newExpense.year}`}
-                      </div>
-                      <div
-                        className={`${styles["deuda-cell"]} ${styles["amount-cell"]}`}
-                        style={{ gridColumn: "span 2" }}
-                      >
-                        {"Bs " + formatNumber(Number(formState.newExpense.amount))}
-                      </div>
-                      <div
-                        className={`${styles["deuda-cell"]} ${styles["deuda-check"]}`}
-                      >
-                        <IconCheckSquare
-                          className={`${styles["check-icon"]} ${styles.selected}`}
-                        />
-                      </div>
-                      <div
-                        className={styles["deuda-cell"]}
-                        style={{ gap: 8, justifyContent: "flex-end" }}
-                      >
-                        <button
-                          type="button"
-                          data-testid="edit-new-expense"
-                          onClick={() => {
-                            setEditingExpense(formState.newExpense ?? null);
-                            setShowCreateExpense(true);
-                          }}
-                          style={{
-                            background: "none",
-                            border: "1px solid var(--cWhiteV2)",
-                            color: "var(--cWhite)",
-                            padding: "4px 10px",
-                            borderRadius: 4,
-                            cursor: "pointer",
-                            fontSize: "0.8rem",
-                          }}
-                        >
-                          Editar
-                        </button>
-                        <button
-                          type="button"
-                          data-testid="remove-new-expense"
-                          onClick={() => removeNewExpense()}
-                          style={{
-                            background: "none",
-                            border: "1px solid var(--cError, #f44)",
-                            color: "var(--cError, #f44)",
-                            padding: "4px 10px",
-                            borderRadius: 4,
-                            cursor: "pointer",
-                            fontSize: "0.8rem",
-                          }}
-                        >
-                          Eliminar
-                        </button>
-                      </div>
-                    </div>
-                  </div>
                 </div>
               )}
 
@@ -581,7 +601,9 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
         suggestedAmount={suggestedAmount}
         editing={editingExpense}
         onConfirm={(data) =>
-          editingExpense ? updateNewExpense(data) : addNewExpense(data)
+          editingExpense
+            ? updateNewExpense(editingExpense.virtualId, data)
+            : addNewExpense(data)
         }
       />
     </>

--- a/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
+++ b/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
@@ -358,9 +358,9 @@ describe("usePaymentsForm", () => {
     expect(concept).toBe("-/-");
   });
 
-  // ============== S86 inline-create-expense (modal approach) ==============
+  // ============== S87 inline-create-expense (modal, multi) ==============
 
-  it("S86-modal: addNewExpense pinea la virtual con el monto y actualiza amount", () => {
+  it("S87-modal: addNewExpense agrega al array y actualiza amount con el total", () => {
     const props = makeExpenseProps({ amount: "100" }) as any;
     const { result } = renderHook(() => usePaymentsForm(props, true));
 
@@ -375,25 +375,41 @@ describe("usePaymentsForm", () => {
     });
 
     expect(r.ok).toBe(true);
-    expect(result.current.formState.newExpense).not.toBeNull();
-    expect(result.current.formState.newExpense?.month).toBe(8);
-    expect(result.current.formState.newExpense?.year).toBe(2026);
-    expect(result.current.formState.newExpense?.amount).toBe(1500);
-    // amount del form se auto-pinea con el monto de la virtual
+    expect(result.current.formState.newExpenses).toHaveLength(1);
+    expect(result.current.formState.newExpenses?.[0]?.month).toBe(8);
+    expect(result.current.formState.newExpenses?.[0]?.year).toBe(2026);
+    expect(result.current.formState.newExpenses?.[0]?.amount).toBe(1500);
+    // amount del form se auto-pinea con la suma de las virtuales
     expect(result.current.formState.amount).toBe("1500");
+    expect(result.current.newExpensesTotal).toBe(1500);
   });
 
-  it("S86-modal: addNewExpense rechaza duplicado contra deudas pre-existentes", async () => {
-    // Mock: adminDebts devuelve 1 deuda para julio 2026
+  it("S87-modal: addNewExpense permite N virtuales y suma al total", () => {
+    const props = makeExpenseProps() as any;
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    act(() => {
+      result.current.addNewExpense({ month: 8, year: 2026, description: "Ago", amount: 1000 });
+    });
+    act(() => {
+      result.current.addNewExpense({ month: 9, year: 2026, description: "Sep", amount: 2000 });
+    });
+    act(() => {
+      result.current.addNewExpense({ month: 10, year: 2026, description: "Oct", amount: 1500 });
+    });
+
+    expect(result.current.formState.newExpenses).toHaveLength(3);
+    expect(result.current.newExpensesTotal).toBe(4500);
+  });
+
+  it("S87-modal: addNewExpense rechaza duplicado contra deudas pre-existentes", async () => {
     const localExecute = vi.fn().mockImplementation((url: string) => {
       if (url === paymentsApi.adminDebts) {
         return Promise.resolve({
           data: {
             success: true,
             data: {
-              deudas: [
-                { id: "1", month: 7, year: 2026, amount: 1000, type: 1 },
-              ],
+              deudas: [{ id: "1", month: 7, year: 2026, amount: 1000, type: 1 }],
             },
           },
         });
@@ -404,12 +420,10 @@ describe("usePaymentsForm", () => {
     const props = makeExpenseProps({ execute: localExecute }) as any;
     const { result } = renderHook(() => usePaymentsForm(props, true));
 
-    // Esperar a que se carguen las deudas
     await waitFor(() => {
       expect(result.current.deudas).toHaveLength(1);
     });
 
-    // Intentar agregar virtual para mismo mes/año
     let r: any;
     act(() => {
       r = result.current.addNewExpense({
@@ -422,71 +436,110 @@ describe("usePaymentsForm", () => {
 
     expect(r.ok).toBe(false);
     expect(r.error).toContain("Ya existe una deuda");
-    expect(result.current.formState.newExpense).toBeNull();
+    expect(result.current.formState.newExpenses).toHaveLength(0);
   });
 
-  it("S86-modal: addNewExpense rechaza duplicado contra la virtual ya creada", () => {
+  it("S87-modal: addNewExpense rechaza duplicado entre virtuales del mismo mes/año", () => {
     const props = makeExpenseProps() as any;
     const { result } = renderHook(() => usePaymentsForm(props, true));
 
-    // Primera virtual OK
     act(() => {
-      result.current.addNewExpense({
-        month: 8,
-        year: 2026,
-        description: "Agosto",
-        amount: 1500,
-      });
+      result.current.addNewExpense({ month: 8, year: 2026, description: "Ago 1", amount: 1000 });
     });
-
-    // Segunda virtual mismo periodo → rechazado
     let r2: any;
     act(() => {
-      r2 = result.current.addNewExpense({
-        month: 8,
-        year: 2026,
-        description: "Agosto otra vez",
-        amount: 1700,
-      });
+      r2 = result.current.addNewExpense({ month: 8, year: 2026, description: "Ago 2", amount: 1500 });
     });
     expect(r2.ok).toBe(false);
     expect(r2.error).toContain("Ya creaste una expensa");
+    // Solo quedó 1 en el array
+    expect(result.current.formState.newExpenses).toHaveLength(1);
   });
 
-  it("S86-modal: removeNewExpense limpia la virtual y resetea amount", () => {
+  it("S87-modal: updateNewExpense edita por virtualId sin chocar consigo mismo", () => {
+    const props = makeExpenseProps() as any;
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    let vid: any;
+    act(() => {
+      vid = result.current.addNewExpense({
+        month: 8,
+        year: 2026,
+        description: "Original",
+        amount: 1000,
+      }).virtualId;
+    });
+
+    // Editar (mismo mes/año que la original) — NO debe rechazarse por sí misma
+    let r: any;
+    act(() => {
+      r = result.current.updateNewExpense(vid, {
+        month: 8,
+        year: 2026,
+        description: "Editado",
+        amount: 2000,
+      });
+    });
+    expect(r.ok).toBe(true);
+    expect(result.current.formState.newExpenses?.[0]?.description).toBe("Editado");
+    expect(result.current.formState.newExpenses?.[0]?.amount).toBe(2000);
+  });
+
+  it("S87-modal: updateNewExpense rechaza si choca con OTRA virtual", () => {
+    const props = makeExpenseProps() as any;
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    let vidA: any;
+    let vidB: any;
+    act(() => {
+      vidA = result.current.addNewExpense({ month: 8, year: 2026, description: "A", amount: 1000 }).virtualId;
+    });
+    act(() => {
+      vidB = result.current.addNewExpense({ month: 9, year: 2026, description: "B", amount: 2000 }).virtualId;
+    });
+
+    // Intentar mover B al periodo de A
+    let r: any;
+    act(() => {
+      r = result.current.updateNewExpense(vidB, {
+        month: 8,
+        year: 2026,
+        description: "B movida",
+        amount: 2500,
+      });
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("Ya creaste una expensa");
+  });
+
+  it("S87-modal: removeNewExpense(virtualId) quita solo ese item", () => {
+    const props = makeExpenseProps() as any;
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    let vidA: any;
+    act(() => {
+      vidA = result.current.addNewExpense({ month: 8, year: 2026, description: "A", amount: 1000 }).virtualId;
+    });
+    act(() => {
+      result.current.addNewExpense({ month: 9, year: 2026, description: "B", amount: 2000 });
+    });
+    expect(result.current.formState.newExpenses).toHaveLength(2);
+
+    act(() => {
+      result.current.removeNewExpense(vidA);
+    });
+    expect(result.current.formState.newExpenses).toHaveLength(1);
+    expect(result.current.formState.newExpenses?.[0]?.month).toBe(9);
+  });
+
+  it("S87-modal: cambiar de tipo limpia el array y amount", () => {
     const props = makeExpenseProps() as any;
     const { result } = renderHook(() => usePaymentsForm(props, true));
 
     act(() => {
-      result.current.addNewExpense({
-        month: 8,
-        year: 2026,
-        description: "",
-        amount: 1500,
-      });
+      result.current.addNewExpense({ month: 8, year: 2026, description: "", amount: 1500 });
     });
-    expect(result.current.formState.newExpense).not.toBeNull();
-
-    act(() => {
-      result.current.removeNewExpense();
-    });
-    expect(result.current.formState.newExpense).toBeNull();
-    expect(result.current.formState.amount).toBe("");
-  });
-
-  it("S86-modal: cambiar de tipo limpia la virtual y amount", () => {
-    const props = makeExpenseProps() as any;
-    const { result } = renderHook(() => usePaymentsForm(props, true));
-
-    act(() => {
-      result.current.addNewExpense({
-        month: 8,
-        year: 2026,
-        description: "",
-        amount: 1500,
-      });
-    });
-    expect(result.current.formState.newExpense).not.toBeNull();
+    expect(result.current.formState.newExpenses).toHaveLength(1);
 
     act(() => {
       result.current.handleChangeInput({
@@ -494,20 +547,37 @@ describe("usePaymentsForm", () => {
       } as any);
     });
 
-    expect(result.current.formState.newExpense).toBeNull();
+    expect(result.current.formState.newExpenses).toHaveLength(0);
     expect(result.current.formState.amount).toBe("");
   });
 
-  it("S86-modal: submit con virtual pinea create_expense + expense_data correctos", async () => {
+  it("S87-modal: cambiar de dpto limpia el array y amount", () => {
+    const props = makeExpenseProps() as any;
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    act(() => {
+      result.current.addNewExpense({ month: 8, year: 2026, description: "", amount: 1500 });
+    });
+    expect(result.current.formState.newExpenses).toHaveLength(1);
+
+    act(() => {
+      result.current.handleChangeInput({
+        target: { name: "dpto_id", value: "202", type: "text" },
+      } as any);
+    });
+
+    expect(result.current.formState.newExpenses).toHaveLength(0);
+    expect(result.current.formState.amount).toBe("");
+  });
+
+  it("S87-modal: submit con array de 2 virtuales pinea create_expenses: [] con 2 items", async () => {
     const localExecute = vi
       .fn()
       .mockImplementation((url: string) => {
         if (url === paymentsApi.adminDebts) {
-          return Promise.resolve({
-            data: { success: true, data: { deudas: [] } },
-          });
+          return Promise.resolve({ data: { success: true, data: { deudas: [] } } });
         }
-        return Promise.resolve({ data: { success: true, data: "payment-s86" } });
+        return Promise.resolve({ data: { success: true, data: "payment-s87" } });
       });
 
     const props = {
@@ -534,17 +604,23 @@ describe("usePaymentsForm", () => {
     const { result } = renderHook(() => usePaymentsForm(props, true));
 
     await waitFor(() => {
-      // deudas cargadas (vacías)
       expect(result.current.deudas).toHaveLength(0);
     });
 
-    // Crear la virtual
     act(() => {
       result.current.addNewExpense({
         month: 8,
         year: 2026,
-        description: "Pago adelantado Agosto",
+        description: "Agosto",
         amount: 1500,
+      });
+    });
+    act(() => {
+      result.current.addNewExpense({
+        month: 9,
+        year: 2026,
+        description: "Septiembre",
+        amount: 1000,
       });
     });
 
@@ -556,20 +632,23 @@ describe("usePaymentsForm", () => {
     expect(createCall).toBeDefined();
     const payload = createCall![2];
 
-    expect(payload.create_expense).toBe(true);
-    expect(payload.expense_data).toBeDefined();
-    expect(payload.expense_data.month).toBe(8);
-    expect(payload.expense_data.year).toBe(2026);
-    expect(payload.expense_data.description).toBe("Pago adelantado Agosto");
-    expect(payload.expense_data.amount).toBe(1500);
-    expect(payload.expense_data.due_at).toBe("2026-08-31");
-    expect(payload.expense_data.subcategory_id).toBe(100);
+    // S87: array de expensas
+    expect(payload.create_expenses).toHaveLength(2);
+    expect(payload.create_expenses[0].month).toBe(8);
+    expect(payload.create_expenses[0].year).toBe(2026);
+    expect(payload.create_expenses[0].amount).toBe(1500);
+    expect(payload.create_expenses[0].due_at).toBe("2026-08-31");
+    expect(payload.create_expenses[0].subcategory_id).toBe(100);
+    expect(payload.create_expenses[1].month).toBe(9);
+    expect(payload.create_expenses[1].amount).toBe(1000);
+    expect(payload.create_expenses[1].due_at).toBe("2026-09-30");
     expect(payload.debt_dpto_ids).toEqual([]);
-    expect(payload.amount).toBe(1500);
+    // amount total = 1500 + 1000
+    expect(payload.amount).toBe(2500);
     expect(payload.bank_account_id).toBe(7);
   });
 
-  it("S86-modal: validación rechaza month/year/amount inválido en addNewExpense", () => {
+  it("S87-modal: validación rechaza month/year/amount inválido en addNewExpense", () => {
     const props = makeExpenseProps() as any;
     const { result } = renderHook(() => usePaymentsForm(props, true));
 

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -11,6 +11,12 @@ export interface Dpto {
   id: string | number;
   nro: string;
   description: string;
+  /**
+   * S87: monto "normal" de expensas para esta unidad (SSoT del back en
+   * `dptos.expense_amount`). Si está presente, se usa como pre-carga del
+   * modal de crear expensa. Si no, cae a la heurística del front.
+   */
+  expense_amount?: number | string | null;
   holder?: "H" | "T";
   homeowner?: any;
   tenant?: any;
@@ -190,11 +196,12 @@ export interface FormState {
   type?: FormPaymentType;
   owner_id?: string | number;
   /**
-   * Expensa virtual creada en memoria desde el modal. Una sola por form.
-   * Si está presente, se suma al monto total y al submit se manda como
-   * `create_expense: true` + `expense_data` (S86).
+   * Lista de expensas virtuales creadas en memoria desde el modal (S87 multi).
+   * Cada item tiene un virtualId único. Se suman al monto total y al submit
+   * se mandan como `create_expenses: [{...expense_data}, ...]` (S87).
+   * El backend las crea en la misma transacción que el pago.
    */
-  newExpense?: NewExpense | null;
+  newExpenses?: NewExpense[];
 }
 
 export interface Errors {
@@ -262,7 +269,7 @@ export const usePaymentsForm = (
       obs: item?.obs || "",
       amount: item?.amount || "",
       owner_id: item?.owner_id || "",
-      newExpense: null,
+      newExpenses: [],
     };
   });
 
@@ -284,11 +291,17 @@ export const usePaymentsForm = (
   const isDebtBasedPayment = Boolean(formState.type && formState.type !== FormPaymentType.DIRECT);
 
   const isExpensasWithoutDebt = useMemo(() => {
-    // S86 inline-create-expense (modal): si hay una expensa virtual en memoria,
-    // vamos a crearla en el submit, así que "no hay deudas" ya no es un error.
-    if (formState.newExpense) return false;
+    // S87 inline-create-expense (modal): si hay expensas virtuales en memoria,
+    // vamos a crearlas en el submit, así que "no hay deudas" ya no es un error.
+    if ((formState.newExpenses?.length ?? 0) > 0) return false;
     return formState.type === FormPaymentType.EXPENSE && deudas.length === 0 && !isLoadingDeudas;
-  }, [formState.type, formState.newExpense, deudas.length, isLoadingDeudas]);
+  }, [formState.type, formState.newExpenses, deudas.length, isLoadingDeudas]);
+
+  // S87: suma de los montos de las expensas virtuales. El front lo usa para
+  // mostrar el "Total a pagar" = periodoTotal + newExpensesTotal.
+  const newExpensesTotal = useMemo(() => {
+    return (formState.newExpenses || []).reduce((sum, e) => sum + Number(e.amount || 0), 0);
+  }, [formState.newExpenses]);
 
   const isReservationsWithoutDebt = useMemo(() => {
     return formState.type === FormPaymentType.RESERVATION && deudas.length === 0 && !isLoadingDeudas;
@@ -307,6 +320,10 @@ export const usePaymentsForm = (
           id: dpto.nro,
           name,
           dpto_id: dpto.id,
+          // S87: monto "normal" de expensas (SSoT del back, dptos.expense_amount).
+          // Lo pineamos al lDptos para que el modal de crear expensa pueda
+          // pre-cargar con el monto real de la unidad.
+          expense_amount: dpto.expense_amount,
         };
       }) || [],
     [extraData?.dptos, store.Unitstype]
@@ -648,8 +665,8 @@ export const usePaymentsForm = (
           category_id: "",
           subcategory_id: "",
           subcategories: [],
-          // Cambio de tipo → reset de la expensa virtual y del amount.
-          newExpense: null,
+          // Cambio de tipo → reset de las expensas virtuales y del amount.
+          newExpenses: [],
           amount: "",
         }));
         setDeudas([]);
@@ -668,12 +685,12 @@ export const usePaymentsForm = (
           }, 0);
         }
       } else if (name === "dpto_id") {
-        // Cambio de unidad → la expensa virtual ya no aplica (estaba asociada
-        // al dpto anterior). Reset.
+        // Cambio de unidad → las expensas virtuales ya no aplican (estaban
+        // asociadas al dpto anterior). Reset.
         setFormState((prev: FormState) => ({
           ...prev,
           dpto_id: newValue,
-          newExpense: null,
+          newExpenses: [],
           amount: "",
         }));
         setSelectedPeriodo([]);
@@ -746,10 +763,10 @@ export const usePaymentsForm = (
 
   const runSimulate = useCallback(async () => {
     if (!isDebtBasedPayment || !formState.amount || selectedPeriodo.length === 0) return;
-    // S86 inline-create-expense (modal): si la deuda todavía no existe (newExpense
-    // virtual presente), no hay nada que simular — el backend la crea con el
-    // monto que mandemos y la cascade la paga en la misma transacción.
-    if (formState.newExpense) return;
+    // S87 inline-create-expense (modal): si hay deudas virtuales (aún no
+    // existen en el back), no hay nada que simular — el backend las crea con
+    // los montos que mandemos y la cascade las paga en la misma transacción.
+    if ((formState.newExpenses?.length ?? 0) > 0) return;
 
     setIsSimulating(true);
     try {
@@ -778,19 +795,19 @@ export const usePaymentsForm = (
     } finally {
       setIsSimulating(false);
     }
-  }, [isDebtBasedPayment, formState.amount, formState.newExpense, selectedPeriodo, execute]);
+  }, [isDebtBasedPayment, formState.amount, formState.newExpenses, selectedPeriodo, execute]);
 
   const handleAmountBlur = useCallback(() => {
     runSimulate();
   }, [runSimulate]);
 
   /**
-   * Agrega una expensa virtual en memoria (S86 inline-create-expense via modal).
-   * Valida que no exista ya una deuda pre-existente para (month, year) en el
-   * `deudas` state (que viene de adminDebts). Devuelve { ok, error? }.
+   * S87: agrega una expensa virtual al array (multi). Valida que no exista
+   * ya una deuda pre-existente para (month, year) en el `deudas` state, ni
+   * otra virtual con el mismo (month, year). Devuelve { ok, error?, virtualId? }.
    */
   const addNewExpense = useCallback(
-    (data: { month: number; year: number; description: string; amount: number }): { ok: boolean; error?: string } => {
+    (data: { month: number; year: number; description: string; amount: number }): { ok: boolean; error?: string; virtualId?: string } => {
       const month = Number(data.month);
       const year = Number(data.year);
       const amount = Number(data.amount);
@@ -816,56 +833,98 @@ export const usePaymentsForm = (
         };
       }
 
-      // Check de duplicado contra la expensa virtual ya existente.
-      if (formState.newExpense) {
-        if (
-          Number(formState.newExpense.month) === month &&
-          Number(formState.newExpense.year) === year
-        ) {
-          return {
-            ok: false,
-            error: `Ya creaste una expensa para ${month}/${year} en este formulario.`,
-          };
-        }
+      // Check de duplicado contra las virtuales ya existentes.
+      const conflictVirtual = (formState.newExpenses || []).find(
+        (e) => Number(e.month) === month && Number(e.year) === year
+      );
+      if (conflictVirtual) {
+        return {
+          ok: false,
+          error: `Ya creaste una expensa para ${month}/${year} en este formulario.`,
+        };
       }
 
-      setFormState((prev: FormState) => ({
-        ...prev,
-        newExpense: {
-          virtualId: `__new_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-          month,
-          year,
-          description: (data.description || "").trim(),
-          amount,
-        },
-        // Auto-pinear el monto del pago con el de la expensa virtual.
-        amount: String(amount),
-      }));
-      return { ok: true };
+      const virtualId = `__new_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const newExpense: NewExpense = {
+        virtualId,
+        month,
+        year,
+        description: (data.description || "").trim(),
+        amount,
+      };
+
+      setFormState((prev: FormState) => {
+        const next = [...(prev.newExpenses || []), newExpense];
+        // Auto-pinear el monto del pago con la suma de todas las virtuales.
+        // El admin puede editar el amount después si quiere (ej: pagar menos
+        // que la suma → pago parcial).
+        return {
+          ...prev,
+          newExpenses: next,
+          amount: String(next.reduce((s, e) => s + e.amount, 0)),
+        };
+      });
+      return { ok: true, virtualId };
     },
-    [deudas, formState.newExpense]
+    [deudas, formState.newExpenses]
   );
 
   /**
-   * Edita la expensa virtual existente. Mismas validaciones que addNewExpense.
-   * Si la expensa virtual ya tenía un (month, year), permitimos "modificarla"
-   * en el modal y re-validamos contra deudas pre-existentes.
+   * S87: edita una expensa virtual por virtualId. Mismas validaciones que
+   * addNewExpense (excluyendo la misma virtual del check de duplicado).
    */
   const updateNewExpense = useCallback(
-    (data: { month: number; year: number; description: string; amount: number }): { ok: boolean; error?: string } => {
-      // Reutilizamos addNewExpense: si el (month, year) no cambió, no hay
-      // conflicto con la expensa virtual misma. Si cambió, validamos igual.
-      return addNewExpense(data);
+    (virtualId: string, data: { month: number; year: number; description: string; amount: number }): { ok: boolean; error?: string } => {
+      const month = Number(data.month);
+      const year = Number(data.year);
+      const amount = Number(data.amount);
+
+      if (!month || month < 1 || month > 12) {
+        return { ok: false, error: "Mes inválido (1-12)" };
+      }
+      if (!year || year < 2000 || year > 2100) {
+        return { ok: false, error: "Año inválido" };
+      }
+      if (!amount || amount <= 0) {
+        return { ok: false, error: "El monto debe ser mayor a cero" };
+      }
+
+      // Check de duplicado contra deudas pre-existentes.
+      const conflict = deudas.find(
+        (d) => Number(d.month) === month && Number(d.year) === year
+      );
+      if (conflict) {
+        return { ok: false, error: `Ya existe una deuda para ${month}/${year} en esta unidad.` };
+      }
+
+      // Check de duplicado contra OTRAS virtuales (excluyendo esta misma).
+      const conflictVirtual = (formState.newExpenses || []).find(
+        (e) => e.virtualId !== virtualId && Number(e.month) === month && Number(e.year) === year
+      );
+      if (conflictVirtual) {
+        return { ok: false, error: `Ya creaste una expensa para ${month}/${year} en este formulario.` };
+      }
+
+      setFormState((prev: FormState) => {
+        const next = (prev.newExpenses || []).map((e) =>
+          e.virtualId === virtualId
+            ? { ...e, month, year, description: (data.description || "").trim(), amount }
+            : e
+        );
+        return { ...prev, newExpenses: next };
+      });
+      return { ok: true };
     },
-    [addNewExpense]
+    [deudas, formState.newExpenses]
   );
 
-  const removeNewExpense = useCallback(() => {
+  /**
+   * S87: quita una expensa virtual del array por virtualId.
+   */
+  const removeNewExpense = useCallback((virtualId: string) => {
     setFormState((prev: FormState) => ({
       ...prev,
-      newExpense: null,
-      // Si el monto coincide con la virtual, lo limpiamos también.
-      amount: "",
+      newExpenses: (prev.newExpenses || []).filter((e) => e.virtualId !== virtualId),
     }));
     setSimulateResult(null);
     setSimulateError(null);
@@ -889,10 +948,10 @@ export const usePaymentsForm = (
       isDebtBasedPayment &&
       deudas?.length > 0 &&
       selectedPeriodo.length === 0 &&
-      !formState.newExpense
+      (formState.newExpenses?.length ?? 0) === 0
     ) {
-      // S86: si newExpense está presente, la deuda virtual se crea en el
-      // submit; selectedPeriodo queda vacío intencionalmente.
+      // S87: si newExpenses tiene items, las deudas virtuales se crean en
+      // el submit; selectedPeriodo queda vacío intencionalmente.
       err.selectedPeriodo = "Debe seleccionar al menos una deuda para pagar";
     }
 
@@ -1022,12 +1081,12 @@ export const usePaymentsForm = (
     const selectedDpto = findSelectedDpto(formState.dpto_id || "");
     const dptoId = Number(selectedDpto?.id || formState.dpto_id);
 
-    // S86 inline-create-expense (modal): si hay una expensa virtual, dejamos
-    // debt_dpto_ids vacío y pineamos create_expense + expense_data. El backend
-    // crea la DebtDpto dentro de la misma transacción que el pago.
-    const hasNewExpense = Boolean(
-      formState.newExpense && formState.type === FormPaymentType.EXPENSE
-    );
+    // S87 inline-create-expense (modal): si hay expensas virtuales, dejamos
+    // debt_dpto_ids vacío y pineamos create_expenses: []. El backend crea
+    // cada DebtDpto dentro de la misma transacción que el pago. Soporta N
+    // expensas en un solo POST.
+    const newExpensesList = formState.newExpenses || [];
+    const hasNewExpense = newExpensesList.length > 0 && formState.type === FormPaymentType.EXPENSE;
 
     const params: any = {
       dpto_id: dptoId,
@@ -1049,26 +1108,22 @@ export const usePaymentsForm = (
       url_file: formState.url_file || [],
     };
 
-    if (hasNewExpense && formState.newExpense) {
-      const ne = formState.newExpense;
-      // due_at: último día del mes pineado. Convención consistente con el
-      // formato Y-m-d que espera el backend.
-      const lastDay = new Date(ne.year, ne.month, 0).getDate();
-      const dueAt = `${ne.year}-${String(ne.month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
-
-      params.create_expense = true;
-      params.expense_data = {
-        dpto_id: dptoId,
-        amount: Number(ne.amount),
-        due_at: dueAt,
-        description: ne.description || "",
-        month: ne.month,
-        year: ne.year,
-        // pinear la subcategoría "expensas" del cliente si está disponible,
-        // para mantener la consistencia con el resto del módulo que usa
-        // client_config.cat_expensas como SSoT.
-        subcategory_id: extraData?.client_config?.cat_expensas ?? null,
-      };
+    if (hasNewExpense) {
+      // S87: array de expensas. due_at = último día del mes pineado.
+      params.create_expenses = newExpensesList.map((ne) => {
+        const lastDay = new Date(ne.year, ne.month, 0).getDate();
+        const dueAt = `${ne.year}-${String(ne.month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+        return {
+          dpto_id: dptoId,
+          amount: Number(ne.amount),
+          due_at: dueAt,
+          description: ne.description || "",
+          month: ne.month,
+          year: ne.year,
+          // SSoT: subcategoría "expensas" del cliente (igual que DIRECT).
+          subcategory_id: extraData?.client_config?.cat_expensas ?? null,
+        };
+      });
     }
 
     isSubmittingRef.current = true;
@@ -1156,5 +1211,6 @@ export const usePaymentsForm = (
     addNewExpense,
     updateNewExpense,
     removeNewExpense,
+    newExpensesTotal,
   };
 };


### PR DESCRIPTION
## Summary
Soporte para crear **N expensas virtuales** en el mismo form de pago (antes solo 1). Cambia de single (`newExpense: NewExpense | null`) a array (`newExpenses: NewExpense[]`).

## Cambios funcionales
- `FormState.newExpenses: NewExpense[]` (antes `newExpense: NewExpense | null`).
- `addNewExpense` → push al array con validación de duplicado contra deudas pre-existentes (adminDebts) y entre virtuales del mismo `(month, year)`.
- `updateNewExpense(virtualId, data)` → edita por id, permite editar sin chocar consigo mismo.
- `removeNewExpense(virtualId)` → quita por id.
- `isExpensasWithoutDebt`, `validar()`, `runSimulate` → skipean si hay virtuales.
- `_onSavePago` → pinea `create_expenses: [N items]` en el body (S87 back). `debt_dpto_ids` queda `[]` cuando hay virtuales.
- `newExpensesTotal` → derivado expuesto al front, suma de los montos.
- `suggestedAmount` → lee `dptos.expense_amount` (SSoT del back, pineado desde S87) del `lDptos`. Si no está, cae a la heurística del front.

## Cambios de UI
- **Lista virtual ARRIBA** del `deudasContent` (antes estaba abajo, después del total).
- Renderiza N cards, una por virtual, con Editar/Eliminar por card.
- El título muestra el conteo (`"Expensa nueva"` vs `"Expensas nuevas (3, ...)"`).
- El botón `+ Crear expensa nueva` **siempre visible** (antes se ocultaba cuando había 1 virtual). El admin puede crear varias.
- El `Total a pagar` muestra `periodoTotal + newExpensesTotal`.

## Archivos tocados (3)
- `src/modulos/Payments/hooks/usePaymentsForm.ts` — lógica
- `src/modulos/Payments/RenderForm/RenderForm.tsx` — UI
- `src/modulos/Payments/__tests__/usePaymentsForm.test.ts` — 11 tests nuevos

## Back (en dev, ya mergeado)
El back ya pineá `create_expenses: []` (S87) y el endpoint `GET /api/v3/payments/admin/has-expense` (commit `be94c51c` en `dev` directo, según instrucción de Mario). Este PR no toca el back.

## Verificación
- ✅ Tests del módulo Payments: **34/34 verde** (23 previos + 11 nuevos).
- ✅ `tsc --noEmit`: 0 errores en los 3 archivos modificados.
- ✅ Hook pre-commit: PASS.

## Caveat
- Este PR abre un único PR al admin, pero el back ya está mergeado a `dev` (commit `be94c51c`). Si mergeás este PR antes de que el back esté en prod, el front pineá `create_expenses: []` y el server va a tirar 500 hasta que el deploy del back llegue. Coordinar el deploy del back antes o en el mismo cambio que este PR.
