### PR TITLE
feat(payments): simulate con create_expenses (pago parcial de virtuales)

### DIFF
--- a/src/modulos/Payments/RenderForm/RenderForm.tsx
+++ b/src/modulos/Payments/RenderForm/RenderForm.tsx
@@ -578,7 +578,7 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
                 <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                   <thead>
                     <tr>
-                      <th style={{ textAlign: "left", padding: "4px 8px" }}>Deuda ID</th>
+                      <th style={{ textAlign: "left", padding: "4px 8px" }}>Deuda</th>
                       <th style={{ textAlign: "right", padding: "4px 8px" }}>Monto aplicado</th>
                       <th style={{ textAlign: "right", padding: "4px 8px" }}>Balance antes</th>
                       <th style={{ textAlign: "right", padding: "4px 8px" }}>Balance después</th>
@@ -586,19 +586,48 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
                     </tr>
                   </thead>
                   <tbody>
-                    {(simulateResult.items || []).map((item: any, idx: number) => (
-                      <tr key={idx}>
-                        <td style={{ padding: "4px 8px" }}>{item.debt_dpto_id}</td>
-                        <td style={{ textAlign: "right", padding: "4px 8px" }}>{item.applied_amount}</td>
-                        <td style={{ textAlign: "right", padding: "4px 8px" }}>{item.balance_before}</td>
-                        <td style={{ textAlign: "right", padding: "4px 8px" }}>{item.balance_after}</td>
-                        <td style={{ textAlign: "center", padding: "4px 8px" }}>{item.excluded ? "Sí" : "No"}</td>
-                      </tr>
-                    ))}
+                    {(simulateResult.items || []).map((item: any, idx: number) => {
+                      // S87: el back pineá ids negativos (-1, -2, ...) para
+                      // las virtuales. Mostramos el label legible (Mes Año +
+                      // descripción) cuando es virtual.
+                      const isVirtual = Number(item.debt_dpto_id) < 0;
+                      const virtual = isVirtual
+                        ? (formState.newExpenses || [])[
+                            Math.abs(Number(item.debt_dpto_id)) - 1
+                          ]
+                        : null;
+                      const label = virtual
+                        ? `${MONTH_NAMES[virtual.month - 1]} ${virtual.year}` +
+                          (virtual.description
+                            ? ` — ${virtual.description}`
+                            : "")
+                        : `#${item.debt_dpto_id}`;
+                      return (
+                        <tr key={idx}>
+                          <td style={{ padding: "4px 8px" }}>
+                            {virtual ? `🆕 ${label}` : label}
+                          </td>
+                          <td style={{ textAlign: "right", padding: "4px 8px" }}>{item.applied_amount}</td>
+                          <td style={{ textAlign: "right", padding: "4px 8px" }}>{item.balance_before}</td>
+                          <td style={{ textAlign: "right", padding: "4px 8px" }}>{item.balance_after}</td>
+                          <td style={{ textAlign: "center", padding: "4px 8px" }}>
+                            {item.excluded ? (
+                              <span style={{ color: "var(--cError, #f44)", fontWeight: "bold" }}>
+                                Sí (no se paga)
+                              </span>
+                            ) : (
+                              "No"
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
                 <p style={{ marginTop: 8, fontSize: 13 }}>
-                  Al confirmar, se aplicará el pago parcial según la distribución mostrada.
+                  Al confirmar, se aplicará el pago parcial según la distribución
+                  mostrada. Las filas con <b>🆕</b> son expensas virtuales nuevas;
+                  las marcadas como <b>Sí (no se paga)</b> quedan pendientes.
                 </p>
               </div>
             </div>

--- a/src/modulos/Payments/__tests__/RenderForm.test.tsx
+++ b/src/modulos/Payments/__tests__/RenderForm.test.tsx
@@ -99,7 +99,7 @@ describe("RenderForm Component", () => {
     };
     render(<RenderForm {...defaultProps} />);
     expect(screen.getByText("Pago parcial detectado")).toBeInTheDocument();
-    expect(screen.getByText("Deuda ID")).toBeInTheDocument();
+    expect(screen.getByText("Deuda")).toBeInTheDocument();
     expect(screen.getByText("Monto aplicado")).toBeInTheDocument();
   });
 });

--- a/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
+++ b/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
@@ -217,6 +217,81 @@ describe("usePaymentsForm", () => {
     });
   });
 
+  // ============== S87: simulate con create_expenses ==============
+
+  it("S87-simulate: con virtuales pinea create_expenses al simulate", async () => {
+    const localExecute = makeSimulateExecute({
+      is_overpayment: false,
+      payment_is_partial: true,
+      items: [
+        { debt_dpto_id: 1, applied_amount: 800, balance_before: 1000, balance_after: 200, excluded: false },
+        { debt_dpto_id: -1, applied_amount: 0, balance_before: 500, balance_after: 500, excluded: true },
+      ],
+    });
+    const props = makeExpenseProps({ execute: localExecute }) as any;
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    // Crear 2 virtuales: 1000 + 500 = 1500. El admin paga 800.
+    act(() => {
+      result.current.addNewExpense({ month: 8, year: 2026, description: "Ago", amount: 1000 });
+    });
+    act(() => {
+      result.current.addNewExpense({ month: 9, year: 2026, description: "Sep", amount: 500 });
+    });
+
+    await act(async () => {
+      result.current.handleChangeInput({ target: { name: "amount", value: "800", type: "text" } } as any);
+    });
+    await act(async () => {
+      await result.current.handleAmountBlur();
+    });
+
+    const simulateCall = localExecute.mock.calls.find((c: any[]) => c[0] === paymentsApi.simulate);
+    expect(simulateCall).toBeDefined();
+    const body = simulateCall![2];
+
+    // S87: el body lleva create_expenses con 2 items
+    expect(body.create_expenses).toHaveLength(2);
+    expect(body.create_expenses[0].amount).toBe(1000);
+    expect(body.create_expenses[0].month).toBe(8);
+    expect(body.create_expenses[0].due_at).toBe("2026-08-31");
+    expect(body.create_expenses[1].amount).toBe(500);
+    expect(body.create_expenses[1].due_at).toBe("2026-09-30");
+    expect(body.debt_dpto_ids).toEqual([]);
+    expect(body.amount).toBe(800);
+
+    // simulateResult guardado
+    await waitFor(() => {
+      expect(result.current.simulateResult?.payment_is_partial).toBe(true);
+      expect(result.current.simulateResult?.items).toHaveLength(2);
+    });
+  });
+
+  it("S87-simulate: is_overpayment con virtuales setea simulateError", async () => {
+    const localExecute = makeSimulateExecute({
+      is_overpayment: true,
+      payment_is_partial: false,
+      items: [],
+    });
+    const props = makeExpenseProps({ execute: localExecute }) as any;
+    const { result } = renderHook(() => usePaymentsForm(props, true));
+
+    act(() => {
+      result.current.addNewExpense({ month: 8, year: 2026, description: "Ago", amount: 1000 });
+    });
+    await act(async () => {
+      result.current.handleChangeInput({ target: { name: "amount", value: "9999", type: "text" } } as any);
+    });
+    await act(async () => {
+      await result.current.handleAmountBlur();
+    });
+
+    await waitFor(() => {
+      expect(result.current.simulateError).toBe("El monto supera la deuda total");
+      expect(result.current.isSubmitDisabled).toBe(true);
+    });
+  });
+
   it("submit: llama paymentsApi.create con payload unificado", async () => {
     const localExecute = vi.fn().mockResolvedValue({ data: { success: true } });
 

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -762,21 +762,41 @@ export const usePaymentsForm = (
   }, [getSubtotal]);
 
   const runSimulate = useCallback(async () => {
-    if (!isDebtBasedPayment || !formState.amount || selectedPeriodo.length === 0) return;
-    // S87 inline-create-expense (modal): si hay deudas virtuales (aún no
-    // existen en el back), no hay nada que simular — el backend las crea con
-    // los montos que mandemos y la cascade las paga en la misma transacción.
-    if ((formState.newExpenses?.length ?? 0) > 0) return;
+    // S87: el simulate corre también cuando hay virtuales (multi-expense
+    // flow). El backend ahora acepta `create_expenses: []` y devuelve la
+    // distribución completa (incluyendo qué virtuales quedan sin pagar si
+    // el monto es insuficiente).
+    if (!isDebtBasedPayment || !formState.amount) return;
+    if (selectedPeriodo.length === 0 && (formState.newExpenses?.length ?? 0) === 0) return;
 
     setIsSimulating(true);
     try {
+      const body: any = {
+        amount: parseFloat(String(formState.amount)),
+        debt_dpto_ids: selectedPeriodo.map((p) => Number(p.id)),
+      };
+      // S87: si hay virtuales, pineamos create_expenses para que el
+      // simulate las incluya en la cascada.
+      const newExpensesList = formState.newExpenses || [];
+      if (newExpensesList.length > 0) {
+        body.create_expenses = newExpensesList.map((ne) => {
+          const lastDay = new Date(ne.year, ne.month, 0).getDate();
+          const dueAt = `${ne.year}-${String(ne.month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+          return {
+            dpto_id: formState.dpto_id,
+            amount: Number(ne.amount),
+            due_at: dueAt,
+            description: ne.description || "",
+            month: ne.month,
+            year: ne.year,
+            subcategory_id: extraData?.client_config?.cat_expensas ?? null,
+          };
+        });
+      }
       const { data } = await execute(
         paymentsApi.simulate,
         "POST",
-        {
-          amount: parseFloat(String(formState.amount)),
-          debt_dpto_ids: selectedPeriodo.map((p) => Number(p.id)),
-        },
+        body,
         false,
         true
       );


### PR DESCRIPTION
## Summary
Cuando el admin agrega expensas virtuales futuras y el monto del ingreso es menor al total, el sistema ahora **detecta pago parcial** y **muestra cómo se distribuirán los pagos** + qué expensas no se pagarán.

## Cambios

### Back (commit `eb67c696` en `dev`, directo sin PR)
- `SimulatePaymentDTO` acepta `expensesData: array` (mismo shape que `CreatePaymentDTO`).
- `PaymentsService::simulatePayment` construye instancias NO persistidas de `DebtDpto` para las virtuales (id negativo, status PENDING, remaining_amount = amount) y las pasa al `distributionService` junto con las deudas pre-existentes. La cascada las incluye naturalmente.
- 3 tests nuevos: pago parcial, full payment, overpayment flagged. **203/203 verde** en `app/Modules/Payments/Tests/`.

### Front (este PR)
- `usePaymentsForm.runSimulate`: ya NO skipea cuando hay `newExpenses`. Pinea `create_expenses: []` al body del simulate con la misma shape que en `createPayment`.
- `RenderForm`: la tabla de "Pago parcial detectado" ahora muestra label legible para las virtuales (`Agosto 2026 — descripción` con emoji 🆕) en vez del id negativo crudo. Las excluidas se marcan como "Sí (no se paga)" en `cError`.
- Cambia el header de la tabla de "Deuda ID" a "Deuda" (más amplio).
- 2 tests nuevos + 1 test actualizado (label del header). **37/37 verde**.

## Archivos tocados (4)
- `src/modulos/Payments/hooks/usePaymentsForm.ts` — `runSimulate` pinea `create_expenses` cuando hay virtuales.
- `src/modulos/Payments/RenderForm/RenderForm.tsx` — tabla con label legible de virtuales.
- `src/modulos/Payments/__tests__/usePaymentsForm.test.ts` — 2 tests nuevos.
- `src/modulos/Payments/__tests__/RenderForm.test.tsx` — label del header actualizado.

## Verificación
- ✅ Tests del módulo Payments: **37/37 verde** (35 previos + 2 nuevos).
- ✅ `tsc --noEmit`: 0 errores en los 4 archivos modificados.
- ✅ Hook pre-commit del repo: PASS.

## Caveat
- El back ya está mergeado a `dev` (commit `eb67c696`). Si mergeás este PR antes del deploy del back, vas a tirar 500 en el simulate (el endpoint pineado pineá `create_expenses` y el controller no lo va a reconocer). Coordiná el deploy del back antes o junto con este PR.
