### PR TITLE
fix(filtros): un filtro que vale 0 tiene que llegar al back (CDT-38)

### DIFF
--- a/src/mk/hooks/useCrud/README.md
+++ b/src/mk/hooks/useCrud/README.md
@@ -328,8 +328,25 @@ const {
 
 ### With Custom Filter
 
+> 🔴 **"Sin filtro" son sólo `undefined`, `null` y `""`.** El hook serializa
+> `filterBy` a la cadena `campo:valor|campo:valor` descartando únicamente esos
+> tres valores, y el **cero es un valor legítimo**: hay estados que valen 0
+> (`ExpenseStatus.CANCELLED`, `PaymentStatus.CANCELLED`,
+> `BankAccountStatus.INACTIVE`, `BankEntityStatus.INACTIVE`). Un `getFilter`
+> propio que borre la clave con un chequeo de verdad (`if (!value) delete ...`)
+> hace que el back reciba la lista SIN filtrar, sin ningún error: la pantalla
+> muestra todos los estados y el usuario les cree (CDT-38, Egresos).
+>
+> `filterValue` puede llegar como número: es el `id` crudo de la opción del
+> `Select`, no una cadena.
+
 ```typescript
-const customFilter = (filterKey: string, filterValue: string, previousFilter: Record<string, any>) => {
+const customFilter = (filterKey: string, filterValue: string | number, previousFilter: Record<string, any>) => {
+  if (filterValue === "" || filterValue === null || filterValue === undefined) {
+    const { [filterKey]: _, ...resto } = previousFilter.filterBy || {};
+    return { filterBy: resto };
+  }
+
   return {
     filterBy: {
       ...previousFilter.filterBy,

--- a/src/mk/hooks/useCrud/__tests__/useCrudFiltroConValorCero.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrudFiltroConValorCero.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Un filtro cuyo valor es CERO tiene que viajar al back y verse elegido.
+ *
+ * 🔴 El bug (CDT-38, lo reportó un tester sobre Egresos): al elegir el estado
+ * "Anulado" la tabla seguía mostrando los pagados y todos los demás estados.
+ *
+ * La causa no estaba en Egresos sino acá, en el hook que usan los ~40 módulos:
+ * `onFilter` armaba la cadena `campo:valor` con un chequeo de VERDAD
+ * (`if (filterBy.filterBy[key])`). "Anulado" es `ExpenseStatus.CANCELLED = 0`,
+ * así que la clave `status` nunca entraba al `filterBy` y el back —sano—
+ * devolvía la lista SIN filtrar. Ningún error, ninguna lista vacía: filas que
+ * el usuario cree.
+ *
+ * Y la mitad visual del mismo falsy: `value={filterSel[f.key] || ""}` dibujaba
+ * el combo VACÍO después de elegir "Anulado", o sea que la pantalla decía que
+ * no habías elegido nada.
+ *
+ * ⚠️ No es exclusivo de Egresos: `PaymentStatus.CANCELLED`,
+ * `BankAccountStatus.INACTIVE` y `BankEntityStatus.INACTIVE` también valen 0 y
+ * estaban rotos por la MISMA línea.
+ *
+ * Misma familia que el `0 == ""` del `Select` compartido (CDT-30).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+// jsdom no trae `matchMedia` y `FilterResponsive` lo usa para decidir si
+// dibuja los combos sueltos o el modal de filtros. Se responde "pantalla
+// ancha": los dos caminos leen el mismo `filterSel`.
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+})) as any;
+
+const paramsDeLaLista: Array<Record<string, any>> = [];
+const valoresDelCombo: any[] = [];
+const bordesDelCombo: any[] = [];
+
+// Egresos pineá `perPage: 20`, o sea que va por la lista infinita: los params
+// de cada request salen por `execute`, no por el `useAxios` declarativo.
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({
+    data: null,
+    reLoad: vi.fn(),
+    loaded: true,
+    error: null,
+    execute: vi.fn(async (_url: any, _method: any, params: any) => {
+      paramsDeLaLista.push(params);
+      return { data: { data: [], message: "", success: true }, error: null };
+    }),
+  }),
+}));
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: 1 },
+    userCan: () => true,
+    store: {},
+    setStore: vi.fn(),
+    showToast: vi.fn(),
+    waiting: false,
+    setWaiting: vi.fn(),
+  }),
+}));
+
+/**
+ * El `Select` real se reemplaza por un botón: lo que se mide es el cableado del
+ * hook (qué `value` recibe el combo y qué `filterBy` sale hacia el back), no
+ * cómo pinta el componente.
+ */
+vi.mock("@/mk/components/forms/Select/Select", () => ({
+  default: ({ name, value, options, onChange, inputStyle }: any) => {
+    valoresDelCombo.push(value);
+    bordesDelCombo.push(inputStyle?.borderColor);
+    return (
+      <button
+        type="button"
+        data-testid={name}
+        onClick={() =>
+          onChange({ target: { name, value: options[options.length - 1].id } })
+        }
+      >
+        combo
+      </button>
+    );
+  },
+}));
+
+import useCrud, { ModCrudType } from "../useCrud";
+
+// Los mismos valores que declara Egresos: "Anulado" es el CERO.
+const OPCIONES_ESTADO = [
+  { id: "ALL", name: "Todos" },
+  { id: 1, name: "Pagado" },
+  { id: 0, name: "Anulado" },
+];
+
+const campos = {
+  id: { rules: [], api: "e" },
+  description: { rules: [], api: "ae", label: "Concepto", list: true },
+  status: {
+    rules: [],
+    api: "ae",
+    label: "Estado",
+    list: true,
+    filter: { label: "Estado", options: () => OPCIONES_ESTADO },
+  },
+};
+
+const montarYElegirAnulado = () => {
+  const Comp = () => {
+    const { List } = useCrud({
+      paramsInitial: { perPage: 20, page: 1, fullType: "L", searchBy: "" },
+      mod: {
+        modulo: "v3/expenses",
+        singular: "egreso",
+        plural: "egresos",
+        permiso: "outlays",
+        filter: true,
+        export: false,
+      } as unknown as ModCrudType,
+      fields: campos,
+    });
+    return <List emptyMsg="vacío" emptyLine2="" />;
+  };
+  render(<Comp />);
+  fireEvent.click(screen.getAllByTestId("status_filter")[0]);
+};
+
+beforeEach(() => {
+  paramsDeLaLista.length = 0;
+  valoresDelCombo.length = 0;
+  bordesDelCombo.length = 0;
+});
+
+describe("useCrud: un filtro que vale 0", () => {
+  it("manda status:0 al back cuando se elige 'Anulado'", async () => {
+    montarYElegirAnulado();
+
+    await waitFor(() => {
+      expect(
+        paramsDeLaLista.at(-1)?.filterBy,
+        "El filtro con valor 0 ('Anulado') no llegó al back: la lista sale SIN " +
+          "filtrar y la tabla sigue mostrando los pagados, sin ningún error.",
+      ).toBe("status:0");
+    });
+  });
+
+  it("deja el 0 elegido en el combo, no lo dibuja vacío", () => {
+    montarYElegirAnulado();
+
+    expect(
+      valoresDelCombo.at(-1),
+      "El combo se dibujó vacío después de elegir 'Anulado': la pantalla dice " +
+        "que no elegiste nada cuando sí elegiste.",
+    ).toBe(0);
+  });
+
+  it("marca el combo como filtrado cuando el valor elegido es 0", () => {
+    montarYElegirAnulado();
+
+    expect(
+      bordesDelCombo.at(-1),
+      "El combo no se pinta como 'filtrado' con el 0 elegido: la pantalla no " +
+        "avisa que hay un filtro activo.",
+    ).toBe("var(--cPrimary)");
+  });
+
+  it("sigue tratando la cadena vacía como 'sin filtro'", async () => {
+    const Comp = () => {
+      const { List } = useCrud({
+        paramsInitial: { perPage: 20, page: 1, fullType: "L", searchBy: "" },
+        mod: {
+          modulo: "v3/expenses",
+          singular: "egreso",
+          plural: "egresos",
+          permiso: "outlays",
+          filter: true,
+          export: false,
+        } as unknown as ModCrudType,
+        fields: {
+          ...campos,
+          status: {
+            ...campos.status,
+            filter: { label: "Estado", options: () => [{ id: "", name: "—" }] },
+          },
+        },
+      });
+      return <List emptyMsg="vacío" emptyLine2="" />;
+    };
+    render(<Comp />);
+    await waitFor(() => expect(paramsDeLaLista.length).toBeGreaterThan(0));
+    fireEvent.click(screen.getAllByTestId("status_filter")[0]);
+
+    await waitFor(() => {
+      expect(
+        paramsDeLaLista.at(-1)?.filterBy,
+        "Un valor vacío se está mandando como filtro: `\"\"` es 'sin filtro', " +
+          "no un criterio.",
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -400,6 +400,24 @@ const CrudRendererHost = memo(
 CrudRendererHost.displayName = "CrudRendererHost";
 
 /**
+ * ¿Este valor de filtro hay que mandarlo al back?
+ *
+ * 🔴 "Sin filtro" son SÓLO tres valores: `undefined`, `null` y `""`. No es lo
+ * mismo que "falsy".
+ *
+ * El chequeo de verdad (`if (valor)`) descarta también el **cero legítimo**, y
+ * hay estados que valen 0: `ExpenseStatus.CANCELLED`, `PaymentStatus.CANCELLED`,
+ * `BankAccountStatus.INACTIVE`, `BankEntityStatus.INACTIVE`. Medido en Egresos
+ * (CDT-38): al elegir "Anulado" la clave `status` NUNCA entraba al `filterBy`,
+ * el back recibía la lista sin filtrar y la tabla seguía mostrando los pagados
+ * — sin ningún error, así que el usuario le cree.
+ *
+ * Misma familia que el `0 == ""` del `Select` compartido (CDT-30).
+ */
+const esValorDeFiltro = (valor: any): boolean =>
+  valor !== undefined && valor !== null && valor !== "";
+
+/**
  * El `filterBy` inicial de un módulo, en la forma que espera el back.
  *
  * Acepta el objeto legible (`{ in_at: "m" }`) y devuelve `"in_at:m"`. Si ya
@@ -411,7 +429,7 @@ const filtroInicialComoCadena = (filtro: any): string | null => {
   if (typeof filtro !== "object") return null;
 
   const partes = Object.entries(filtro)
-    .filter(([, valor]) => valor !== "" && valor !== null && valor !== undefined)
+    .filter(([, valor]) => esValorDeFiltro(valor))
     .map(([campo, valor]) => `${campo}:${valor}`);
 
   return partes.length ? partes.join("|") : null;
@@ -1126,7 +1144,8 @@ const useCrud = ({
     //iterar filterBy para quitar los vacios
     let fil: any = [];
     for (const key in filterBy.filterBy) {
-      if (filterBy.filterBy[key]) fil.push(key + ":" + filterBy.filterBy[key]);
+      const valor = filterBy.filterBy[key];
+      if (esValorDeFiltro(valor)) fil.push(key + ":" + valor);
     }
     fil = fil.join("|");
     // Always update filterBy: set to new value OR explicitly to undefined to clear old filters from params
@@ -1719,13 +1738,15 @@ const useCrud = ({
   const FilterResponsive = ({ filters, onChange, breakPoint }: any) => {
     const isBreak = useMediaQuery("(max-width: " + breakPoint + "px)");
 
+    // ⚠️ `esValorDeFiltro` y no un chequeo de verdad: un estado que vale 0
+    // ("Anulado") está tan seleccionado como cualquier otro y el borde tiene
+    // que pintarse igual.
     const getFilterInputStyle = (filterKey: string) => ({
       backgroundColor: "var(--controlSecondaryBg)",
       borderColor:
-        filterSel[filterKey] &&
-        filterSel[filterKey] != "" &&
-        filterSel[filterKey] != "T" &&
-        filterSel[filterKey] != "ALL"
+        esValorDeFiltro(filterSel[filterKey]) &&
+        String(filterSel[filterKey]) !== "T" &&
+        String(filterSel[filterKey]) !== "ALL"
           ? "var(--cPrimary)"
           : "var(--controlSecondaryBorder)",
       color: "var(--controlSecondaryText)",
@@ -1765,7 +1786,10 @@ const useCrud = ({
                   name={f.key + "_filter"}
                   onChange={onChange}
                   options={f.options || []}
-                  value={filterSel[f.key] || ""}
+                  // 🔴 `??` y no `||`: con `||`, un filtro elegido que vale 0
+                  // ("Anulado") se dibuja VACÍO y el usuario cree que no eligió
+                  // nada.
+                  value={filterSel[f.key] ?? ""}
                   optionLabel={f?.optionLabel}
                   optionValue={f?.optionValue}
                   error={false}
@@ -1793,7 +1817,8 @@ const useCrud = ({
                 name={f.key + "_filter"}
                 onChange={onChange}
                 options={f.options || []}
-                value={filterSel[f.key] || ""}
+                // 🔴 Mismo `??` que en `BreakFilter`: el 0 es un valor elegido.
+                value={filterSel[f.key] ?? ""}
                 optionLabel={f?.optionLabel}
                 optionValue={f?.optionValue}
                 inputStyle={getFilterInputStyle(f.key)}

--- a/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
+++ b/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
@@ -139,7 +139,12 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
 
     if (value === "ALL") {
       currentFilters[opt] = "ALL"; // Enviamos 'ALL' explícitamente // esto?
-    } else if (!value) {
+      // 🔴 Los tres valores explícitos y no `!value`: un estado que vale 0 es
+      // una opción elegida, no "sin filtro". Con el chequeo de verdad la clave
+      // se borraba y el back devolvía la lista SIN filtrar, sin ningún error
+      // (es lo que pasó en Egresos, CDT-38). Hoy ningún `DebtStatus` vale 0,
+      // pero el próximo enum que se agregue acá no tiene por qué saberlo.
+    } else if (value === "" || value === null || value === undefined) {
       delete currentFilters[opt];
     } else {
       currentFilters[opt] = value;


### PR DESCRIPTION
## CDT-38 — El filtro "Anulado" de Egresos no filtraba nada

El tester reportó que al elegir el estado "Anulado" la tabla seguía mostrando
egresos pagados y todos los demás estados.

## Causa raíz

`useCrud.onFilter` armaba la cadena `campo:valor` del `filterBy` con un chequeo
de verdad (`if (filterBy.filterBy[key])`). `ExpenseStatus.CANCELLED` vale **0**,
así que la clave `status` nunca entraba al `filterBy` y el back —que está sano—
devolvía la lista sin filtrar, sin ningún error visible.

Es la misma familia que CDT-30: `0` es falsy en JavaScript.

Se arregló **en el hook** (una sola función `esValorDeFiltro` que distingue
"sin filtro" —`undefined`, `null`, `""`— de "cero legítimo") y no en Egresos,
porque la misma línea rompía a todo módulo con un estado que vale 0:
`PaymentStatus.CANCELLED`, `BankAccountStatus.INACTIVE`,
`BankEntityStatus.INACTIVE`. Esas tres pantallas quedan arregladas solas.

Dos superficies más del mismo falsy en el mismo archivo: el combo se dibujaba
vacío después de elegir "Anulado", y el borde no se pintaba como filtrado.

## Archivos

- `src/mk/hooks/useCrud/useCrud.tsx` — `esValorDeFiltro`, `onFilter`,
  `getFilterInputStyle`, `?? ""` en vez de `|| ""`.
- `src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx:142` — el mismo
  defecto, todavía latente.
- `src/mk/hooks/useCrud/README.md` — el contrato "vacío vs cero" para los
  `getFilter` propios.

## Verificación

Test nuevo `useCrudFiltroConValorCero.test.tsx` (4 casos): monta el List real,
clickea la opción con id 0 y mide el `filterBy` que sale por `execute`.

Verificado por reinyección, las tres mitades por separado:

1. Chequeo de verdad de vuelta en `onFilter` → rojo: `expected undefined to be 'status:0'`.
2. `|| ""` de vuelta en el `value` del combo → rojo: `expected '' to be +0`.
3. Chequeo de verdad de vuelta en `getFilterInputStyle` → rojo: el borde no se pinta.

**Suite completa: 101 archivos / 682 tests, todo verde.** eslint 0 errores.
`tsc`: 29 errores, todos preexistentes en tests ajenos, cero en lo tocado.

## Riesgo aceptado

Valores `0`/`false` que hoy se descartan en silencio ahora viajan en el
`filterBy` de todos los módulos. Ningún módulo declara hoy una opción de filtro
con valor booleano (se revisaron todos).

## Falta verificar en pantalla

Egresos → filtro Estado → "Anulado": tiene que mostrar sólo anulados, dejar
"Anulado" escrito en el combo y pintar el borde. Segunda pasada barata en el
mismo release: Pagos, Cuentas bancarias y Entidades bancarias, rotas por la
misma línea y nunca reportadas.