### PR TITLE
chore: sacar el gitlink huérfano de .worktrees y dejar de versionar la carpeta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,17 @@ WARP.md
 #package-lock.json
 package-lock.json
 
+# Los worktrees efímeros de los tickets viven acá y no se versionan.
+#
+# Git guarda un worktree anidado como gitlink (modo 160000), o sea como si
+# fuera un submódulo. Eso ya pasó: `.worktrees/cdt-34-ver-recibo` quedó
+# commiteado apuntando a un commit suelto, y cada build de Vercel arrancaba con
+#
+#     Warning: Failed to fetch one or more git submodules
+#
+# El directorio ya no existía, así que el puntero quedó huérfano.
+.worktrees/
+
 # pnpm-workspace.yaml is versioned on purpose. It holds the dependency overrides
 # that pull the security fixes into packages next pins for itself, and pnpm
 # records those same overrides inside pnpm-lock.yaml. If the file is missing, the


### PR DESCRIPTION
Cada build de Vercel arrancaba con:

```
Warning: Failed to fetch one or more git submodules
```

Git guarda un worktree anidado como **gitlink** (modo `160000`), o sea como si fuera un submódulo. En `f91e27fd` se commiteó `.worktrees/cdt-34-ver-recibo` apuntando a un commit suelto; el directorio después dejó de existir, así que el puntero quedó huérfano y Vercel intentaba resolverlo en cada clone.

Se saca del índice con `git rm --cached`: el aviso desaparece y **no se toca ningún worktree del disco**. `.worktrees/` pasa al `.gitignore` para que no vuelva a entrar solo.

⚠️ `.worktrees/cdt-31-grafica-balance` está **vivo**, en su propia rama `cdt-31-grafica-balance`. No se tocó — lo único que cambia es que deja de poder colarse al índice por accidente.