### PR TITLE
fix(condominios): ids string en el filtro de estado, el 0 colisionaba con vacio (CDT-26)

### DIFF
--- a/src/modulos/Condominios/Condominios.tsx
+++ b/src/modulos/Condominios/Condominios.tsx
@@ -102,9 +102,20 @@ const Condominios = () => {
           width: "180px",
           options: () => [
             { id: "ALL", name: "Todos" },
-            ...Object.entries(statusCondominios).map(([value, cfg]) => ({
-              id: Number(value),
-              name: cfg.text,
+            // Los ids van como STRING a propósito, y en orden explícito.
+            //
+            // 🔴 `ClientStatus.INACTIVE` vale 0, y `Select` decide qué opción
+            // está seleccionada con `option[optionValue] == value` (`==`, flojo)
+            // contra un "sin selección" que es `""`. En JavaScript `0 == ""` es
+            // `true`, así que con un id numérico la opción "Inactivo" aparecía
+            // seleccionada sola, con el filtro sin aplicar. `"0"` no colisiona.
+            //
+            // El orden es explícito porque `Object.entries` sobre claves
+            // numéricas las devuelve en orden ascendente, y eso ponía "Inactivo"
+            // antes que "Activo".
+            ...[ClientStatus.ACTIVE, ClientStatus.INACTIVE].map((value) => ({
+              id: String(value),
+              name: statusCondominios[value].text,
             })),
           ],
         },


### PR DESCRIPTION
Seguimiento de [#678](https://github.com/mariogfos/condaty2025-admin/pull/678). **Regresión que introdujo ese mismo PR**, encontrada mirando la pantalla andando.

## Qué pasó

Al pasar el mapa de estados a claves numéricas, los ids de las opciones del filtro pasaron a ser números. Y `ClientStatus.INACTIVE` vale `0`.

`Select` resuelve qué opción está seleccionada así:

```ts
// src/mk/components/forms/Select/Select.tsx:350
safeOptions.find((option: any) => option?.[optionValue] == value) || null
```

Igualdad flexible, contra un "sin selección" que es `""` (línea 194). **En JavaScript `0 == ""` es `true`**, así que "Inactivo" figuraba seleccionado solo, con el filtro sin aplicar.

## Qué cambia

- Los ids de las opciones van como **string**. `"0"` no colisiona con `""`.
- El orden se fija explícito: `Object.entries` sobre claves numéricas las devuelve ascendentes, y eso ponía "Inactivo" antes que "Activo".

## Verificación

Navegador, sesión de superadmin, base de dev:

| | Antes (#678 mergeado) | Después |
|---|---|---|
| Select cerrado, sin filtrar | `Inactivo` | `Seleccionar` |
| Orden de opciones | Todos / Inactivo / Activo | Todos / Activo / Inactivo |
| Elegir "Activo" | — | `GET …&filterBy=status%3A1` → 200 con filas |

`tsc`: 0 errores bajo `src/modulos/Condominios/`, 29 totales, idénticos a `dev`.

## Lo que vale la pena leer

El defecto sobrevivió a `tsc` en verde, `eslint` en verde y una revisión de gentle-ai con **cero hallazgos**. Lo encontró abrir la pantalla. Nada más lo encontró.

## La causa raíz NO se arregla acá, a propósito

Las dos colisiones con valores falsy viven en el `Select` **compartido** (`value || ""` en la 194, `==` flojo en la 350). Ese componente lo usa todo el admin, así que va en **CDT-30** con su propio barrido, no de polizón en un fix de etiquetas.

**Sin migración.**

Refs: CDT-26, CDT-30