### PR TITLE
fix(reportes): aceptar 200 al encolar, no sólo 202 — nginx se come el CORS de los 202

### DIFF
--- a/src/mk/hooks/useAsyncExport/__tests__/elEncoladoSeAceptaCon200Y202.test.ts
+++ b/src/mk/hooks/useAsyncExport/__tests__/elEncoladoSeAceptaCon200Y202.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Encolar un reporte se acepta con 200 igual que con 202.
+ *
+ * ## 🔴 Qué se rompía (medido el 2026-08-14 en el servidor de dev)
+ *
+ * Ningún reporte de lista se podía bajar: el admin decía "Failed to fetch" y el
+ * log de Laravel decía lo contrario —job iniciado, job completado, PDF de
+ * 103 KB escrito—. El síntoma no apuntaba a nada.
+ *
+ * La causa estaba en el servidor, no en el código. nginx esconde el
+ * `Access-Control-Allow-Origin` que pone Laravel y lo vuelve a agregar con
+ * `add_header` SIN el flag `always`. Sin `always`, `add_header` sólo se aplica
+ * a una lista fija de estados:
+ *
+ *     200, 201, 204, 206, 301, 302, 303, 304, 307, 308
+ *
+ * El 202 no está en esa lista. La respuesta llegaba sin esa cabecera y el
+ * navegador la descartaba entera: en DevTools se veía el 202 en rojo y acá
+ * llegaba un "Failed to fetch" pelado.
+ *
+ * Medido contra el servidor real, con `Origin` puesto:
+ *
+ *     POST /api/v3/adm-login   200   trae allow-origin
+ *     OPTIONS (preflight)      204   trae allow-origin
+ *     export de reportes       202   NO la trae
+ *     sin token                401   NO la trae
+ *
+ * Y como TODO export de lista salía por un 202, fallaban TODOS los reportes y
+ * nada más. El recibo de pagos seguía andando porque va por un 200 y después
+ * abre el PDF con `window.open()`, una navegación donde CORS ni se aplica.
+ *
+ * Por eso el back pasó a responder 200 al encolar.
+ *
+ * ## Qué cuida este test
+ *
+ * Que se acepten LOS DOS códigos. No es un detalle:
+ *
+ *   - Sin el 200, el front vuelve a romperse contra el back de hoy.
+ *   - Sin el 202, se rompe el día que alguien le ponga `always` al nginx y el
+ *     back vuelva al código correcto.
+ *
+ * Aceptar los dos es lo que permite que los dos lados se desplieguen en
+ * cualquier orden, y que volver a 202 no necesite coordinar nada.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useAsyncExport } from "../useAsyncExport";
+
+vi.mock("@/mk/hooks/useToast", () => ({
+  default: () => ({ showToast: vi.fn() }),
+}));
+
+/**
+ * Responde el encolado con el status pedido y después deja el polling en
+ * "pending", que alcanza: acá sólo interesa si el encolado se aceptó.
+ */
+const stubFetch = (statusDelEncolado: number) => {
+  let primera = true;
+  const fetchMock = vi.fn(async () => {
+    if (primera) {
+      primera = false;
+      return {
+        ok: true,
+        status: statusDelEncolado,
+        json: async () => ({ job_id: "job-1", status: "pending" }),
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "pending" }),
+    };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+const encolarCon = async (status: number) => {
+  stubFetch(status);
+  const { result } = renderHook(() =>
+    useAsyncExport({ type: "defaulters", endpoint: "/v3/defaulters" }),
+  );
+
+  await act(async () => {
+    await result.current.start({ format: "pdf" });
+  });
+
+  // ⚠️ El hook devuelve `{ state, start, reset, download }`, así que hay que
+  // entrar por `state`. La primera version de este test miraba
+  // `result.current.status` —que es `undefined`— y el `waitFor` de "que no sea
+  // idle" pasaba trivialmente: no medía nada.
+  await waitFor(() => expect(result.current.state.jobId).toBeTruthy());
+  return result;
+};
+
+describe("useAsyncExport: el status con el que el back acepta el encolado", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("acepta el 200 que devuelve el back de hoy", async () => {
+    const result = await encolarCon(200);
+
+    expect(
+      result.current.state.status,
+      'El back responde 200 al encolar (nginx se come el CORS de los 202) y el front lo trató como error. ' +
+        "Casi seguro alguien dejó el chequeo en `res.status === 202` a secas: tiene que aceptar los dos.",
+    ).not.toBe("failed");
+    expect(result.current.state.jobId).toBe("job-1");
+  });
+
+  it("sigue aceptando el 202, que es lo correcto y vuelve cuando se arregle nginx", async () => {
+    const result = await encolarCon(202);
+
+    expect(
+      result.current.state.status,
+      "Se dejó de aceptar el 202. El día que nginx lleve `always` el back vuelve a 202 " +
+        "y esto rompe todos los reportes de nuevo.",
+    ).not.toBe("failed");
+    expect(result.current.state.jobId).toBe("job-1");
+  });
+});

--- a/src/mk/hooks/useAsyncExport/useAsyncExport.ts
+++ b/src/mk/hooks/useAsyncExport/useAsyncExport.ts
@@ -406,7 +406,27 @@ export function useAsyncExport(
               body: JSON.stringify(params ?? {}),
             });
 
