### PR TITLE
fix(egresos): devolver al mod las cinco claves que perdió la mudanza a la factory (CDT-37, CDT-39)

### DIFF
--- a/src/mk/hooks/useCrud/__tests__/useCrudDetalleGenericoNoRevientaConUnObjeto.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrudDetalleGenericoNoRevientaConUnObjeto.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * CDT-39 (causa raíz compartida) — el Detail genérico y los valores objeto.
+ *
+ * El síntoma se reportó en Egresos, pero el defecto es del hook: el Detail
+ * genérico mete `item[key]` CRUDO adentro de `KeyValue` para todo campo que
+ * tenga label y no declare `onRender`. Si ese valor es un objeto —una relación
+ * que el back manda expandida en `fullType=DET`— React tira "Objects are not
+ * valid as a React child" al montar el modal, se desmonta el árbol ENTERO y la
+ * pantalla queda en negro.
+ *
+ * Egresos se arregló declarando su `renderView`, pero eso arregla UN módulo:
+ * cualquier otro sin `mod.renderView`, con una relación expandida y un label
+ * encima, cae exactamente igual. Por eso la guarda vive en el hook.
+ *
+ * `asRenderableValue` tiene un solo llamador —el `value` de `KeyValue` dentro
+ * del Detail genérico— y se exporta para poder medirlo sin montar el CRUD
+ * entero. Lo que se mide acá es el contrato: pasa todo lo que hoy funciona,
+ * descarta sólo lo que hoy revienta.
+ */
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { asRenderableValue } from "../useCrud";
+
+describe("asRenderableValue — lo que React puede pintar como hijo", () => {
+  it("deja pasar primitivos tal cual", () => {
+    expect(asRenderableValue("Mario")).toBe("Mario");
+    expect(asRenderableValue(0)).toBe(0);
+    expect(asRenderableValue(false)).toBe(false);
+    expect(asRenderableValue(null)).toBe(null);
+    expect(asRenderableValue(undefined)).toBe(undefined);
+  });
+
+  it("deja pasar elementos de React", () => {
+    const el = <span>hola</span>;
+    expect(asRenderableValue(el)).toBe(el);
+  });
+
+  it("deja pasar arrays de primitivos, que hoy se pintan concatenados", () => {
+    const arr = ["a", "b"];
+    expect(asRenderableValue(arr)).toBe(arr);
+  });
+
+  /**
+   * 🔴 Ésta es la línea del bug: `user` viene como objeto en `fullType=DET` y
+   * el campo "Responsable" de Egresos no declara `onRender`.
+   */
+  it("descarta un objeto pelado: es lo que dejaba la pantalla en negro", () => {
+    expect(
+      asRenderableValue({ id: "u-1", name: "Mario", last_name: "Guzmán" }),
+    ).toBe(null);
+  });
+
+  it("descarta un array con objetos adentro, que revienta igual", () => {
+    expect(asRenderableValue([{ id: 1 }, { id: 2 }])).toBe(null);
+  });
+});

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useRef,
   useMemo,
+  isValidElement,
 } from "react";
 import useAxios, { type MethodType } from "../useAxios";
 import { capitalize, getUrlImages } from "../../utils/string";
@@ -339,6 +340,39 @@ const mergeRowsById = (currentRows: any[] = [], incomingRows: any[] = []) => {
   });
 
   return merged;
