### PR TITLE
fix(condominios): mapear el estado por el enum numerico, no por el char (CDT-26)

### DIFF
--- a/src/modulos/Condominios/Condominios.tsx
+++ b/src/modulos/Condominios/Condominios.tsx
@@ -33,13 +33,31 @@ const mod: ModCrudType = {
   },
   renderForm: (props: any) => <RenderForm {...props} />,
 };
+/**
+ * CDT-26: keyed by the numeric ClientStatus enum, not the legacy 'A'/'I' chars.
+ *
+ * `clients.status` became TINYINT UNSIGNED on 2026-07-18
+ * (migration `migrate_clients_status_to_numeric`), so a char-keyed map returned
+ * `undefined` and the list fell back to printing the raw value ("1").
+ *
+ * This map feeds two surfaces: the badge in the list AND the "Filtrar por
+ * estado" dropdown, whose option ids come from `Object.keys` below. With char
+ * keys the filter silently sent 'A'/'I' and matched no rows without erroring.
+ */
 const statusCondominios: Record<
-  string,
+  number,
   { text: string; bgColor: string; color: string }
 > = {
-  A: { text: "Activo", bgColor: "#15392B", color: "var(--cAccent)" },
-  I: { text: "Inactivo", bgColor: "#3A2121", color: "var(--cError)" },
-  // S: { text: "Suspendido", bgColor: "#3B351E", color: "var(--cWarning)" },
+  [ClientStatus.ACTIVE]: {
+    text: "Activo",
+    bgColor: "#15392B",
+    color: "var(--cAccent)",
+  },
+  [ClientStatus.INACTIVE]: {
+    text: "Inactivo",
+    bgColor: "#3A2121",
+    color: "var(--cError)",
+  },
 };
 const privacyCondominios: Record<string, string> = {
   T: "Prueba",
@@ -84,9 +102,9 @@ const Condominios = () => {
           width: "180px",
           options: () => [
             { id: "ALL", name: "Todos" },
-            ...Object.keys(statusCondominios).map((key) => ({
-              id: key,
-              name: statusCondominios[key]?.text || key,
+            ...Object.entries(statusCondominios).map(([value, cfg]) => ({
+              id: Number(value),
+              name: cfg.text,
             })),
           ],
         },


### PR DESCRIPTION
## Qué reportó el tester

CDT-26 — la columna **Estado** del listado de Condominios muestra `1` en vez de la etiqueta.

## Causa

`clients.status` pasó a `TINYINT UNSIGNED` el 2026-07-18 (migración `migrate_clients_status_to_numeric`, `'A'` → `1`). El front seguía indexando `statusCondominios` con claves `'A'`/`'I'`, el lookup devolvía `undefined`, y el render caía al fallback `|| item?.status`.

## Qué cambia

- `statusCondominios` se indexa con `ClientStatus.ACTIVE` / `ClientStatus.INACTIVE` — el enum numérico que este mismo archivo **ya importaba** y usaba en `onHideActions`.
- El filtro **"Filtrar por estado"** arma sus opciones desde las claves de ese mismo mapa, así que le mandaba `'A'`/`'I'` a un `WHERE` contra una columna numérica: **no devolvía filas y no mostraba error**. El tester no lo reportó porque no da error. Se migra a `Object.entries` para que el id de cada opción sea el número.
- Se elimina la entrada comentada `S: Suspendido`, que referenciaba un código de letra que ya no existe en la columna.

## Verificación

| Chequeo | Resultado |
|---|---|
| `tsc --noEmit` en la rama | 29 errores |
| `tsc --noEmit` en `dev` | 29 errores (los mismos, todos en `src/mk/hooks/useAsyncExport/__tests__/`) |
| Errores bajo `src/modulos/Condominios/` | 0 |
| `eslint` del archivo tocado | 0 errores, 9 warnings preexistentes |

Contra la base de datos:

```
SELECT status, privacy, COUNT(*) FROM clients GROUP BY status, privacy
  status=1  privacy='P'  ->  34 filas
  status=1  privacy='T'  ->   3 filas
COLUMN_TYPE de clients.status: tinyint(3) unsigned
```

Los **37 condominios** pasan a mostrar "Activo".

## Sobre el título del ticket

El ticket dice que faltan **"Público"** y **"Prueba"**, pero esas dos son las etiquetas de la columna **Privacidad**, no de Estado. `clients.privacy` sigue siendo `char(1)` con `'T'`/`'P'` y su mapa quedó intacto — esa columna nunca estuvo rota. Quedó consultado en el ticket.

## Lo que no cubre

Sin captura de pantalla: la pantalla está detrás de un login y este agente no ingresa contraseñas. La verifica el tester en `dev`.

**Sin migración.** No requiere ninguna acción en el servidor.

Refs: CDT-26