### PR TITLE
perf(lista): cortar la cascada de renders y memoizar la fila — 3.120 celdas a 120

### DIFF
--- a/src/mk/components/ui/Table/Table.tsx
+++ b/src/mk/components/ui/Table/Table.tsx
@@ -344,6 +344,123 @@ const getResolvedFillIndex = (header: NonNullable<PropsType["header"]>) => {
   return firstFlexible?.index ?? -1;
 };
 
+
+/**
+ * Una fila de la tabla, memoizada.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 POR QUÉ ES UN COMPONENTE Y NO SIGUE INLINE
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Estaba escrita dentro del `.map()` de `Table`, así que **no había nada que
+ * memoizar**: cada render de la tabla rehacía todas las celdas de todas las
+ * filas cargadas, aunque no hubiera cambiado ninguna.
+ *
+ * Con scroll infinito eso escala mal, porque el costo crece con el total ya
+ * cargado. Medido el 2026-08-13 (`__tests__/tablaEscalaAlCargarMas.test.tsx`),
+ * agregando un lote de 40 filas:
+ *
+ *   40 filas cargadas   →   240 celdas
+ *   200 filas cargadas  →   720 celdas
+ *   1.000 filas cargadas → 3.120 celdas   ← deberían ser 120 en los tres casos
+ *
+ * Una sesión que carga 1.000 filas en 25 lotes hacía ~40.000 renders de celda en
+ * vez de ~3.000. No se veía como un bug —la lista muestra lo correcto—, se veía
+ * como que la app va pesada cuando hay muchos datos.
+ *
+ * ⚠️ Esto sólo sirve si `header` y los handlers mantienen su identidad entre
+ * renders. `mergeRowsById` de `useCrud` ya conserva el objeto de cada fila ya
+ * cargada, así que `row` sí es estable.
+ */
+const Row = memo(function Row({
+  row,
+  index,
+  header,
+  extraData,
+  manualWidths,
+  measuredWidths,
+  fillColumnIndex,
+  actionsWidth,
+  onButtonActions,
+  activo,
+  onRowClick,
+  onContextMenu,
+}: {
+  row: Record<string, any>;
+  index: number;
+  header: any[];
+  extraData: any;
+  manualWidths: any;
+  measuredWidths: any;
+  fillColumnIndex: number;
+  actionsWidth: any;
+  onButtonActions: any;
+  activo: boolean;
+  onRowClick: (row: any) => void;
+  onContextMenu: (event: any, row: any, index: number) => void;
+}) {
+  return (
+    <div
+      className={activo ? styles.contextMenuActiveRow : ""}
+      onClick={() => onRowClick(row)}
+      onContextMenu={(event) => onContextMenu(event, row, index)}
+    >
+      {header.map((item: any, i: number) => {
+        if (item.onHide?.()) {
+          return null;
+        }
+
+        const ignoreTranslation = shouldIgnoreValueTranslationContext({
+          label: item.label,
+          key: item.key,
+        });
+
+        return (
+          <span
+            key={item.key + i}
+            data-col-index={i}
+            className={[
+              styles[item.responsive],
+              item.className,
+              isAmountColumn(item) ? styles.amountCell : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            style={{
+              ...item.style,
+              ...getColumnWidthStyle({
+                item,
+                manualWidth: manualWidths[i],
+                measuredWidth: measuredWidths?.[i],
+                preferFill: i === fillColumnIndex,
+              }),
+            }}
+            data-i18n-ignore={ignoreTranslation ? "true" : undefined}
+          >
+            {item.onRender &&
+              item.onRender?.({
+                value: row[item.key],
+                key: item.key,
+                item: row,
+                i: index + 1,
+                extraData,
+              })}
+            {!item.onRender && row[item.key]}
+          </span>
+        );
+      })}
+      {onButtonActions && (
+        <span
+          className={styles.onlyDesktop}
+          style={{ ...getActionsWidthStyle(actionsWidth) }}
+        >
+          {onButtonActions(row)}
+        </span>
+      )}
+    </div>
+  );
+});
+
 const Table = ({
   header = [],
   id = "0",
@@ -953,7 +1070,10 @@ const Body = ({
     }
   }, []);
 
-  const _onRowClick = (e: any) => {
+  // Memoizada porque baja como prop a cada fila: como función suelta, su
+  // identidad nueva por render invalidaba el memo de TODAS las filas y la
+  // extracción del componente `Row` no servía de nada.
+  const _onRowClick = useCallback((e: any) => {
     closeContextMenu();
     if (onRowClick) {
       // const scrollTop = divRef?.current?.scrollTop;
@@ -962,7 +1082,7 @@ const Body = ({
       // }
       onRowClick(e);
     }
-  };
+  }, [closeContextMenu, onRowClick]);
 
   const resolveScrollContainer = useCallback(() => {
     if (height) return divRef.current as HTMLElement;
@@ -1195,71 +1315,20 @@ const Body = ({
             ) : onRenderCard ? (
               onRenderCard(row, index, onRowClick)
             ) : (
-              <div
-                key={"row" + index}
-                className={
-                  contextMenuState?.rowIndex === index
-                    ? styles.contextMenuActiveRow
-                    : ""
-                }
-                onClick={() => _onRowClick(row)}
-                onContextMenu={(event) =>
-                  handleRowContextMenu(event, row, index)
-                }
-              >
-                {header.map((item: any, i: number) => {
-                  if (item.onHide?.()) {
-                    return null;
-                  }
-
-                  const ignoreTranslation = shouldIgnoreValueTranslationContext({
-                    label: item.label,
-                    key: item.key,
-                  });
-
-                  return (
-                    <span
-                      key={item.key + i}
-                      data-col-index={i}
-                      className={[
-                        styles[item.responsive],
-                        item.className,
-                        isAmountColumn(item) ? styles.amountCell : "",
-                      ]
-                        .filter(Boolean)
-                        .join(" ")}
-                      style={{
-                        ...item.style,
-                        ...getColumnWidthStyle({
-                          item,
-                          manualWidth: manualWidths[i],
-                          measuredWidth: measuredWidths?.[i],
-                          preferFill: i === fillColumnIndex,
-                        }),
-                      }}
-                      data-i18n-ignore={ignoreTranslation ? "true" : undefined}
-                    >
-                      {item.onRender &&
-                        item.onRender?.({
-                          value: row[item.key],
-                          key: item.key,
-                          item: row,
-                          i: index + 1,
-                          extraData,
-                        })}
-                      {!item.onRender && row[item.key]}
-                    </span>
-                  );
-                })}
-                {onButtonActions && (
-                  <span
-                    className={styles.onlyDesktop}
-                    style={{ ...getActionsWidthStyle(actionsWidth) }}
-                  >
-                    {onButtonActions(row)}
-                  </span>
-                )}
-              </div>
+              <Row
+                row={row}
+                index={index}
+                header={header}
+                extraData={extraData}
+                manualWidths={manualWidths}
+                measuredWidths={measuredWidths}
+                fillColumnIndex={fillColumnIndex}
+                actionsWidth={actionsWidth}
+                onButtonActions={onButtonActions}
+                activo={contextMenuState?.rowIndex === index}
+                onRowClick={_onRowClick}
+                onContextMenu={handleRowContextMenu}
+              />
             )}
           </Fragment>
       ))}

--- a/src/mk/components/ui/Table/__tests__/tablaEscalaAlCargarMas.test.tsx
+++ b/src/mk/components/ui/Table/__tests__/tablaEscalaAlCargarMas.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+/**
+ * Cuánto cuesta un "cargar más" cuando ya hay filas en pantalla.
+ *
+ * ## 🔴 Lo medido el 2026-08-13
+ *
+ * `Table` dibuja cada fila y cada celda dentro de un `.map()` en su propio
+ * cuerpo. No hay componente de fila, así que **no hay nada que memoizar**: cada
+ * vez que `Table` se renderiza, se rehacen TODAS las celdas de TODAS las filas
+ * cargadas, aunque el 97% no haya cambiado.
+ *
+ * Con scroll infinito eso escala mal. Medido con este mismo test:
+ *
+ * | filas cargadas | celdas al agregar un lote de 40 |
+ * |---|---|
+ * | 40    | 240   |
+ * | 200   | 720   |
+ * | 1.000 | **3.120** |
+ *
+ * Debería ser 120 en los tres casos: sólo las 40 filas nuevas × 3 columnas. El
+ * costo crece con el total, así que una sesión de scroll que carga 1.000 filas
+ * en 25 lotes hace ~40.000 renders de celda en vez de ~3.000.
+ *
+ * No se ve como un bug: la lista muestra lo correcto. Se ve como que "la app va
+ * pesada cuando hay muchos datos".
+ *
+ * ## Qué fija este test
+ *
+ * El número de HOY, para que el día que se memoice la fila esto se ponga rojo y
+ * haya que bajarlo a propósito, con la mejora medida al lado. Es un termómetro,
+ * no una prohibición: si sube, alguien empeoró el escalado sin darse cuenta.
+ *
+ * ⚠️ Cuenta llamadas a `onRender` de cada columna, no nodos del DOM: lo que
+ * importa es el trabajo de React, no cuántos `<span>` quedaron.
+ */
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    store: {},
+    setStore: vi.fn(),
+    user: { id: 1 },
+    userCan: () => true,
+    showToast: vi.fn(),
+  }),
+}));
+vi.mock("@/mk/hooks/useMediaQuery", () => ({ default: () => false }));
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) mocked[key] = () => null;
+  return mocked;
+});
+
+import Table from "@/mk/components/ui/Table/Table";
+
+const LOTE = 40;
+
+const filas = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `r${i}`,
+    name: `Fila ${i}`,
+    tipo: "X",
+    estado: "Activo",
+  }));
+
+/** Cada llamada a `onRender` es una celda que React volvió a construir. */
+const armarHeader = (contador: { n: number }) =>
+  ["name", "tipo", "estado"].map((key) => ({
+    key,
+    // `responsive` es obligatorio en el tipo de columna de `Table`.
+    responsive: "",
+    label: key,
+    onRender: (p: any) => {
+      contador.n++;
+      return p?.item?.[key];
+    },
+  }));
+
+const celdasAlAgregarUnLote = (yaCargadas: number) => {
+  const contador = { n: 0 };
+  const header = armarHeader(contador);
+
+  const { rerender } = render(<Table header={header} data={filas(yaCargadas)} />);
+
+  contador.n = 0;
+  rerender(<Table header={header} data={filas(yaCargadas + LOTE)} />);
+
+  return contador.n;
+};
+
+describe("Table: qué cuesta un 'cargar más'", () => {
+  it("hoy re-renderiza TODAS las filas cargadas, no sólo el lote nuevo", () => {
+    const conPocas = celdasAlAgregarUnLote(40);
+    const conMuchas = celdasAlAgregarUnLote(1000);
+
+    // El ideal sería que las dos dieran lo mismo: sólo el lote nuevo.
+    const ideal = LOTE * 3;
+
+    expect(conPocas).toBeGreaterThan(ideal);
+    expect(conMuchas).toBeGreaterThan(ideal);
+
+    // 🔴 El costo crece con el total ya cargado. Esto es lo que hay que romper
+    // el día que se memoice la fila.
+    expect(
+      conMuchas / conPocas,
+      `Con 1.000 filas cargadas, agregar 40 costó ${conMuchas} celdas; con 40 cargadas costó ${conPocas}. ` +
+        "Si esta proporción bajó a ~1, alguien memoizó la fila: bajá los números de este test y dejá la mejora medida en el docblock.",
+    ).toBeGreaterThan(5);
+  });
+
+  it("deja anotado el número exacto de hoy, para comparar cuando se mejore", () => {
+    expect(celdasAlAgregarUnLote(40)).toBe(240);
+    expect(celdasAlAgregarUnLote(200)).toBe(720);
+    expect(celdasAlAgregarUnLote(1000)).toBe(3120);
+  });
+});