+};
+
+/**
+ * Un valor que React puede pintar como hijo, o `null`.
+ *
+ * 🔴 CDT-39: el Detail genérico mete `item[key]` CRUDO adentro de `KeyValue`
+ * para todo campo que tenga label y no declare `onRender`. Un campo cuyo valor
+ * es un objeto —una relación que el back manda expandida en `fullType=DET`,
+ * como el `user` de Egresos— hace que React tire "Objects are not valid as a
+ * React child" al montar el modal. Eso no rompe el modal: rompe el árbol
+ * ENTERO, la pantalla queda en negro y el usuario reporta "deja de responder".
+ *
+ * El síntoma se vio en Egresos, pero el defecto es de acá: cualquier módulo sin
+ * `mod.renderView` con una relación expandida y un label encima cae igual. La
+ * guarda va en el punto por donde pasan todos y no en cada módulo.
+ *
+ * Se deja pasar TODO lo que hoy funciona —primitivos, elementos de React y
+ * arrays de primitivos— y sólo se descarta lo que hoy revienta. Un campo vacío
+ * es peor que el dato, pero es muchísimo mejor que la pantalla en negro; el
+ * módulo que quiera mostrarlo declara su `onRender`, que es justo lo que le
+ * faltaba a Egresos.
+ */
+const isRenderableChild = (value: any): boolean =>
+  value === null ||
+  value === undefined ||
+  typeof value !== "object" ||
+  isValidElement(value);
+
+export const asRenderableValue = (value: any) => {
+  if (Array.isArray(value)) {
+    return value.every(isRenderableChild) ? value : null;
+  }
+  return isRenderableChild(value) ? value : null;
 };
 
 const CrudRendererHost = memo(
@@ -1370,7 +1404,7 @@ const useCrud = ({
                                 item,
                                 i,
                               })
-                            : item[col.key]
+                            : asRenderableValue(item[col.key])
                         }
                       />
                       {col.onBottom && (

--- a/src/modulos/Outlays/Outlays.tsx
+++ b/src/modulos/Outlays/Outlays.tsx
@@ -8,9 +8,6 @@ import { formatNumber } from "@/mk/utils/numbers";
 import Button from "@/mk/components/forms/Button/Button";
 import { useRouter } from "next/navigation";
 import { getDateStrMes } from "@/mk/utils/date";
-import RenderForm from "./RenderForm/RenderForm";
-import RenderView from "./RenderView/RenderView";
-import RenderDel from "./RenderDel/RenderDel";
 
 import { IconIngresos } from "@/components/layout/icons/IconsBiblioteca";
 import DateRangeFilterModal from "@/components/DateRangeFilterModal/DateRangeFilterModal";
@@ -233,16 +230,23 @@ const Outlays = () => {
         },
       },
 
+      // 🔴 CDT-37: acá había un `form: { type: "select", options: () => [] }`.
+      // La lista vacía no era un placeholder inofensivo: mientras el `mod` se
+      // quedó sin `renderForm`, ESE era el campo que veía el usuario, y como es
+      // `required` y no ofrecía ninguna opción, no se podía registrar un egreso.
+      //
+      // El form de Egresos es propio (`RenderForm/RenderForm.tsx`): arma la
+      // Subcategoría filtrando `extraData.subcategories` por la categoría
+      // elegida. Este campo se declara igual porque `useCrud` lo necesita para
+      // validar (`rules`) y para armar el payload (`api: "ae"`) — el back
+      // colapsa `subcategory_id` dentro de `category_id` en `beforeCreate`, así
+      // que si el form dejara de mandar los DOS el egreso quedaría colgado del
+      // padre y la columna de abajo mostraría "-/-".
       subcategory_id: {
         rules: ["required"],
         api: "ae",
         label: "Subcategoría",
         order: 4,
-        form: {
-          type: "select",
-          disabled: (formState: { category_id: any }) => !formState.category_id,
-          options: () => [],
-        },
         list: {
           order: 4,
           onRender: (props: any) => {
@@ -382,6 +386,17 @@ const Outlays = () => {
         rules: [""],
         api: "ae",
         label: "Usuario",
+      },
+      // Los comprobantes que sube `UploadFileV3` viajan acá: el archivo ya está
+      // en el storage y `url_file` guarda las URLs. Hay que declararlo porque
+      // `getParamFields` arma el payload recorriendo ESTE objeto, y lo que no
+      // esté declarado no se manda: sin esta clave el egreso se crea igual, sin
+      // ningún comprobante y sin un solo mensaje de error.
+      // Sin `label` a propósito: el Detail genérico arma su header con todo
+      // campo que tenga uno, y este valor es una lista de URLs que no se lee.
+      url_file: {
+        rules: [],
+        api: "ae",
       },
       avatar: {
         rules: [],

--- a/src/modulos/Outlays/RenderForm/RenderForm.tsx
+++ b/src/modulos/Outlays/RenderForm/RenderForm.tsx
@@ -154,8 +154,14 @@ const RenderForm: React.FC<RenderFormProps> = ({
           subcategory_id: "",
         }));
         if (newValue && extraData?.subcategories) {
+          // Se compara como texto de los DOS lados. Antes era
+          // `subcat.category_id === Number(String(newValue))`: `===` contra un
+          // Number, así que alcanzaba con que la API mandara el `category_id`
+          // de la subcategoría como string —o el Select devolviera el id como
+          // texto— para que el filtro no encontrara nada y la Subcategoría
+          // quedara vacía. Mismo síntoma que CDT-37, otra causa.
           const filtered = extraData.subcategories.filter(
-            (subcat) => subcat.category_id === Number(String(newValue))
+            (subcat) => String(subcat.category_id) === String(newValue)
           );
           setFilteredSubcategories(filtered || []);
         } else {

--- a/src/modulos/Outlays/RenderView/RenderView.tsx
+++ b/src/modulos/Outlays/RenderView/RenderView.tsx
@@ -112,12 +112,24 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
     return { categoryName, subCategoryName };
   };
 
-  const getStatusText = (status: number | string) => {
-    const statusMap: Record<string, string> = {
-      A: "Pagado",
-      X: "Anulado",
+  /**
+   * 🔴 Segundo defecto de CDT-39, tapado por el primero.
+   *
+   * Este mapa estaba keyeado por los chars legacy `'A'` y `'X'`. `expenses.status`
+   * es numérico desde S140 (0 = anulado, 1 = pagado), así que ninguna key
+   * matcheaba y el `|| status` devolvía el número crudo: la fila "Estado" del
+   * detalle mostraba "1" en vez de "Pagado". No se veía porque sin `renderView`
+   * este archivo no se renderizaba desde el 2026-07-21.
+   *
+   * "Desconocido" y no el valor crudo: un número suelto en la fila "Estado" se
+   * lee como un dato del egreso, no como un defecto de la pantalla.
+   */
+  const getStatusText = (value: number) => {
+    const statusMap: Record<number, string> = {
+      [ExpenseStatus.ACTIVE]: "Pagado",
+      [ExpenseStatus.CANCELLED]: "Anulado",
     };
-    return statusMap[status] || status;
+    return statusMap[value] ?? "Desconocido";
   };
 
   if (!item) {
@@ -145,15 +157,21 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
   }
 
   const currentItem = item;
+  // El estado, normalizado UNA vez. Abajo se compara en cuatro lugares distintos
+  // (color, "Anulado por", "Motivo de anulación" y el botón de anular) y hasta
+  // ahora cada uno decidía por su cuenta si coercionaba o no: el botón hacía
+  // `Number(...)` y los otros tres comparaban con `===` contra el enum, así que
+  // un `status` que llegara como texto los apagaba a los tres sin un error.
+  const status = Number(currentItem.status);
 
   const { categoryName, subCategoryName } = item
     ? getCategoryNames()
     : { categoryName: "", subCategoryName: "" };
   const parsedDescription = parseExpenseDescription(item?.description);
 
-  const getStatusStyle = (status: number | string) => {
-    if (status === ExpenseStatus.ACTIVE) return styles.statusPaid;
-    if (status === ExpenseStatus.CANCELLED) return styles.statusCancelled;
+  const getStatusStyle = (value: number) => {
+    if (value === ExpenseStatus.ACTIVE) return styles.statusPaid;
+    if (value === ExpenseStatus.CANCELLED) return styles.statusCancelled;
     return "";
   };
 
@@ -324,7 +342,7 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
           })
         : "-/-",
     },
-    currentItem.status === ExpenseStatus.CANCELLED && currentItem.canceled_by
+    status === ExpenseStatus.CANCELLED && currentItem.canceled_by
       ? {
           key: "canceledBy",
           label: "Anulado por",
@@ -400,10 +418,10 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
     {
       key: "status",
       label: "Estado",
-      value: getStatusText(currentItem.status),
-      valueClassName: getStatusStyle(currentItem.status),
+      value: getStatusText(status),
+      valueClassName: getStatusStyle(status),
     },
-    currentItem.status === ExpenseStatus.CANCELLED && currentItem.canceled_obs
+    status === ExpenseStatus.CANCELLED && currentItem.canceled_obs
       ? {
           key: "canceledReason",
           label: "Motivo de anulación",
@@ -466,11 +484,10 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
           `0 !== "X"` es SIEMPRE verdadero: el botón "Anular egreso" seguía
           apareciendo en egresos que YA estaban anulados.
 
-          Este archivo ya usaba `ExpenseStatus.CANCELLED` bien en otros cuatro
-          lugares; sólo esta línea quedó con el char. `Number()` porque el tipo
-          de `status` admite string y el JSON a veces lo manda así.
+          La coerción ya no está acá: `status` se normaliza una sola vez arriba
+          y las cuatro comparaciones de estado leen esa misma variable.
         */}
-        {onDel && Number(currentItem.status) !== ExpenseStatus.CANCELLED && (
+        {onDel && status !== ExpenseStatus.CANCELLED && (
           <Button
             variant="danger"
             onClick={handleAnularClick}

--- a/src/modulos/Outlays/RenderView/RenderView.tsx
+++ b/src/modulos/Outlays/RenderView/RenderView.tsx
@@ -486,8 +486,12 @@ const RenderView: React.FC<DetailOutlayProps> = memo((props) => {
 
           La coerción ya no está acá: `status` se normaliza una sola vez arriba
           y las cuatro comparaciones de estado leen esa misma variable.
+
+          Se exige ACTIVE en vez de negar CANCELLED: un status ilegible da
+          `NaN`, y `NaN !== CANCELLED` es verdadero, así que la negación volvía
+          a mostrar el botón sobre un egreso cuyo estado no se pudo leer.
         */}
-        {onDel && status !== ExpenseStatus.CANCELLED && (
+        {onDel && status === ExpenseStatus.ACTIVE && (
           <Button
             variant="danger"
             onClick={handleAnularClick}

--- a/src/modulos/Outlays/__tests__/outlaysDetalleEgreso.test.tsx
+++ b/src/modulos/Outlays/__tests__/outlaysDetalleEgreso.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * CDT-39 — Detalle de un egreso y modal de anular.
+ *
+ * Lo que reportó el tester: pantalla negra al entrar al informe de pago. Sin
+ * `mod.renderView`, `useCrud` caía a su Detail genérico, que mete `item[key]`
+ * crudo adentro de `KeyValue`. El campo `user` ("Responsable") viene como OBJETO
+ * en `fullType=DET`, React tiraba "Objects are not valid as a React child" al
+ * montar el modal y se desmontaba el árbol ENTERO: de ahí el negro y el "deja de
+ * responder".
+ *
+ * Igual que en CDT-37, se entra por el `mod` y no por un import directo: la
+ * causa raíz fue una clave perdida en la mudanza a la factory, así que un test
+ * que importe el componente derecho queda verde con el bug puesto.
+ *
+ * El detalle y el modal de anular llevaban 23 días sin ejecutarse, y en el medio
+ * `expenses.status` pasó a enum numérico. Por eso acá no alcanza con que monte:
+ * se afirma el TEXTO del estado, que es donde estaba el segundo defecto.
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getOutlaysMod } from "../config/outlaysMod";
+import { ExpenseStatus, PaymentMethod } from "@/modulos/Payments/Type/PaymentType";
+
+const mockExecute = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({ execute: mockExecute }),
+}));
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({ user: { id: 1 }, showToast: mockShowToast }),
+}));
+
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: ({ open, children, onSave, buttonText, title }: any) =>
+    open ? (
+      <div>
+        <h1>{title}</h1>
+        {children}
+        {buttonText ? (
+          <button type="button" onClick={onSave}>
+            {buttonText}
+          </button>
+        ) : null}
+      </div>
+    ) : null,
+}));
+
+/** Un egreso tal como lo devuelve `ExpenseController` en `fullType=DET`. */
+const buildEgreso = (overrides: Record<string, any> = {}) => ({
+  id: 12,
+  amount: 350,
+  date_at: "2026-07-15 10:00:00",
+  status: ExpenseStatus.ACTIVE,
+  type: PaymentMethod.CASH,
+  description: "Factura de luz de julio",
+  // 🔴 El back manda la relación EXPANDIDA. Éste es exactamente el tipo de
+  // valor que hacía explotar al Detail genérico.
+  user: { id: "u-1", name: "Mario", last_name: "Guzmán" },
+  category: {
+    id: 11,
+    name: "Luz",
+    category_id: 1,
+    padre: { id: 1, name: "Servicios básicos" },
+  },
+  url_file: [],
+  ...overrides,
+});
+
+const renderDetalle = (item: any, onDel = vi.fn()) => {
+  const mod = getOutlaysMod();
+
+  // 🔴 Sin esta clave se renderea el Detail genérico: pantalla negra.
+  expect(mod.renderView).toBeDefined();
+
+  const View = mod.renderView as React.FC<any>;
+  render(<View open onClose={vi.fn()} item={item} extraData={{}} onDel={onDel} />);
+  return { onDel };
+};
+
+describe("CDT-39 — detalle del egreso", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("muestra datos reales: responsable, categoría y subcategoría", () => {
+    renderDetalle(buildEgreso());
+
+    expect(screen.getByText("Servicios básicos")).toBeInTheDocument();
+    expect(screen.getByText("Luz")).toBeInTheDocument();
+    expect(screen.getByText("Mario Guzmán")).toBeInTheDocument();
+  });
+
+  /**
+   * 🔴 Segundo defecto, tapado por el primero: el mapa de estados seguía
+   * keyeado por los chars legacy 'A'/'X'. Con `status` numérico ninguna key
+   * matcheaba y el `|| status` devolvía el número crudo, así que la fila
+   * "Estado" mostraba "1". No se veía porque el archivo no se renderizaba.
+   */
+  it.each([
+    [ExpenseStatus.ACTIVE, "Pagado", "1"],
+    [ExpenseStatus.CANCELLED, "Anulado", "0"],
+  ])(
+    "traduce el estado numérico %i a '%s' y no lo muestra crudo",
+    (status, etiqueta, crudo) => {
+      renderDetalle(buildEgreso({ status, canceled_obs: "Duplicado" }));
+
+      expect(screen.getByText(etiqueta)).toBeInTheDocument();
+      expect(screen.queryByText(crudo)).toBeNull();
+    },
+  );
+
+  it("ofrece anular un egreso activo", () => {
+    renderDetalle(buildEgreso({ status: ExpenseStatus.ACTIVE }));
+    expect(
+      screen.getByRole("button", { name: "Anular egreso" }),
+    ).toBeInTheDocument();
+  });
+
+  it("no ofrece anular un egreso que ya está anulado", () => {
+    renderDetalle(
+      buildEgreso({ status: ExpenseStatus.CANCELLED, canceled_obs: "Duplicado" }),
+    );
+    expect(screen.queryByRole("button", { name: "Anular egreso" })).toBeNull();
+  });
+});
+
+describe("CDT-39 — modal de anular", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exige el motivo antes de anular", () => {
+    const mod = getOutlaysMod();
+    expect(mod.renderDel).toBeDefined();
+
+    const Del = mod.renderDel as React.FC<any>;
+    render(
+      <Del
+        open
+        onClose={vi.fn()}
+        item={buildEgreso()}
+        onSave={vi.fn()}
+        execute={mockExecute}
+        reLoad={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Anular egreso" }));
+
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("anula con el motivo, contra el endpoint del egreso", async () => {
+    mockExecute.mockResolvedValue({ data: { success: true } });
+
+    const mod = getOutlaysMod();
+    const Del = mod.renderDel as React.FC<any>;
+    const reLoad = vi.fn();
+    render(
+      <Del
+        open
+        onClose={vi.fn()}
+        item={buildEgreso()}
+        onSave={vi.fn()}
+        execute={mockExecute}
+        reLoad={reLoad}
+      />,
+    );
+
+    fireEvent.change(
+      document.getElementById("canceled_obs") as HTMLTextAreaElement,
+      { target: { name: "canceled_obs", value: "Cargado dos veces" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Anular egreso" }));
+
+    await waitFor(() => expect(mockExecute).toHaveBeenCalledTimes(1));
+    expect(mockExecute).toHaveBeenCalledWith(
+      "/v3/expenses/12",
+      "DELETE",
+      expect.objectContaining({ id: 12, canceled_obs: "Cargado dos veces" }),
+    );
+    await waitFor(() => expect(reLoad).toHaveBeenCalled());
+  });
+});

--- a/src/modulos/Outlays/__tests__/outlaysRegistrarEgreso.test.tsx
+++ b/src/modulos/Outlays/__tests__/outlaysRegistrarEgreso.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * CDT-37 — Registro de nuevo egreso: la Subcategoría tiene que ofrecer opciones.
+ *
+ * Lo que reportó el tester: "Subcategoría es obligatorio pero el desplegable no
+ * ofrece ninguna opción". El flujo de gastos quedó bloqueado entero.
+ *
+ * Este test NO verifica que exista un componente. Verifica el camino que aprieta
+ * el usuario: monta el formulario QUE EL MÓDULO DECLARA (`mod.renderForm`, no un
+ * import directo), elige una categoría y mira qué ofrece el desplegable de
+ * Subcategoría. Se entra por el `mod` a propósito: la causa raíz de CDT-37 fue
+ * que la mudanza del `mod` a la factory perdió la clave `renderForm`, así que un
+ * test que importara `RenderForm` directo habría quedado VERDE con el bug puesto
+ * —justo lo que pasa con el test de anular, que mide un componente que nadie
+ * renderea.
+ *
+ * Las dos formas del id se prueban por separado porque cada una rompe por su
+ * lado:
+ *  - numérica: es lo que manda el back hoy.
+ *  - texto: el filtro comparaba `subcat.category_id === Number(String(valor))`,
+ *    o sea `===` contra un Number. Con el id como texto no matcheaba NADA y la
+ *    Subcategoría volvía a quedar vacía: mismo síntoma, otra causa.
+ */
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getOutlaysMod } from "../config/outlaysMod";
+import { PaymentMethod } from "@/modulos/Payments/Type/PaymentType";
+
+// El modal real anima y monta en un portal propio; acá sólo estorba. Se deja
+// pasar el contenido y se expone el botón de guardar para poder apretarlo.
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: ({ open, children, onSave, buttonText }: any) =>
+    open ? (
+      <div>
+        {children}
+        <button type="button" onClick={onSave}>
+          {buttonText}
+        </button>
+      </div>
+    ) : null,
+}));
+
+// La subida de comprobantes no participa de la cascada y arrastra medio storage.
+vi.mock("@/mk/components/forms/UploadFileV3/UploadFileV3", () => ({
+  default: () => <div data-testid="upload-comprobantes" />,
+}));
+
+vi.mock("@/mk/components/ui/Toast/Toast", () => ({
+  default: () => null,
+}));
+
+/**
+ * `extraData` con la forma exacta que devuelve `ExpenseController` en
+ * `fullType=EXTRA`: `categories` son SÓLO los padres (`whereNull('category_id')`)
+ * y `subcategories` son los hijos, cada uno con su `category_id`.
+ */
+const buildExtraData = (id: (n: number) => number | string) => ({
+  categories: [
+    { id: id(1), name: "Servicios básicos" },
+    { id: id(2), name: "Mantenimiento" },
+  ],
+  subcategories: [
+    { id: id(10), name: "Agua", category_id: id(1) },
+    { id: id(11), name: "Luz", category_id: id(1) },
+    { id: id(20), name: "Jardinería", category_id: id(2) },
+  ],
+  bankAccounts: [],
+});
+
+const asNumber = (n: number) => n;
+const asString = (n: number) => String(n);
+
+/** El disparador de un `Select`, buscado por su etiqueta visible. */
+const selectTrigger = (label: string) =>
+  screen.getByText(label).closest("button") as HTMLButtonElement;
+
+/** Abre un `Select` y devuelve el panel de opciones (vive en el portal). */
+const openSelect = (label: string) => {
+  fireEvent.click(selectTrigger(label));
+  const portal = document.getElementById("portal-root") as HTMLElement;
+  return within(portal);
+};
+
+const renderOutlayForm = (extraData: any, onSave = vi.fn()) => {
+  const mod = getOutlaysMod();
+
+  // 🔴 El módulo tiene que declarar su form. Sin esto `useCrud` renderea el
+  // form genérico, que es donde el tester vio la Subcategoría vacía.
+  expect(mod.renderForm).toBeDefined();
+
+  const Form = mod.renderForm as React.FC<any>;
+  render(
+    <Form
+      open
+      onClose={vi.fn()}
+      onSave={onSave}
+      extraData={extraData}
+      execute={vi.fn()}
+      showToast={vi.fn()}
+      reLoad={vi.fn()}
+    />,
+  );
+  return { onSave };
+};
+
+describe("CDT-37 — el formulario de Egresos ofrece subcategorías", () => {
+  beforeEach(() => {
+    const portal = document.createElement("div");
+    portal.id = "portal-root";
+    document.body.appendChild(portal);
+  });
+
+  afterEach(() => {
+    document.getElementById("portal-root")?.remove();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["numéricos (lo que manda el back hoy)", asNumber],
+    ["de texto (si el JSON los serializa como string)", asString],
+  ])(
+    "con ids %s, elegir una categoría llena el desplegable de Subcategoría",
+    (_caso, id) => {
+      renderOutlayForm(buildExtraData(id));
+
+      // Antes de elegir categoría no hay nada que elegir, y el campo está
+      // deshabilitado: ése es el estado legítimo, no el que reportó el tester.
+      expect(selectTrigger("Subcategoría")).toBeDisabled();
+
+      fireEvent.click(openSelect("Categoría").getByText("Servicios básicos"));
+
+      const opciones = openSelect("Subcategoría");
+      expect(opciones.getByText("Agua")).toBeInTheDocument();
+      expect(opciones.getByText("Luz")).toBeInTheDocument();
+      // Y sólo las de ESA categoría.
+      expect(opciones.queryByText("Jardinería")).toBeNull();
+    },
+  );
+
+  it("cambiar de categoría reemplaza las subcategorías ofrecidas", () => {
+    renderOutlayForm(buildExtraData(asNumber));
+
+    fireEvent.click(openSelect("Categoría").getByText("Servicios básicos"));
+    fireEvent.click(openSelect("Categoría").getByText("Mantenimiento"));
+
+    const opciones = openSelect("Subcategoría");
+    expect(opciones.getByText("Jardinería")).toBeInTheDocument();
+    expect(opciones.queryByText("Agua")).toBeNull();
+  });
+
+  /**
+   * 🔴 `ExpenseController::beforeCreate` colapsa `subcategory_id` adentro de
+   * `category_id` antes de guardar. Si el form dejara de mandar los DOS, el
+   * egreso quedaría colgado del padre, la columna Subcategoría del listado
+   * mostraría "-/-" y el defecto se volvería invisible.
+   */
+  it("guarda mandando category_id Y subcategory_id, no sólo el padre", () => {
+    const { onSave } = renderOutlayForm(buildExtraData(asNumber));
+
+    fireEvent.click(openSelect("Categoría").getByText("Servicios básicos"));
+    fireEvent.click(openSelect("Subcategoría").getByText("Luz"));
+    fireEvent.click(openSelect("Método de pago").getByText("Efectivo"));
+
+    fireEvent.change(document.getElementById("amount") as HTMLInputElement, {
+      target: { name: "amount", value: "350" },
+    });
+    fireEvent.change(
+      document.getElementById("description") as HTMLTextAreaElement,
+      { target: { name: "description", value: "Factura de luz de julio" } },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Crear egreso" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category_id: 1,
+        subcategory_id: 11,
+        type: PaymentMethod.CASH,
+        amount: 350,
+      }),
+    );
+  });
+});

--- a/src/modulos/Outlays/config/__tests__/outlaysMod.test.ts
+++ b/src/modulos/Outlays/config/__tests__/outlaysMod.test.ts
@@ -85,4 +85,35 @@ describe("Outlays mod config (S43 + S118b)", () => {
     const mod = getOutlaysMod();
     expect(mod.exportAsync?.extraParams?.title).toBeUndefined();
   });
+
+  /**
+   * 🔴 CDT-37 + CDT-39 — el pin que impide que esto vuelva a pasar.
+   *
+   * Cuando el `mod` se mudó de `Outlays.tsx` a esta factory (ed9beaf6), la
+   * mudanza perdió CINCO claves y nada avisó: no hay tipo que las exija, el
+   * módulo siguió compilando y la lista siguió andando. El agujero vivió 23
+   * días con el registro de egresos bloqueado (sin `renderForm`, la
+   * Subcategoría no ofrecía nada) y el detalle en pantalla negra (sin
+   * `renderView`, el Detail genérico explotaba con el `user` objeto).
+   *
+   * Las pantallas propias del módulo se prueban en `__tests__/` del módulo, que
+   * es donde se mide el comportamiento. Esto de acá es más chico y más bruto: la
+   * próxima mudanza de este objeto se pone ROJA en vez de borrar una clave en
+   * silencio.
+   */
+  it("declara sus pantallas propias y los titulos de sus acciones", () => {
+    const mod = getOutlaysMod();
+
+    // Lo que exige `CrudRendererHost`: o una función, o un componente envuelto
+    // en `memo` (un objeto con `.type` función). RenderView y RenderDel son
+    // `memo`, RenderForm no — por eso no alcanza con `toBeTypeOf("function")`.
+    const esRenderizable = (renderer: any) =>
+      typeof renderer === "function" || typeof renderer?.type === "function";
+
+    expect(esRenderizable(mod.renderForm)).toBe(true);
+    expect(esRenderizable(mod.renderView)).toBe(true);
+    expect(esRenderizable(mod.renderDel)).toBe(true);
+    expect(mod.titleAdd).toBe("Nuevo");
+    expect(mod.titleDel).toBe("Anular");
+  });
 });

