### PR TITLE
fix(select): una opcion con id 0 ya no aparece elegida sola (CDT-30)

### DIFF
--- a/src/mk/components/forms/Select/Select.tsx
+++ b/src/mk/components/forms/Select/Select.tsx
@@ -82,8 +82,7 @@ const Section = ({
         />
       </div>
       <ul>
-        {_options.map
-          ? _options.map((option: any, key: any) => (
+        {_options.map((option: any, key: any) => (
               (() => {
                 const isGroupLabel = Boolean(option?.isGroupLabel);
                 const isSelected = isGroupLabel
@@ -150,18 +149,6 @@ const Section = ({
               </li>
                 );
               })()
-            ))
-          : Object.keys(_options).map((key) => (
-              <li
-                key={`li${name}${key}`}
-                onClick={() =>
-                  handleSelectClickElement(
-                    _options[key][optionValue] || _options[key].label,
-                  )
-                }
-              >
-                {_options[key][optionValue] || _options[key].label}
-              </li>
             ))}
       </ul>
     </section>
@@ -190,8 +177,21 @@ const Select = ({
   onBlur = () => {},
   onChange = (e: any) => {},
 }: PropsType) => {
+  // La segunda trampa de CDT-30, y cada modo la resuelve distinto.
+  //
+  // Simple: `??` y no `||`. Con `||`, un `value` de 0 —una opción legítimamente
+  // seleccionada— se convertía en cadena vacía en el primer render, y el efecto
+  // de más abajo tenía que corregirlo después.
+  //
+  // Múltiple: se exige un ARRAY. Esto es DEFENSIVO, no un bug reproducido: hoy
+  // un escalar falsy se colaría como `selectValue`, pero el spread y el
+  // `.includes()` de más abajo van los dos detrás de un `Array.isArray`, así
+  // que nada se rompe. Se intentó escribir el test que lo pusiera en rojo y
+  // quedó verde — o sea que no hay comportamiento observable que cubrir. Se
+  // deja la guarda porque el invariante "en múltiple esto es un array" es más
+  // barato de sostener acá que en cada consumidor.
   const [selectValue, setSelectValue] = useState(
-    value || (multiSelect ? [] : ""),
+    multiSelect ? (Array.isArray(value) ? value : []) : (value ?? ""),
   );
   const [openOptions, setOpenOptions] = useState(false);
   const [search, setSearch] = useState("");
@@ -346,8 +346,25 @@ const Select = ({
 
   const selectedOption = useMemo(() => {
     if (multiSelect || safeOptions.length === 0) return null;
+
+    // "Sin selección" es null, undefined o cadena vacía — y NADA MÁS.
+    //
+    // 🔴 Este chequeo explícito es el arreglo de CDT-30. Antes la comparación
+    // de abajo era `==` flojo contra `value`, y con `value = ""` (que es lo que
+    // vale un select sin elegir) `0 == ""` da `true` en JavaScript: cualquier
+    // opción cuyo id fuera 0 aparecía seleccionada sola, sin que el usuario
+    // tocara nada. Se vio en el filtro de estado de Condominios, donde
+    // `ClientStatus.INACTIVE` vale 0.
+    if (value === null || value === undefined || value === "") return null;
+
+    // Se compara como texto, no con `===` a secas, para conservar lo ÚNICO
+    // útil que hacía el `==` flojo: enganchar el id numérico que manda el
+    // backend (1) con el id string que arman las pantallas ("1"). Lo que se
+    // pierde es la coerción con vacío y con booleanos, que es justo el bug.
     return (
-      safeOptions.find((option: any) => option?.[optionValue] == value) || null
+      safeOptions.find(
+        (option: any) => String(option?.[optionValue]) === String(value),
+      ) || null
     );
   }, [multiSelect, optionValue, safeOptions, value]);
 

--- a/src/mk/components/forms/Select/__tests__/SelectValorCero.test.tsx
+++ b/src/mk/components/forms/Select/__tests__/SelectValorCero.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * CDT-30 — una opción cuyo id vale 0 no puede aparecer elegida sola.
+ *
+ * El bug: `Select` resolvía la opción seleccionada con `==` flojo contra el
+ * "sin selección", que es la cadena vacía. En JavaScript `0 == ""` es `true`,
+ * así que cualquier opción con id 0 se mostraba como elegida sin que el usuario
+ * tocara nada. Se vio en el filtro de estado de Condominios, donde
+ * `ClientStatus.INACTIVE` vale 0.
+ *
+ * Se mira el TEXTO DEL CONTROL CERRADO, que es lo que ve el usuario, y no el
+ * estado interno: el estado interno estaba bien y el usuario igual leía
+ * "Inactivo".
+ *
+ * ## Reinyección verificada (2026-08-13)
+ *
+ * Volvé a poner `option?.[optionValue] == value` en `selectedOption` y sacá la
+ * guarda de "sin selección": se pone ROJO `sin selección no elige la opción con
+ * id 0`.
+ *
+ * ⚠️ NO hay test del inicializador de `selectValue` en modo múltiple, y es a
+ * propósito: se escribió uno, se reinyectó el `value ?? (...)` que deja pasar
+ * un escalar falsy, y quedó VERDE. El spread y el `.includes()` que consumen
+ * `selectValue` van los dos detrás de un `Array.isArray`, así que no hay
+ * comportamiento observable que medir. La guarda del componente queda como
+ * invariante defensivo, no como arreglo de un defecto reproducible.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Select from "../Select";
+
+/** Las dos opciones de ClientStatus, con el 0 que dispara el bug. */
+const ESTADOS = [
+  { id: 0, name: "Inactivo" },
+  { id: 1, name: "Activo" },
+];
+
+describe("Select — ids con valor 0", () => {
+  it("sin selección no elige la opción con id 0", () => {
+    render(
+      <Select name="estado" value="" options={ESTADOS} placeholder="Seleccionar" />,
+    );
+
+    expect(screen.getByText("Seleccionar")).toBeTruthy();
+    expect(screen.queryByText("Inactivo")).toBeNull();
+  });
+
+  it("con el 0 elegido de verdad, muestra su etiqueta", () => {
+    render(
+      <Select name="estado" value={0} options={ESTADOS} placeholder="Seleccionar" />,
+    );
+
+    expect(screen.getByText("Inactivo")).toBeTruthy();
+  });
+
+  it("un id numérico engancha con un value string, y al revés", () => {
+    // Lo único útil que hacía el `==` flojo: el backend manda 1, la pantalla
+    // arma "1". Se conserva comparando como texto.
+    const { unmount } = render(
+      <Select name="a" value="1" options={ESTADOS} placeholder="Seleccionar" />,
+    );
+    expect(screen.getByText("Activo")).toBeTruthy();
+    unmount();
+
+    render(
+      <Select
+        name="b"
+        value={1}
+        options={[
+          { id: "0", name: "Inactivo" },
+          { id: "1", name: "Activo" },
+        ]}
+        placeholder="Seleccionar"
+      />,
+    );
+    expect(screen.getByText("Activo")).toBeTruthy();
+  });
+
+  it("null y undefined tampoco eligen el 0", () => {
+    const { unmount } = render(
+      <Select name="c" value={null} options={ESTADOS} placeholder="Seleccionar" />,
+    );
+    expect(screen.queryByText("Inactivo")).toBeNull();
+    unmount();
+
+    render(
+      <Select name="d" value={undefined} options={ESTADOS} placeholder="Seleccionar" />,
+    );
+    expect(screen.queryByText("Inactivo")).toBeNull();
+  });
+});


### PR DESCRIPTION
## El bug

`Select` resolvía la opción seleccionada así:

```ts
// src/mk/components/forms/Select/Select.tsx
safeOptions.find((option: any) => option?.[optionValue] == value) || null
```

Igualdad flexible, contra un "sin selección" que es `""`. **En JavaScript `0 == ""` es `true`.**

Cualquier opción cuyo id valiera `0` figuraba elegida sin que el usuario tocara nada. El filtro no se aplicaba —la lista seguía completa— pero el desplegable mentía sobre su estado.

Salió en el filtro de estado de Condominios ([CDT-26](https://github.com/mariogfos/condaty2025-admin/pull/679)), donde `ClientStatus.INACTIVE` vale `0`. Ahí se tapó mandando los ids como string, que es **un parche por pantalla**. Esto lo arregla donde vive.

## Por qué va a volver a morder si no se arregla acá

El proyecto migra todos los estados a enums numéricos. La regla es *desde 1*, y por eso casi ninguno pisa la trampa — pero `ClientStatus.INACTIVE` vale `0` (pineado a propósito en S135) y `OwnerStatus` también. Cada pantalla que filtre por uno de esos repite el síntoma.

## Qué cambia

**1. `selectedOption`** declara explícito que "sin selección" es `null`, `undefined` o `""` — y nada más. Después compara con `String(a) === String(b)`, que **conserva lo único útil del `==` flojo** (enganchar el `1` numérico del backend con el `"1"` string del front) y pierde la coerción con vacío y con booleanos, que es justo el bug.

**2. El inicializador de `selectValue`** separa los dos modos: `??` en simple, para que un `value` de `0` legítimo no se vuelva `""` en el primer render; y un array garantizado en múltiple.

> Lo segundo es **defensivo, no un bug reproducido**. Escribí el test que lo pondría en rojo y **quedó verde**: el spread y el `.includes()` de más abajo ya van detrás de un `Array.isArray`. Borré ese test en vez de dejarlo — un test que no puede fallar anuncia cobertura que no existe.

**3. Se eliminan 12 líneas muertas** del sub-componente `Section`. La rama `Object.keys(_options)` es inalcanzable (`safeOptions` siempre es array, `filteredOptions` también, y es lo único que llega como `_options`) y cargaba **una segunda copia del mismo bug falsy**.

## Verificación

**Test nuevo, verificado por reinyección** — un test verde no prueba nada hasta verlo rojo:

```
npx vitest run src/mk/components/forms/Select/__tests__/SelectValorCero.test.tsx
  Tests  4 passed (4)
```

Con el `==` flojo devuelto y la guarda sacada:

```
  Tests  1 failed | 4 passed (5)
  FAIL > sin seleccion no elige la opcion con id 0
  TestingLibraryElementError: Unable to find an element with the text: Seleccionar
```

**En pantalla** (sesión de superadmin, base de dev). Revertí el llamador de Condominios a ids **numéricos** — el estado exacto que esta mañana mostraba "Inactivo" elegido solo:

| | Antes | Después |
|---|---|---|
| Filtro cerrado, sin aplicar | `Inactivo` | **`Seleccionar`** |

**`tsc`**: 29 errores en el candidato, 29 en `dev`. Cero nuevos, cero bajo `forms/Select/`.

## Lo que hay que leer de esto

Este defecto es **invisible** para `tsc`, `eslint` y CI: los tipos están bien, la sintaxis está bien, y la comparación mentirosa vive en un archivo que el diff del llamador no toca. Por eso la regresión original de CDT-26 les pasó por al lado a los cinco checks y llegó a `dev`. Lo encontró abrir la pantalla.

**Sin migración.**

Refs: CDT-30, CDT-26