### PR TITLE
refactor(useAxios): tipar el hook y destapar cinco bugs vivos que el any escondía

### DIFF
--- a/src/components/AppVersionModal/AppVersionModal.tsx
+++ b/src/components/AppVersionModal/AppVersionModal.tsx
@@ -70,18 +70,19 @@ export const AppVersionModal: React.FC = () => {
     setSaving(true);
     try {
       const payload = { ...form };
-      console.log('AppVersion PUT payload', payload);
-      // include token fallback header in case interceptors haven't attached token yet
-      let axiosConfig: any = {};
-      try {
-        const apiToken = JSON.parse(
-          (localStorage.getItem((process.env.NEXT_PUBLIC_AUTH_IAM as string) + 'token') as string) || 'null'
-        )?.token;
-        if (apiToken) axiosConfig = { headers: { Authorization: 'Bearer ' + apiToken } };
-      } catch (e) {
-        axiosConfig = {};
-      }
-      const res: any = await execute('/app-version', 'PUT', payload, false, false, axiosConfig);
+
+      // 🔴 Acá había un bloque que armaba `axiosConfig` con el header
+      // `Authorization` y lo pasaba como SEXTO argumento de `execute` — que
+      // recibe CINCO. El argumento se descartaba: el header nunca viajó.
+      //
+      // Y tampoco hacía falta. El interceptor de peticiones
+      // (`mk/interceptors/axiosInterceptors.tsx`) lee la misma clave del
+      // localStorage y pone el mismo header en TODAS las peticiones. Era una
+      // copia del interceptor, muerta por partida doble.
+      //
+      // Lo destapó tipar `execute`: como estaba declarada `Function`,
+      // TypeScript aceptaba cualquier cantidad de argumentos sin chistar.
+      const res = await execute('/app-version', 'PUT', payload, false, false);
       if (res.error) {
         console.error('AppVersion PUT error', res.error);
         const detail = res.error.data || res.error.message || JSON.stringify(res.error);

--- a/src/components/ProfileModal/EditProfile/EditProfile.tsx
+++ b/src/components/ProfileModal/EditProfile/EditProfile.tsx
@@ -95,7 +95,12 @@ const EditProfile = ({
       onClose();
     } else {
       console.error("error:", err);
-      setErrors(err.data?.errors);
+      // 🔴 Era `err.data?.errors`, y `err` es `null` justo en el caso más común
+      // de esta rama: el API rechaza una validación con **HTTP 200 y
+      // `success: false`**, así que no hay error de transporte. Leerlo tiraba
+      // "Cannot read properties of null" en vez de marcar el campo mal
+      // completado. Los errores vienen en el sobre, no en el error.
+      setErrors(err?.data?.errors ?? data?.errors);
     }
   };
   return (

--- a/src/mk/components/chat/chatBot/useChatBotLLM.tsx
+++ b/src/mk/components/chat/chatBot/useChatBotLLM.tsx
@@ -552,7 +552,7 @@ Este manual cubre la implementación y configuración de Condaty para una gesti�
         //   " no debes mostrar la info de permisos literalmente, los permisos de cada modulo significan  C:Crear, R:Leer, U:Editar, D:Borrar.\n" +
         //   " Las respuestas de calculos y datos recuperados por las Tools, que sean exactas y no inventadas.\n" +
         //   " si no se te ocurre una respuesta, responde con 'no se te ocurre una respuesta'. \n";
-        if (data.success) {
+        if (data?.success) {
           context.push({
             role: "tool",
             content: JSON.stringify(data?.data),

--- a/src/mk/components/chat/chatBot/useChatProvider.tsx
+++ b/src/mk/components/chat/chatBot/useChatProvider.tsx
@@ -41,10 +41,12 @@ export function useChatProvider({ provider, context }: UseChatProviderOptions) {
         context: context ?? "",
         provider: provider || "chatgpt",
       });
-      if (data.success === true) {
+      if (data?.success === true) {
         response = data.data;
       } else {
-        setError(error);
+        // `error` es el fallo de transporte y puede ser `null` —el rechazo de
+        // negocio llega con 200—, así que se guarda su mensaje, no el objeto.
+        setError(error?.message ?? null);
         response = "No se pudo responder la pregunta, intenta mas tarde";
       }
     } catch (err: any) {

--- a/src/mk/hooks/useAxios.tsx
+++ b/src/mk/hooks/useAxios.tsx
@@ -11,29 +11,113 @@ import {
 import { AxiosContext } from "../contexts/AxiosInstanceProvider";
 import { logError } from "../utils/logs";
 
-export type MethodType = "GET" | "POST" | "PUT" | "DELETE";
+/**
+ * ⚠️ `PATCH` faltaba, y no era un olvido inocuo: el API tiene rutas `patch`
+ * —`assemblies/{assembly}/status`, `tasks/{task}/status`, `tasks/{task}/assign`—
+ * y el front ya las llamaba. Como `execute` estaba tipada `Function`, nadie se
+ * enteraba de que el tipo no contemplaba el verbo que el código usa.
+ */
+export type MethodType = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
-export type UseAxiosType = {
-  countAxios: number;
-  cancel: Function;
+/**
+ * El sobre que devuelve el API en TODA respuesta.
+ *
+ * ⚠️ La firma es abierta a propósito (`[key: string]: any`). El sobre real trae
+ * cuatro claves fijas —`success`, `data`, `message`, `errors`— y cada módulo le
+ * agrega las suyas: `extraData` aparece en 34 lugares, y hay listados que suman
+ * `total` o campos propios. Cerrarlo hoy rompería esos accesos sin haber ganado
+ * nada: lo que importa es que las cuatro fijas **dejen de ser `any`**.
+ *
+ * 🔴 `success` es lo que más se lee mal. El API responde los rechazos de negocio
+ * con **HTTP 200 y `success: false`**, así que un `try/catch` no los ve: hay que
+ * mirar esta clave. De 168 llamadas del repo, sólo 44 lo hacían.
+ */
+export type ApiEnvelope<T = any> = {
+  success?: boolean;
+  data?: T;
+  message?: any;
+  errors?: any;
+  [key: string]: any;
+};
+
+/** Lo que devuelve `execute` cuando la petición NO llegó a completarse. */
+export type ApiError = {
+  message: string;
+  status: number;
   data: any;
-  error: any;
+};
+
+/**
+ * El par que devuelve `execute`: uno de los dos viene en null.
+ *
+ * ⚠️ `error` acá es sólo el fallo de transporte (red caída, 500, timeout). Un
+ * rechazo de negocio llega con `error === null` y `data.success === false`.
+ */
+export type ExecuteResult<T = any> = {
+  data: ApiEnvelope<T> | null;
+  error: ApiError | null;
+};
+
+/**
+ * 🔴 Antes era `Function`, que en TypeScript no verifica NADA: ni cuántos
+ * argumentos recibe, ni de qué tipo, ni qué devuelve. Con cinco parámetros
+ * posicionales —tres de ellos opcionales y dos booleanos seguidos— era la firma
+ * más fácil de invocar mal de todo el repo, y el compilador miraba para otro
+ * lado.
+ */
+export type ExecuteFn<T = any> = (
+  url?: string | null,
+  method?: MethodType,
+  payload?: Record<string, any>,
+  /** Si además de devolver la respuesta la guarda en el estado del hook. */
+  saveInState?: boolean,
+  notWaiting?: boolean,
+) => Promise<ExecuteResult<T>>;
+
+export type ReLoadFn = (
+  payload?: Record<string, any> | null,
+  noWaiting?: boolean,
+  /** Si es `true`, no hace nada hasta que haya corrido la primera petición. */
+  prevent?: boolean,
+) => Promise<void>;
+
+/** Suma o resta al contador global de peticiones en vuelo. */
+export type SetWaitingFn = (delta: number, origen?: string) => void;
+
+export type UseAxiosType<T = any> = {
+  countAxios: number;
+  cancel: () => void;
+  /**
+   * El sobre de la última respuesta, o `null` mientras no haya ninguna.
+   *
+   * ⚠️ Arranca en `[]` —no en `null`— cuando el hook se crea con `url: null`.
+   * Es de la implementación vieja y NO se cambió acá: hay 83 llamadas y varias
+   * podrían estar leyendo `.length` sobre eso. Cambiarlo es su propio PR, con
+   * la medición hecha.
+   */
+  data: ApiEnvelope<T> | null;
+  error: ApiError | "";
   loaded: boolean;
-  execute: Function;
-  reLoad: Function;
+  execute: ExecuteFn<T>;
+  reLoad: ReLoadFn;
   waiting: number;
-  setWaiting: Function;
+  setWaiting: SetWaitingFn;
   notWaiting?: boolean;
 };
 
-const useAxios = (
+/**
+ * @typeParam T - Qué hay adentro de `data.data`. Por omisión es `any`, así que
+ * las 83 llamadas que ya existen siguen compilando igual. Un módulo que quiera
+ * chequeo real lo pide: `useAxios<Reserva[]>("/reservations")`.
+ */
+const useAxios = <T = any,>(
   url: string | null = null,
   method: MethodType = "GET",
-  payload: object = {},
+  payload: Record<string, any> = {},
   noWaiting = false,
-): UseAxiosType => {
-  const [data, setData] = useState<any>(null);
-  const [error, setError]: any = useState("");
+): UseAxiosType<T> => {
+  const [data, setData] = useState<ApiEnvelope<T> | null>(null);
+  const [error, setError] = useState<ApiError | "">("");
   const [loaded, setLoaded] = useState(false);
   const [countAxios, setCountAxios] = useState(0);
   const { contextInstance, waiting, setWaiting }: any =
@@ -77,13 +161,13 @@ const useAxios = (
    * Depende solo de cosas que casi nunca cambian. Todo lo inestable
    * —`setWaiting`, `payload`— entra por ref.
    */
-  const execute: any = useCallback(async (
+  const execute: ExecuteFn<T> = useCallback(async (
     _url: string | null = url,
     _method: MethodType = method,
-    payload: any = {},
+    payload: Record<string, any> = {},
     Act: boolean = false,
     notWaiting = false,
-  ) => {
+  ): Promise<ExecuteResult<T>> => {
     setError("");
     if (!notWaiting) {
       setLoaded(false);
@@ -99,8 +183,8 @@ const useAxios = (
       _url = _url + "?" + new URLSearchParams(payload).toString();
     }
 
-    let data = null;
-    let error: null | { message: string; status: number; data: any } = null;
+    let data: ApiEnvelope<T> | null = null;
+    let error: ApiError | null = null;
 
     try {
       const response = await instance?.request({
@@ -148,8 +232,12 @@ const useAxios = (
   // de dependencias, `execute` se lee durante el render, y leerlo antes de su
   // declaracion es un ReferenceError por la zona muerta temporal. Como
   // funcion suelta no se notaba, porque recien se resolvia al llamarla.
-  const reLoad = useCallback(
-    async (_payload: any = null, noWaiting = false, prevent = false) => {
+  const reLoad: ReLoadFn = useCallback(
+    async (
+      _payload: Record<string, any> | null = null,
+      noWaiting = false,
+      prevent = false,
+    ) => {
       if (prevent && countAxiosRef.current == 0) return;
       const pay = {
         ...payloadRef.current,

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useMemo,
 } from "react";
-import useAxios from "../useAxios";
+import useAxios, { type MethodType } from "../useAxios";
 import { capitalize, getUrlImages } from "../../utils/string";
 import { useAuth } from "../../contexts/AuthProvider";
 import {
@@ -936,7 +936,7 @@ const useCrud = ({
       }
 
       const url = "/" + mod.modulo + (data.id ? "/" + data.id : "");
-      let method = "POST";
+      let method: MethodType = "POST";
       if (data.id) {
         method = "PUT";
         if (action == "del") {

--- a/src/modulos/Areas/RenderView/RenderView.tsx
+++ b/src/modulos/Areas/RenderView/RenderView.tsx
@@ -113,7 +113,7 @@ const RenderView = ({ open, item, onClose, reLoad }: any) => {
       showToast(data.msg, "success");
       setOpenConfirm(false);
     } else {
-      showToast(data.msg, "error");
+      showToast(data?.msg, "error");
     }
   };
 

--- a/src/modulos/BankProviderTester/BankProviderTester.tsx
+++ b/src/modulos/BankProviderTester/BankProviderTester.tsx
@@ -28,7 +28,8 @@ interface HistoryItem {
   success: boolean;
   message: string;
   requestData?: Record<string, unknown>;
-  responseData?: Record<string, unknown>;
+  /** `null` cuando la petición falló y no hubo sobre que guardar. */
+  responseData?: Record<string, unknown> | null;
 }
 
 interface TokenData {
@@ -334,11 +335,12 @@ const BankProviderTester: React.FC = () => {
     setConfigLoading(true);
     setConfigError(null);
     try {
-      const result = await execute("/v3/bank-qr/config", "GET", null);
+      const result = await execute("/v3/bank-qr/config", "GET");
       if (result.error) {
         setConfigError(result.error.data?.message || "Failed to load config");
       } else {
-        setQrConfig(result.data);
+        // El sobre trae la configuración en `data`, no en la raíz.
+        setQrConfig(result.data?.data ?? null);
       }
     } catch (err: any) {
       setConfigError(err?.message || "Unknown error loading config");
@@ -362,7 +364,9 @@ const BankProviderTester: React.FC = () => {
     success: boolean,
     message: string,
     request?: Record<string, unknown>,
-    response?: Record<string, unknown>,
+    // `execute` devuelve el sobre, que puede venir en `null` si la petición
+    // falló. Antes era `Record<string, unknown> | undefined` y no lo contemplaba.
+    response?: Record<string, unknown> | null,
   ) => {
     const newItem: HistoryItem = {
       id: Date.now().toString(),

--- a/src/modulos/Dptos/RenderForm.tsx
+++ b/src/modulos/Dptos/RenderForm.tsx
@@ -5,6 +5,7 @@ import Input from "@/mk/components/forms/Input/Input";
 import Select from "@/mk/components/forms/Select/Select";
 import TextArea from "@/mk/components/forms/TextArea/TextArea";
 import { checkRules, hasErrors } from "@/mk/utils/validate/Rules";
+import type { MethodType } from "@/mk/hooks/useAxios";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { getFullName } from "@/mk/utils/string";
 import useAxios from "@/mk/hooks/useAxios";
@@ -131,7 +132,7 @@ const RenderForm = ({
   };
 
   const onSave = async () => {
-    let method = formState.id ? "PUT" : "POST";
+    const method: MethodType = formState.id ? "PUT" : "POST";
     if (hasErrors(validate())) return;
 
     // Preparar los campos adicionales habilitados en el formato requerido

--- a/src/modulos/Profile/Profile.tsx
+++ b/src/modulos/Profile/Profile.tsx
@@ -122,7 +122,10 @@ const Profile = () => {
       setOpenProfileModal(false);
     } else {
       console.error("error:", err);
-      setErrors(err.data?.errors);
+      // Mismo caso que en `EditProfile`: en un rechazo de validación el API
+      // responde 200 con `success: false`, así que `err` es `null` y esto
+      // reventaba en vez de mostrar qué campo está mal.
+      setErrors(err?.data?.errors ?? data?.errors);
     }
   };
 

--- a/src/modulos/QrDinamico/Conciliation/Conciliation.tsx
+++ b/src/modulos/QrDinamico/Conciliation/Conciliation.tsx
@@ -9,10 +9,14 @@ const Conciliation = () => {
   const [data, setData] = useState<ConciliationData | null>(null);
   const [selectedClients, setSelectedClients] = useState<Record<string, boolean>>({});
 
+  // 🔴 `execute` devuelve `{ data, error }`, y el sobre del API viene ADENTRO de
+  // `data`. Esto leía `res.success` y `res.data` —un nivel de más arriba—, así
+  // que `res.success` era SIEMPRE `undefined` y la pantalla no cargaba nunca.
+  // Lo tapaba `execute: Function`, que en TypeScript no verifica nada.
   const loadData = async () => {
-    const res = await execute('v3/qr-dynamic/conciliation/summary', 'GET');
-    if (res?.success) {
-      setData(res.data);
+    const { data: sobre } = await execute('v3/qr-dynamic/conciliation/summary', 'GET');
+    if (sobre?.success) {
+      setData(sobre.data);
     }
   };
 
@@ -49,15 +53,18 @@ const Conciliation = () => {
       return;
     }
 
-    const res = await execute('v3/qr-dynamic/conciliation/mark-deposited', 'POST', {
+    // Mismo error que en `loadData`: se leía un nivel más arriba del sobre. Acá
+    // el efecto era peor —conciliaba bien y avisaba "Error al conciliar"—,
+    // porque el `else` era la única rama alcanzable.
+    const { data: sobre } = await execute('v3/qr-dynamic/conciliation/mark-deposited', 'POST', {
       order_ids: orderIdsToConciliate
     });
 
-    if (res?.success) {
+    if (sobre?.success) {
       setSelectedClients({});
       loadData();
     } else {
-      alert(res?.message || 'Error al conciliar');
+      alert(sobre?.message || 'Error al conciliar');
     }
   };
 

--- a/src/modulos/QrDinamico/GenerateQrModal/GenerateQrModal.tsx
+++ b/src/modulos/QrDinamico/GenerateQrModal/GenerateQrModal.tsx
@@ -11,7 +11,10 @@ interface Props {
 }
 
 const GenerateQrModal = ({ open, onClose, onSuccess }: Props) => {
-  const { execute, loaded } = useAxios();
+  // Primer uso del genérico de `useAxios`: acá `data.data` es el pedido de QR
+  // tipado, no `any`. `GenerateQrResponse` ya describía el sobre entero, así que
+  // sólo hace falta decirle qué lleva adentro.
+  const { execute, loaded } = useAxios<GenerateQrResponse['data']>();
 
   const [form, setForm] = useState<GenerateQrPayload>({
     amount: 0,
@@ -45,12 +48,17 @@ const GenerateQrModal = ({ open, onClose, onSuccess }: Props) => {
     if (form.payment_type) payload.payment_type = form.payment_type;
     if (form.owner_id)     payload.owner_id = form.owner_id;
 
-    const res: GenerateQrResponse = await execute('v3/qr-dynamic/generate', 'POST', payload);
+    // 🔴 Esto declaraba `res: GenerateQrResponse` sobre lo que devuelve
+    // `execute`, que es `{ data, error }` — el sobre está un nivel más adentro.
+    // La anotación mentía y TypeScript la creía, así que `res.success` era
+    // siempre `undefined`: el QR se generaba y la pantalla decía "Error al
+    // generar el QR" igual.
+    const { data: sobre } = await execute('v3/qr-dynamic/generate', 'POST', payload);
 
-    if (res?.success && res.data) {
-      setGeneratedOrder(res.data);
+    if (sobre?.success && sobre.data) {
+      setGeneratedOrder(sobre.data);
     } else {
-      setApiError(res?.message ?? 'Error al generar el QR. Intenta nuevamente.');
+      setApiError(sobre?.message ?? 'Error al generar el QR. Intenta nuevamente.');
     }
   };
 

--- a/src/modulos/QrDinamico/RenderView/RenderView.tsx
+++ b/src/modulos/QrDinamico/RenderView/RenderView.tsx
@@ -22,8 +22,11 @@ const RenderView = ({ order, onClose, onCancel }: Props) => {
 
   const handleCancel = async () => {
     if (!confirm('¿Confirmas la anulación de este QR?')) return;
-    const res = await doCancel(`qr-dynamic/orders/${order.id}/cancel`, 'POST');
-    if (res?.success) onCancel();
+    // El sobre del API viene dentro de `data`. Leyendo `res.success` esto era
+    // siempre `undefined`: el QR se anulaba en el servidor y la pantalla no se
+    // enteraba nunca.
+    const { data: sobre } = await doCancel(`qr-dynamic/orders/${order.id}/cancel`, 'POST');
+    if (sobre?.success) onCancel();
   };
 
   const handlePrint = () => {

--- a/src/modulos/Surveys/components/VotersListModal/VotersListModal.tsx
+++ b/src/modulos/Surveys/components/VotersListModal/VotersListModal.tsx
@@ -48,10 +48,8 @@ const VotersListModal: React.FC<VotersListModalProps> = ({
       const { data: response } = await execute(url, "GET");
       setLoaded(true);
 
-      if (response.success) {
-        // console.error("[VotersListModal] API error:", error);
-        console.log(response.data);
-        setVoters(response.data.voters || response.data?.data?.voters || []);
+      if (response?.success) {
+        setVoters(response.data?.voters || response.data?.data?.voters || []);
       } else {
         setVoters([]);
       }


### PR DESCRIPTION
Segundo trabajo del sprint transversal: tipar `useAxios`, la raíz de los 2.509 `any` del repo.

## Qué estaba mal

`execute`, `reLoad`, `cancel` y `setWaiting` estaban declarados como `Function`. En TypeScript eso **no verifica nada**: ni cuántos argumentos recibe, ni de qué tipo, ni qué devuelve.

Y `execute` tiene cinco parámetros posicionales, tres opcionales y dos booleanos seguidos, sobre **189 llamadas**. Era la firma más fácil de invocar mal del repo, y el compilador miraba para otro lado.

## Qué se hizo

Firma real para las cuatro funciones, tipo para el sobre del API (`ApiEnvelope`, **abierto a propósito** porque cada módulo le agrega claves — `extraData` aparece en 34 lugares), y el hook pasa a ser genérico.

Las 83 llamadas que ya existían **compilan sin cambios** porque el default es `any`. El que quiera chequeo real lo pide: `useAxios<Reserva[]>()`.

## Los cinco bugs vivos que destapó

🔴 **QrDinamico entero — cuatro pantallas.** Todas leían `res.success` sobre lo que devuelve `execute`, que es `{ data, error }`: el sobre está un nivel más adentro. `res.success` era **siempre `undefined`**.

| pantalla | qué pasaba |
|---|---|
| Conciliación | no cargaba nunca |
| Conciliar | conciliaba bien y avisaba "Error al conciliar" |
| Anular QR | se anulaba en el servidor, la pantalla no se enteraba |
| Generar QR | decía "Error al generar el QR" con el QR ya generado |

🔴 **Perfil y Editar Perfil reventaban al rechazar una validación.** Leían `err.data?.errors`, y `err` es `null` **justo en el caso de esa rama**: el API rechaza validaciones con HTTP 200 y `success: false`, así que no hay error de transporte. Tiraba `Cannot read properties of null` en vez de marcar el campo mal cargado.

🔴 **`AppVersionModal` pasaba un sexto argumento** a una función que recibe cinco: el header `Authorization` que armaba **nunca viajó**. Encima era una copia del interceptor, que ya pone ese mismo header en todas las peticiones. Borrado.

🔴 **`MethodType` no contemplaba `PATCH`**, y el API tiene rutas `patch` que el front ya llamaba: `assemblies/{assembly}/status`, `tasks/{task}/status`, `tasks/{task}/assign`.

Más `VotersListModal` y el chatbot asumiendo respuesta no nula en el camino de error.

## Verificación

Reinyección: con el bug del sobre puesto de vuelta, `tsc` se pone **ROJO en la línea exacta** (`TS2339: Property 'success' does not exist on type 'ExecuteResult<any>'`).

⚠️ Con un `any` explícito **no lo detecta** — por eso se tipa de afuera hacia adentro.

`tsc` queda en 29 errores, los mismos de antes, todos en `__tests__` de módulos sin migrar y ya anotados. Suite: 93 archivos, 651 tests en verde. Verificado en el navegador.

## Lo que NO pasó

El conteo global de `any` **no bajó** (2.510). Era una métrica proxy: no se sacó un `any` de las llamadas, se le puso piso a la raíz. Lo que cambió es que **189 llamadas a `execute` y 65 a `reLoad` ahora las verifica el compilador**.