--- a/src/modulos/Outlays/config/outlaysMod.ts
+++ b/src/modulos/Outlays/config/outlaysMod.ts
@@ -1,4 +1,7 @@
 import { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
+import RenderForm from "../RenderForm/RenderForm";
+import RenderView from "../RenderView/RenderView";
+import RenderDel from "../RenderDel/RenderDel";
 
 /**
  * getOutlaysMod (S43 — NEW-NEW-43 Expenses async export frontend)
@@ -35,12 +38,44 @@ import { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
  * @see D-37.5-3 (S37.5) — factory pattern para configs `mod` (patrón reusable)
  * @see S41 (Outlays discovery) — modulo: "v3/expenses" + permiso: "outlays"
  *   es alias del módulo Expenses canónico
+ *
+ * 🔴 CDT-37 + CDT-39: la mudanza del `mod` a esta factory se llevó puestas
+ * CINCO claves —`renderForm`, `renderView`, `renderDel`, `titleAdd` y
+ * `titleDel`— y nada avisó. El módulo siguió compilando y la lista siguió
+ * andando, así que el agujero vivió 23 días con dos pantallas rotas:
+ *
+ * - CDT-37 (registrar egreso): sin `renderForm`, `useCrud` cae a su form
+ *   genérico, que arma la Subcategoría con las opciones declaradas en
+ *   `Outlays.tsx` — y esa lista estaba hardcodeada vacía. Un campo obligatorio
+ *   que no ofrecía NINGUNA opción: no se podía registrar un egreso.
+ * - CDT-39 (ver el detalle): sin `renderView`, `useCrud` cae a su Detail
+ *   genérico, que mete `item[key]` crudo dentro de `KeyValue` para todo campo
+ *   con label y sin `onRender`. El campo `user` ("Responsable") viene como
+ *   OBJETO en `fullType=DET`, React tira "Objects are not valid as a React
+ *   child" al montar el modal y se desmonta el árbol entero: pantalla negra.
+ *
+ * 🔴 Estas cinco claves son la interfaz del módulo. Si alguien vuelve a mudar
+ * este objeto, `config/__tests__/outlaysMod.test.ts` se pone rojo antes de que
+ * una clave se pierda de nuevo en silencio.
  */
 export const getOutlaysMod = (): ModCrudType => ({
   modulo: "v3/expenses",
   singular: "Egreso",
   plural: "Egresos",
   filter: true,
+  // El form propio de Egresos: cascada categoría→subcategoría y cuenta
+  // bancaria heredada de la subcategoría. Sin esta clave `useCrud` renderea su
+  // form genérico a partir de `fields` — ver CDT-37 arriba.
+  renderForm: RenderForm,
+  titleAdd: "Nuevo",
+  // El detalle propio: resuelve categoría/subcategoría, el estado y los
+  // comprobantes. Sin esta clave el detalle genérico revienta con el `user`
+  // objeto — ver CDT-39 arriba.
+  renderView: RenderView,
+  titleDel: "Anular",
+  // El modal de anular pide el motivo (`canceled_obs`, obligatorio) y hace el
+  // DELETE él mismo. El modal genérico de borrado no tiene dónde pedirlo.
+  renderDel: RenderDel,
   // S43: kill legacy IconExport (D-38-5 pattern) + slot async pineado.
   // S118b: type: "outlays" → matchea el nuevo OutlaysReportType del back.
   //        extraParams.title: "Reporte de Egresos" → title dinámico del PDF.


### PR DESCRIPTION
## Qué estaba roto

El commit `ed9beaf6` (21/07, *S43-T02 — Outlays mod.exportAsync + factory*) movió el `mod` de Egresos desde `Outlays.tsx` a la factory `getOutlaysMod()` y en la mudanza perdió **cinco** claves: `renderForm`, `renderView`, `renderDel`, `titleAdd` y `titleDel`. Ningún tipo las exige, así que nada avisó. Desde entonces el módulo venía usando los componentes genéricos de `useCrud`.

Dos tickets, una sola causa:

- **CDT-37** — sin `renderForm` se renderea el form genérico, donde `subcategory_id` estaba declarado con `options: () => []` y `rules: ["required"]`. Campo obligatorio que nunca ofrece nada: bloqueo total del registro de egresos.
- **CDT-39** — sin `renderView` cae al Detail genérico, que mete `item[key]` crudo dentro de `KeyValue`. El campo `user` tiene label "Responsable", ningún `onRender`, y el back lo manda como objeto en `fullType=DET`. React tira *Objects are not valid as a React child*, se desmonta el árbol entero, y la pantalla queda negra sin responder.

## Qué cambia

- Vuelven las cinco claves al mod, y se van los tres imports que quedaron muertos en `Outlays.tsx`.
- `RenderForm` comparaba `subcat.category_id === Number(String(newValue))`: `===` contra `Number`. Si la API mandara ese id como texto el desplegable volvía a quedar vacío, mismo síntoma y otra causa. Ahora compara por `String` de los dos lados.
- `RenderView.getStatusText` seguía keyeado por los chars legacy `'A'`/`'X'`. Con los estados ya numéricos ninguna key matcheaba y el `|| status` devolvía el número crudo: la fila Estado mostraba `1` en vez de `Pagado`. El archivo comparaba el estado de cuatro formas distintas; ahora se normaliza una sola vez.
- 🔴 **`url_file` no estaba declarado en `fields`.** `getParamFields` arma el payload recorriendo `fields`, así que los comprobantes que sube el formulario **nunca se mandaban al back**, sin un solo mensaje de error. Es anterior a `ed9beaf6` — el form estaba muerto y no se notaba. Reactivarlo sin esto habría shippeado pérdida silenciosa de adjuntos.
- Guarda en `useCrud`: el Detail genérico ya no revienta con una relación expandida. Devolver `renderView` arregla un módulo; la guarda arregla el próximo que declare un label sobre un objeto.

## Tests

678 verdes en la suite entera. Tres archivos nuevos, todos entrando por `getOutlaysMod().renderX` y nunca por un import directo: acá el defecto es que *nadie renderea el componente*, así que un test que lo importe queda verde midiendo nada.

Reinyección, una por una y revirtiendo por hunk:

| Bug reinyectado | Rojo |
|---|---|
| sin `renderForm` | `expected undefined to be defined` — mueren los 4 del form y el guard del mod |
| `=== Number(String(...))` | `Unable to find an element with the text: Agua` (sólo el caso de ids de texto; el numérico sigue verde, que es el punto) |
| sin `renderView` | `expected undefined to be defined` — mueren los 5 del detalle |
| mapa `'A'`/`'X'` | `Unable to find an element with the text: Pagado` / `Anulado` |
| sin la guarda de `useCrud` | `expected { id: 'u-1', … } to be null` |

El guard de las cinco claves en `outlaysMod.test.ts` es lo que impide que la próxima mudanza a una factory las borre en silencio.

Sin migración de base de datos.

## Falta verificar a ojo

`RenderView` y `RenderDel` llevaban 23 días sin ejecutarse contra el back actual y sólo se verificaron con jsdom contra fixtures que copian el JSON de `fullType=DET`. En `/outlays`: detalle de un egreso pagado (Estado "Pagado", no "1", con Categoría, Subcategoría y "Registrado por"), detalle de uno anulado (con "Anulado por", el motivo, y sin el botón de anular), el modal de anular, y crear un egreso con comprobante para confirmar que el adjunto quedó guardado.