### PR TITLE
fix(deploy): destrabar Vercel — pnpm 9 exige `packages` e ignora los overrides del workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,12 @@
     "react-scan": "^0.3.4",
     "typescript": "^5",
     "vitest": "^4.1.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "postcss": "^8.5.26",
+      "sharp": "^0.35.0",
+      "@babel/core": "^7.29.1"
+    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,20 +1,40 @@
+# 🔴 `packages` tiene que estar, aunque este repo no sea un monorepo.
+#
+# Vercel corre pnpm 9 (lo elige por el lockfileVersion y la fecha de creación
+# del proyecto). pnpm 9 exige este campo apenas ve el archivo, y sin él corta
+# la instalación con "packages field missing or empty" — el deploy no arranca.
+# Medido el 2026-08-13 contra pnpm 9.15.9.
+packages:
+  - "."
+
 allowBuilds:
   esbuild: true
   msw: true
   sharp: true
   unrs-resolver: true
 
-# Next pins its own copies of these, and they are older than the ones with the
-# security fix. The pins are transitive, so bumping our own dependency does not
-# reach them: only an override does.
+# Next fija por su cuenta copias más viejas de estos tres, y las fija de forma
+# transitiva, así que subir nuestra propia dependencia no las alcanza: sólo un
+# override llega.
 #
-#   postcss      next pins 8.4.31 — arbitrary file read + path traversal in the
-#                source-map reader, fixed in 8.5.23. Same minor line we already
-#                use directly, so this only deduplicates to one copy.
-#   sharp        next pins 0.34.5 — inherited libvips CVEs, fixed in 0.35.0.
-#   @babel/core  arbitrary file read via sourceMappingURL, fixed in 7.29.1.
+#   postcss      next fija 8.4.31 — lectura arbitraria de archivos y path
+#                traversal en el lector de source maps, arreglado en 8.5.23.
+#                Es la misma línea menor que ya usamos directo, así que esto
+#                sólo deja una copia en vez de dos.
+#   sharp        next fija 0.34.5 — CVEs heredados de libvips, arreglado en 0.35.0.
+#   @babel/core  lectura arbitraria de archivos vía sourceMappingURL, en 7.29.1.
 #
-# Verified against a real production build and the running app before merging.
+# 🔴 Estos mismos overrides están DUPLICADOS en package.json, bajo `pnpm`.
+# No es un descuido: cada gestor lee uno solo de los dos.
+#
+#   pnpm 11 (local)   lee este archivo e IGNORA el de package.json, avisando
+#                     por stderr y siguiendo de largo.
+#   pnpm 9 (Vercel)   al revés: lee el de package.json e ignora este, en
+#                     silencio y sin avisar nada.
+#
+# Si se toca uno hay que tocar el otro. Con sólo este archivo, Vercel compila
+# en VERDE y se lleva postcss 8.4.31 y sharp 0.34.5 de vuelta — o sea, un
+# deploy exitoso con las vulnerabilidades adentro. Medido, no supuesto.
 overrides:
   postcss: ^8.5.26
   sharp: ^0.35.0


### PR DESCRIPTION
Arregla el deploy de `dev`, que quedó cortado por el PR #684.

```
ERROR  packages field missing or empty
Error: Command "pnpm install" exited with 1
```

## Qué pasó

Vercel corre **pnpm 9**, no pnpm 11. Lo elige por el lockfileVersion y la fecha de creación del proyecto, y lo dice en el propio log:

```
Detected `pnpm-lock.yaml` 9 which may be generated by pnpm@9.x or pnpm@10.x
Using pnpm@9.x based on project creation date
```

pnpm 9 se comporta distinto en dos cosas, las dos medidas contra 9.15.9:

1. **Apenas ve un `pnpm-workspace.yaml` exige el campo `packages`**, aunque el repo no sea un monorepo. Sin él corta la instalación. Eso era el error.
2. **No lee `overrides:` de ese archivo.** Lee `pnpm.overrides` de `package.json` — justo de donde pnpm 11 los sacó.

## 🔴 La trampa: agregar sólo `packages` deja el deploy en VERDE y sin los arreglos

Lo probé primero así. pnpm 9 instaló sin quejarse... resolviendo `postcss` a 8.4.31 y `sharp` a 0.34.5. Un deploy exitoso con las vulnerabilidades que el #684 venía a cerrar, y ningún check avisando nada.

Por eso los overrides van **duplicados** en los dos archivos:

| | lee | ignora |
|---|---|---|
| pnpm 11 (local) | `pnpm-workspace.yaml` | `package.json` — avisa por stderr |
| pnpm 9 (Vercel) | `package.json` | `pnpm-workspace.yaml` — **en silencio** |

Si se toca uno hay que tocar el otro. Queda escrito en `pnpm-workspace.yaml`, que es donde alguien va a mirar primero.

## Por qué el #684 no lo vio

Ahí escribí que el archivo se había ignorado "cuando sólo tenía `allowBuilds`". Lo supuse, no lo verifiqué. Estaba ignorado exactamente por esto: `56846365` lo había commiteado y el 2026-05-19 lo sacaron.

⚠️ Los checks tampoco lo iban a agarrar. El de Vercel figura como **"Canceled by Ignored Build Step"**, así que en un PR nunca corre una instalación de verdad — el fallo sólo aparece al mergear a `dev`.

## Verificación

**`pnpm install` completo con pnpm 9.15.9**, el mismo comando que corre Vercel, sobre copias exactas de los tres archivos:

| | resuelto |
|---|---|
| `@babel/core` | 7.29.7 |
| `postcss` | 8.5.26 |
| `sharp` | 0.35.3 |
| versiones viejas presentes | **ninguna** |

El lockfile quedó **byte a byte igual**, o sea que pnpm 9 lo aceptó tal cual en vez de re-resolver.

Con **pnpm 11** en local, sin cambios contra la línea base:

| | |
|---|---|
| `pnpm install --frozen-lockfile` | ok |
| `tsc --noEmit` | 29 errores (los de siempre) |
| `vitest` | 659 verdes / 96 archivos |
| `next build` | ok |