--- a/src/mk/components/ui/Table/__tests__/tablaEscalaAlCargarMas.test.tsx
+++ b/src/mk/components/ui/Table/__tests__/tablaEscalaAlCargarMas.test.tsx
@@ -5,33 +5,34 @@ import React from "react";
 /**
  * Cuánto cuesta un "cargar más" cuando ya hay filas en pantalla.
  *
- * ## 🔴 Lo medido el 2026-08-13
+ * ## 🔴 El problema, medido el 2026-08-13
  *
- * `Table` dibuja cada fila y cada celda dentro de un `.map()` en su propio
- * cuerpo. No hay componente de fila, así que **no hay nada que memoizar**: cada
- * vez que `Table` se renderiza, se rehacen TODAS las celdas de TODAS las filas
- * cargadas, aunque el 97% no haya cambiado.
+ * `Table` dibujaba cada fila y cada celda dentro de un `.map()` en su propio
+ * cuerpo. No había componente de fila, así que **no había nada que memoizar**:
+ * cada render rehacía todas las celdas de todas las filas cargadas, aunque no
+ * hubiera cambiado ninguna.
  *
- * Con scroll infinito eso escala mal. Medido con este mismo test:
+ * Con scroll infinito escalaba mal, porque el costo crecía con el total:
  *
- * | filas cargadas | celdas al agregar un lote de 40 |
- * |---|---|
- * | 40    | 240   |
- * | 200   | 720   |
- * | 1.000 | **3.120** |
+ * | filas cargadas | celdas al agregar un lote de 40 | hoy |
+ * |---|---|---|
+ * | 40    | 240       | 120 |
+ * | 200   | 720       | 120 |
+ * | 1.000 | **3.120** | 120 |
  *
- * Debería ser 120 en los tres casos: sólo las 40 filas nuevas × 3 columnas. El
- * costo crece con el total, así que una sesión de scroll que carga 1.000 filas
- * en 25 lotes hace ~40.000 renders de celda en vez de ~3.000.
+ * Una sesión que cargaba 1.000 filas en 25 lotes hacía ~40.000 renders de celda
+ * en vez de ~3.000. No se veía como un bug —la lista muestra lo correcto—, se
+ * veía como que la app va pesada cuando hay muchos datos.
  *
- * No se ve como un bug: la lista muestra lo correcto. Se ve como que "la app va
- * pesada cuando hay muchos datos".
+ * Arreglado extrayendo `Row` como componente memoizado y estabilizando las props
+ * que le bajan.
  *
- * ## Qué fija este test
+ * ## Qué cuida este test
  *
- * El número de HOY, para que el día que se memoice la fila esto se ponga rojo y
- * haya que bajarlo a propósito, con la mejora medida al lado. Es un termómetro,
- * no una prohibición: si sube, alguien empeoró el escalado sin darse cuenta.
+ * Que el número **no vuelva a crecer con el total**. Alcanza con que una prop de
+ * la fila —`header`, `onRowClick`, `onContextMenu`, `extraData`— vuelva a
+ * cambiar de identidad en cada render para que el memo deje de pegar y nadie se
+ * entere: la lista sigue mostrando lo correcto, sólo que otra vez lenta.
  *
  * ⚠️ Cuenta llamadas a `onRender` de cada columna, no nodos del DOM: lo que
  * importa es el trabajo de React, no cuántos `<span>` quedaron.
@@ -79,41 +80,53 @@ const armarHeader = (contador: { n: number }) =>
     },
   }));
 
+/**
+ * ⚠️ Las filas ya cargadas CONSERVAN su objeto; sólo se agregan las nuevas.
+ *
+ * Es lo que hace `mergeRowsById` de `useCrud` en un "cargar más": las páginas
+ * que llegan traen ids nuevos, así que las filas viejas nunca se reemplazan.
+ *
+ * La primera versión de este test recreaba TODAS las filas en cada lote, y con
+ * eso el memo de la fila no puede pegar nunca: medía un escenario que la app no
+ * produce, y hacía parecer que memoizar no servía de nada.
+ */
 const celdasAlAgregarUnLote = (yaCargadas: number) => {
   const contador = { n: 0 };
   const header = armarHeader(contador);
 
-  const { rerender } = render(<Table header={header} data={filas(yaCargadas)} />);
+  const cargadas = filas(yaCargadas);
+  const { rerender } = render(<Table header={header} data={cargadas} />);
 
   contador.n = 0;
-  rerender(<Table header={header} data={filas(yaCargadas + LOTE)} />);
+  const conElLoteNuevo = [...cargadas, ...filas(LOTE).map((f, i) => ({ ...f, id: `nueva${i}` }))];
+  rerender(<Table header={header} data={conElLoteNuevo} />);
 
   return contador.n;
 };
 
 describe("Table: qué cuesta un 'cargar más'", () => {
-  it("hoy re-renderiza TODAS las filas cargadas, no sólo el lote nuevo", () => {
+  it("cuesta lo mismo con 40 filas cargadas que con 1.000", () => {
     const conPocas = celdasAlAgregarUnLote(40);
     const conMuchas = celdasAlAgregarUnLote(1000);
 
-    // El ideal sería que las dos dieran lo mismo: sólo el lote nuevo.
-    const ideal = LOTE * 3;
-
-    expect(conPocas).toBeGreaterThan(ideal);
-    expect(conMuchas).toBeGreaterThan(ideal);
-
-    // 🔴 El costo crece con el total ya cargado. Esto es lo que hay que romper
-    // el día que se memoice la fila.
     expect(
-      conMuchas / conPocas,
-      `Con 1.000 filas cargadas, agregar 40 costó ${conMuchas} celdas; con 40 cargadas costó ${conPocas}. ` +
-        "Si esta proporción bajó a ~1, alguien memoizó la fila: bajá los números de este test y dejá la mejora medida en el docblock.",
-    ).toBeGreaterThan(5);
+      conMuchas,
+      `Agregar un lote de 40 sobre 1.000 filas costó ${conMuchas} celdas y sobre 40 filas costó ${conPocas}. ` +
+        "Si el número creció con el total, el memo de `Row` dejó de pegar: casi seguro alguna prop que baja a la fila " +
+        "(`header`, `onRowClick`, `onContextMenu`, `extraData`) volvió a cambiar de identidad en cada render.",
+    ).toBe(conPocas);
   });
 
-  it("deja anotado el número exacto de hoy, para comparar cuando se mejore", () => {
-    expect(celdasAlAgregarUnLote(40)).toBe(240);
-    expect(celdasAlAgregarUnLote(200)).toBe(720);
-    expect(celdasAlAgregarUnLote(1000)).toBe(3120);
+  it("sólo re-renderiza el lote nuevo, no lo que ya estaba", () => {
+    // 🔴 Los números de antes de memoizar la fila (medidos el 2026-08-13):
+    //      40 cargadas   →   240
+    //      200 cargadas  →   720
+    //      1.000 cargadas → 3.120
+    //    Crecían con el total. Ahora son constantes: sólo el lote nuevo.
+    const soloElLoteNuevo = LOTE * 3;
+
+    expect(celdasAlAgregarUnLote(40)).toBe(soloElLoteNuevo);
+    expect(celdasAlAgregarUnLote(200)).toBe(soloElLoteNuevo);
+    expect(celdasAlAgregarUnLote(1000)).toBe(soloElLoteNuevo);
   });
 });

--- a/src/mk/hooks/useCrud/__tests__/useCrudDataNoCambiaDeIdentidadPorGusto.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrudDataNoCambiaDeIdentidadPorGusto.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act, waitFor } from "@testing-library/react";
+import React from "react";
+
+/**
+ * `data` no puede cambiar de identidad si los datos no cambiaron.
+ *
+ * ## 🔴 Qué se rompía (medido el 2026-08-13 en `/owners`)
+ *
+ * Los módulos arman `mod` como objeto literal DENTRO del componente: **23 de
+ * los 40 consumidores** lo hacen así, y con `fields` es peor —35 de 40, afuera
+ * CERO—. O sea que en cada render llega una identidad nueva.
+ *
+ * `getListRowsFromResponse` tenía `[mod, params]` en sus dependencias, así que
+ * se recreaba en cada render. Y como es dependencia del `useMemo` de
+ * `resolvedData` —que en el camino de scroll infinito **arma un objeto nuevo
+ * cada vez que corre**—, la lista entera recibía datos nuevos sin que hubiera
+ * cambiado un solo dato.
+ *
+ * Medido abriendo `/owners`: **`data` cambiaba de identidad 10 veces seguidas**
+ * sin que cambiara ningún otro estado del hook. Al buscar, 6 veces más.
+ *
+ * No es un bug visible —la pantalla muestra lo correcto—, y por eso sobrevivió:
+ * cuesta memoria y velocidad, que no se ven en una captura.
+ *
+ * ## ⚠️ La primera versión de este test no medía nada
+ *
+ * Usaba `perPage: -1` y un `useAxios` que devolvía `data: null`. Con `data` en
+ * null, `resolvedData` corta en la primera línea y devuelve `null` siempre:
+ * `null === null`, identidad estable, verde eterno. Reinyecté el bug y quedó
+ * **verde igual**.
+ *
+ * Por eso acá se monta el camino REAL: scroll infinito (`perPage: 20`) y una
+ * respuesta con filas de verdad. Reinyección medida: con `[mod, params]` de
+ * vuelta en las dependencias, da **rojo** — 3 identidades donde debería haber 1.
+ */
+
+const execute = vi.fn();
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({
+    data: null,
+    reLoad: vi.fn(),
+    execute,
+    loaded: true,
+    error: null,
+    cancel: vi.fn(),
+    waiting: 0,
+    setWaiting: vi.fn(),
+  }),
+}));
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: 1 },
+    userCan: () => true,
+    store: {},
+    setStore: vi.fn(),
+    showToast: vi.fn(),
+  }),
+}));
+
+vi.mock("@/mk/components/ui/Table/Table", () => ({
+  default: () => <div data-testid="table-mock" />,
+}));
+vi.mock("@/mk/components/ui/Pagination/Pagination", () => ({ default: () => null }));
+vi.mock("@/mk/hooks/useCrud/FormElement", () => ({ default: () => null }));
+vi.mock("@/mk/components/forms/DataSearch/DataSearch", () => ({ default: () => null }));
+vi.mock("@/mk/components/data/ImportDataModal/ImportDataModal", () => ({ default: () => null }));
+vi.mock("@/mk/components/ui/DetailModal/DetailModal", () => ({ default: () => null }));
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({ default: () => null }));
+vi.mock("@/mk/components/ui/NewModal/NewModal", () => ({ default: () => null }));
+vi.mock("@/mk/components/forms/FloatButton/FloatButton", () => ({ default: () => null }));
+vi.mock("@/components/NoData/EmptyData", () => ({ default: () => null }));
+vi.mock("@/mk/hooks/useMediaQuery", () => ({ default: () => false }));
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) mocked[key] = () => null;
+  return mocked;
+});
+
+import useCrud, { ModCrudType } from "../useCrud";
+
+/** `useCrud` normaliza el perPage del módulo (20) a su lote mínimo. */
+const LOTE = 40;
+
+const filas = (desde: number, cuantas: number) =>
+  Array.from({ length: cuantas }, (_, i) => ({
+    id: `r-${desde + i}`,
+    name: `Fila ${desde + i}`,
+  }));
+
+const paginaOk = (p: any) => ({
+  data: {
+    data: filas((Number(p?.page || 1) - 1) * LOTE + 1, LOTE),
+    message: { total: 200 },
+  },
+  error: null,
+});
+
+/**
+ * Reproduce lo que hace un módulo real: `mod` y `fields` se declaran ADENTRO
+ * del componente, así que son objetos nuevos en cada render. Declararlos afuera
+ * haría pasar el test sin medir nada.
+ */
+const montar = () => {
+  const datas: any[] = [];
+  let forzarRender: (() => void) | null = null;
+
+  const Comp = () => {
+    const [, setTick] = React.useState(0);
+    forzarRender = () => setTick((t) => t + 1);
+
+    const mod: ModCrudType = {
+      modulo: "owners",
+      singular: "residente",
+      plural: "residentes",
+      permiso: "owners",
+    } as ModCrudType;
+
+    const fields = {
+      id: { rules: [], api: "e" },
+      name: { rules: [], api: "ae", label: "Nombre", list: {} },
+    };
+
+    const crud = useCrud({
+      paramsInitial: { page: 1, perPage: 20, fullType: "L", searchBy: "" },
+      mod,
+      fields,
+    });
+
+    datas.push(crud.data);
+    return null;
+  };
+
+  render(<Comp />);
+  return { datas, forzarRender: () => act(() => forzarRender?.()) };
+};
+
+describe("useCrud: la identidad de `data`", () => {
+  beforeEach(() => {
+    execute.mockReset();
+    execute.mockImplementation(async (_url: any, _method: any, p: any) => paginaOk(p));
+  });
+
+  it("no cambia cuando se re-renderiza sin que cambien los datos", async () => {
+    const { datas, forzarRender } = montar();
+
+    // Sin filas cargadas el memo corta antes de llegar a la parte que importa.
+    await waitFor(() => expect(datas.at(-1)?.data?.length).toBe(LOTE));
+
+    const desde = datas.length;
+    forzarRender();
+    forzarRender();
+    forzarRender();
+
+    const trasRerender = datas.slice(desde - 1);
+    const identidades = new Set(trasRerender).size;
+
+    expect(
+      identidades,
+      `\`data\` cambió de identidad ${identidades} veces en ${trasRerender.length} renders sin que cambiaran los datos. ` +
+        "Casi seguro alguien volvió a meter `mod`, `fields` o `params` en las dependencias de `getListRowsFromResponse` " +
+        "o del memo de `resolvedData`: los módulos los arman adentro del componente, así que llegan con identidad nueva en cada render.",
+    ).toBe(1);
+  });
+
+  it("sobrevive a diez renders seguidos con `mod` y `fields` nuevos cada vez", async () => {
+    const { datas, forzarRender } = montar();
+    await waitFor(() => expect(datas.at(-1)?.data?.length).toBe(LOTE));
+
+    // Diez renders seguidos: el escenario exacto que se midió en `/owners`.
+    for (let i = 0; i < 10; i++) forzarRender();
+
+    expect(new Set(datas.slice(-10)).size).toBe(1);
+  });
+});

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -498,16 +498,44 @@ const useCrud = ({
     INFINITE_PREFETCH_ROWS,
     Math.round(Number(infiniteBatchSize || INFINITE_BATCH_SIZE) * 0.5),
   );
+  /**
+   * 🔴 `mod` y `params` se leen por REF, no por dependencia.
+   *
+   * Los módulos arman `mod` como objeto literal DENTRO del componente, así que
+   * es una identidad nueva en cada render. Medido el 2026-08-13 sobre los 40
+   * consumidores: 23 lo declaran adentro, y `fields` lo hace 35 de 40 —afuera,
+   * CERO—. Con `mod` en las dependencias, este `useCallback` se recreaba en cada
+   * render, y como es dependencia de `resolvedData`, el memo de los datos se
+   * invalidaba también.
+   *
+   * El efecto medido en `/owners`: **`data` cambiaba de identidad 10 veces
+   * seguidas** sin que cambiara ningún otro estado. Cada una de esas veces
+   * re-renderiza la lista entera y arma un objeto nuevo — el costo es memoria y
+   * velocidad, no un bug visible, que es justamente por qué nadie lo vio.
+   *
+   * Leerlos por ref es correcto acá: esta función se ejecuta cuando llega una
+   * respuesta, no durante el render, así que `.current` siempre tiene el valor
+   * de ese momento. Es el mismo patrón que ya usa `useAxios` para `setWaiting`.
+   */
+  const modRef = useRef(mod);
+  const paramsRef = useRef(params);
+  modRef.current = mod;
+  paramsRef.current = params;
+
   const getListRowsFromResponse = useCallback(
-    (response: any, sourceParams: Record<string, any> = params) => {
-      if (mod.getListRows) {
-        const customRows = mod.getListRows(response, sourceParams);
+    (response: any, sourceParams?: Record<string, any>) => {
+      const currentMod = modRef.current;
+      if (currentMod.getListRows) {
+        const customRows = currentMod.getListRows(
+          response,
+          sourceParams ?? paramsRef.current,
+        );
         return Array.isArray(customRows) ? customRows : [];
       }
 
       return Array.isArray(response?.data) ? response.data : [];
     },
-    [mod, params],
+    [],
   );
 
   const beginListReset = useCallback(() => {


### PR DESCRIPTION
Tercer trabajo del sprint transversal. **Encadenado sobre #680** — se mergea después de ese.

## 🔴 Lo primero: la premisa del plan estaba parcialmente equivocada

El plan decía *"`useCrud` devuelve el JSX de la lista, y mientras lo haga ningún módulo puede arreglar sus re-renders"*. Medí antes de refactorizar:

- **`List` ya es un componente estable.** Vive en un `useRef` creado una sola vez y lee el runtime de otro ref. Los consumidores hacen `return <List height="100%" />`. Ese trabajo ya estaba hecho.
- **Tipear en la búsqueda cuesta cero re-renders.** 7 letras = 0 renders del hook y 0 de `List`.
- Los "5 montajes" que creí ver eran un **artefacto de mi propio contador global**. Con un contador de montaje real: 2 montajes / 1 desmontaje = StrictMode en dev.

**Por eso este PR no parte `useCrud`.** Partir 2.662 líneas que tocan 73 archivos sería el mayor riesgo del sprint para arreglar algo que no es el problema.

## Lo que sí costaba, medido

### 1. La cascada de identidad de `data`

Abriendo `/owners`, **`data` cambiaba de identidad diez veces seguidas** sin que cambiara ningún otro estado del hook. Al buscar, seis más.

La raíz: los módulos arman `mod` y `fields` como objetos literales **dentro** del componente.

| prop | adentro (inestable) | afuera (estable) |
|---|---|---|
| `mod` | 23 de 40 | 8 |
| `fields` | **35 de 40** | **cero** |

`getListRowsFromResponse` los tenía en sus dependencias → se recreaba cada render → invalidaba el memo de `resolvedData`, que en el camino de scroll infinito **arma un objeto nuevo cada vez que corre**.

Arreglado en la raíz, no en los 40 consumidores: `mod` y `params` por ref. Correcto porque esa función corre cuando llega la respuesta, no durante el render — mismo patrón que ya usa `useAxios` para `setWaiting`.

| recorrido | antes | después |
|---|---|---|
| abrir `/owners` — identidades de `data` | 10 | **2** |
| buscar — renders del hook | 12 | **9** |
| buscar — identidades de `data` | 6 | **3** |

### 2. La fila de la tabla no era un componente

`Table` dibujaba cada fila y cada celda dentro de su propio `.map()`, así que **no había nada que memoizar**: cada render rehacía todas las celdas de todas las filas cargadas.

| filas cargadas | celdas al agregar un lote de 40 | ahora |
|---|---|---|
| 40 | 240 | **120** |
| 200 | 720 | **120** |
| 1.000 | **3.120** | **120** |

El costo **dejó de crecer con el total**. Una sesión de scroll que carga 1.000 filas en 25 lotes hacía ~40.000 renders de celda; ahora hace ~3.000.

No se veía como un bug —la lista muestra lo correcto—, se veía como que la app va pesada cuando hay muchos datos.

## ⚠️ Medí mal dos veces antes de medir bien

Las dos quedaron documentadas en el código, porque las dos casi hacen abandonar el trabajo:

1. **El primer test recreaba todas las filas en cada lote.** Con eso el memo no puede pegar nunca: medía un escenario que la app no produce, y decía que extraer la fila no servía de nada. `mergeRowsById` conserva el objeto de cada fila ya cargada.
2. **Extraer la fila sin tocar `_onRowClick` tampoco cambiaba nada.** Era una función suelta: identidad nueva por render, baja como prop a cada fila, invalida el memo de todas. Lo encontré con un comparador temporal que loguea **qué prop** rompe el memo, no adivinando.

## Verificación

Dos reinyecciones, las dos en rojo con el número exacto:
- Con `[mod, params]` de vuelta: **10 identidades en 10 renders**.
- Sacando el `memo` de `Row`: **3.120 celdas contra 240**.

Quedan dos tests que lo fijan. El de `Table` es un termómetro: compara el costo con 40 filas contra el costo con 1.000, así que si alguien desestabiliza una prop de la fila —`header`, `onRowClick`, `onContextMenu`, `extraData`— se pone rojo. Sin eso nadie se enteraría: la lista sigue mostrando lo correcto, sólo que otra vez lenta.

95 archivos y 655 tests en verde, `tsc` sin cambios. Verificado en el navegador: la lista renderiza y el click en la fila sigue abriendo el detalle.