-        if (res.status === 202) {
+        // 🔴 200 y 202 son el MISMO caso: el reporte quedó encolado.
+        //
+        // Lo correcto para algo asíncrono es 202 Accepted, y así estaba. Pero
+        // en el servidor de dev nginx esconde el `Access-Control-Allow-Origin`
+        // que pone Laravel y lo vuelve a agregar con `add_header` SIN el flag
+        // `always`. Sin `always`, `add_header` sólo se aplica a una lista fija
+        // de estados:
+        //
+        //     200, 201, 204, 206, 301, 302, 303, 304, 307, 308
+        //
+        // El 202 no está en esa lista, así que la respuesta llegaba sin esa
+        // cabecera y el navegador la descartaba: en DevTools se veía el 202 en
+        // rojo y acá llegaba un "Failed to fetch" pelado, mientras el log del
+        // back decía que el job había terminado y el PDF estaba escrito.
+        //
+        // Medido el 2026-08-14 contra el servidor de dev: 200 y 204 traen la
+        // cabecera; 202, 401 y 404 no. Por eso el back pasó a devolver 200.
+        //
+        // Se aceptan los dos a propósito: el día que nginx lleve `always`, el
+        // back puede volver a 202 sin coordinar el despliegue de los dos lados.
+        if (res.status === 202 || res.status === 200) {
           const data = await res.json();
           setState((s) => ({
             ...s,


### PR DESCRIPTION
Ningún reporte de lista se podía bajar en el servidor de dev. El admin decía **"Failed to fetch"** y el log de Laravel decía lo contrario: job iniciado, job completado, PDF de 103 KB escrito.

## La causa

nginx esconde el `Access-Control-Allow-Origin` que pone Laravel y lo vuelve a agregar con `add_header` **sin el flag `always`**. Sin `always`, `add_header` sólo se aplica a una lista fija de estados:

> 200, 201, 204, 206, 301, 302, 303, 304, 307, 308

**El 202 no está en esa lista.** La respuesta llegaba sin esa cabecera y el navegador la descartaba entera: en DevTools se veía el 202 en rojo y el hook recibía un "Failed to fetch" pelado.

Medido contra el servidor de dev, con `Origin` puesto:

| | status | ¿trae `allow-origin`? |
|---|---|---|
| `POST /api/v3/adm-login` | 200 | 🟢 sí |
| `OPTIONS` (preflight) | 204 | 🟢 sí |
| export de reportes | **202** | 🔴 no |
| sin token | 401 | 🔴 no |
| ruta inexistente | 404 | 🔴 no |

Y como **todo** export de lista sale por un 202, fallaban **todos** los reportes y nada más. El recibo de pagos seguía andando porque va por un 200 y después abre el PDF con `window.open()` — una navegación, donde CORS ni se aplica. Esa fue la pista que partió el problema en dos.

## El cambio

El back pasa a responder **200** al encolar ([condaty2025-api#250](https://github.com/mariogfos/condaty2025-api/pull/250)). Acá se aceptan **los dos** códigos:

- sin el **200**, el front se rompe contra el back nuevo;
- sin el **202**, se rompe el día que nginx lleve `always` y el back vuelva al código correcto.

Aceptar los dos permite desplegar las dos puntas **en cualquier orden**, y que volver a 202 después no necesite coordinar nada.

⚠️ **Esto es un rodeo, no el arreglo de fondo.** El arreglo es `always` en nginx, que además destapa los 401 — hoy una sesión vencida también llega ilegible y se ve como "Failed to fetch". No hay acceso para tocar esa configuración.

## Verificación

Test nuevo con los dos casos, **reinyectado** dejando el chequeo en `=== 202` a secas: da rojo **sólo** el caso del 200, y el del 202 sigue verde.

⚠️ La primera versión del test **no medía nada**: miraba `result.current.status` cuando el hook devuelve `{ state, start, reset, download }`, así que leía `undefined` y el `waitFor` de "que no sea idle" pasaba trivialmente.

| | |
|---|---|
| `tsc --noEmit` | 29 errores (los de siempre) |
| `vitest` | **661 verdes / 97 archivos** |