### PR TITLE
fix(balance): la grafica por categoria no dibujaba nada (CDT-31)

### DIFF
--- a/src/modulos/Balance/Balance.tsx
+++ b/src/modulos/Balance/Balance.tsx
@@ -2,13 +2,10 @@
 
 import React, { useEffect, useState, useMemo, useRef } from "react";
 import useAxios from "@/mk/hooks/useAxios";
-import { getUrlImages } from "@/mk/utils/string";
 import { useAsyncExport } from "@/mk/hooks/useAsyncExport/useAsyncExport";
 import ExportProgressModal from "@/mk/components/ui/ExportProgressModal/ExportProgressModal";
 import Select from "@/mk/components/forms/Select/Select";
 import Button from "@/mk/components/forms/Button/Button";
-import Input from "@/mk/components/forms/Input/Input";
-import DataModal from "@/mk/components/ui/DataModal/DataModal";
 import LoadingScreen from "@/mk/components/ui/LoadingScreen/LoadingScreen";
 import TableIngresos from "./TableIngresos";
 import TableEgresos from "./TableEgresos";
@@ -41,11 +38,6 @@ interface FilterState {
   filter_mov: string;
   filter_categ: string[];
 }
-interface FormStateType {
-  date_inicio?: string;
-  date_fin?: string;
-  [key: string]: string | undefined;
-}
 
 interface ErrorType {
   [key: string]: string;
@@ -66,7 +58,6 @@ const BalanceGeneral: React.FC = () => {
   const [errors, setErrors] = useState<ErrorType>({});
   const [lchars, setLchars] = useState<ChartTypeOption[]>([]);
   const [openCustomFilter, setOpenCustomFilter] = useState(false);
-  const [formState, setFormState] = useState<FormStateType>({});
 
   const chartRefBalance = useRef<HTMLDivElement>(null);
   const chartRefIngresos = useRef<HTMLDivElement>(null);
@@ -177,48 +168,6 @@ const BalanceGeneral: React.FC = () => {
       filter_mov: formStateFilter.filter_mov,
       filter_categ: formStateFilter.filter_categ,
     });
-  };
-  const onSaveCustomFilter = () => {
-    let err: ErrorType = {};
-    if (!formState.date_inicio) {
-      err = { ...err, date_inicio: "La fecha de inicio es obligatoria" };
-    }
-    if (!formState.date_fin) {
-      err = { ...err, date_fin: "La fecha de fin es obligatoria" };
-    }
-    if (
-      formState.date_inicio &&
-      formState.date_fin &&
-      formState.date_inicio > formState.date_fin
-    ) {
-      err = {
-        ...err,
-        date_inicio: "La fecha de inicio no puede ser mayor a la de fin",
-      };
-    }
-    if (
-      formState.date_inicio &&
-      formState.date_fin &&
-      formState.date_inicio.slice(0, 4) !== formState.date_fin.slice(0, 4)
-    ) {
-      err = {
-        ...err,
-        date_inicio: "El periodo personalizado debe estar dentro del mismo año",
-        date_fin: "El periodo personalizado debe estar dentro del mismo año",
-      };
-    }
-    if (Object.keys(err).length > 0) {
-      setErrors(err);
-      return;
-    }
-    if (formState.date_inicio && formState.date_fin) {
-      setFormStateFilter({
-        ...formStateFilter,
-        filter_date: "c:" + formState.date_inicio + "," + formState.date_fin,
-      });
-    }
-    setOpenCustomFilter(false);
-    setErrors({});
   };
   const getCategories = () => {
     let data = [];
@@ -1040,7 +989,6 @@ const BalanceGeneral: React.FC = () => {
       <DateRangeFilterModal
         open={openCustomFilter}
         onClose={() => {
-          setFormState({});
           setOpenCustomFilter(false);
           setErrors({});
         }}

--- a/src/modulos/Balance/Balance.tsx
+++ b/src/modulos/Balance/Balance.tsx
@@ -364,7 +364,7 @@ const BalanceGeneral: React.FC = () => {
     }
     return "Total del saldo acumulado";
   };
-  const filtrarHastaMesActual = (data: any[], tipo: string) => {
+  const filtrarHastaMesActual = (data: any[]) => {
     if (formStateFilter.filter_date === "y" && Array.isArray(data)) {
       const mesActual = new Date().getMonth();
       return data.filter((item: any) => {
@@ -393,59 +393,30 @@ const BalanceGeneral: React.FC = () => {
     return formStateFilter.filter_categ;
   };
 
-  const filtrarPorCategorias = (data: any[], key: string) => {
-    const selectcategorias = getSelectCategorias();
-    if (selectcategorias && selectcategorias.length > 0) {
-      return data.filter((item: any) => selectcategorias.includes(item[key]));
-    }
-    return data;
-  };
-
-  const getLegendIngresos = () => {
-    const selectcategorias = getSelectCategorias();
-    let legend = legendCategoriasIngresos;
-    if (selectcategorias && selectcategorias.length > 0) {
-      legend = (finanzas?.data?.ingresosHist ?? [])
-        .filter((item: any) => selectcategorias.includes(item.category_id))
-        .reduce((acc: any[], item: any) => {
-          let found = acc.find((a) => a.id === item.categ_id);
-          if (found) {
-            found.total = roundMoney(found.total + parseFloat(item.amount ?? 0));
-          } else {
-            acc.push({
-              id: item.categ_id,
-              name: item.name,
-              total: roundMoney(parseFloat(item.amount ?? 0)),
-            });
-          }
-          return acc;
-        }, []);
-    }
-    return legend;
-  };
-
-  const getLegendEgresos = () => {
-    const selectcategorias = getSelectCategorias();
-    let legend = legendCategoriasEgresos;
-    if (selectcategorias && selectcategorias.length > 0) {
-      legend = (finanzas?.data?.egresosHist ?? [])
-        .filter((item: any) => selectcategorias.includes(item.category_id))
-        .reduce((acc: any[], item: any) => {
-          let found = acc.find((a) => a.id === item.categ_id);
-          if (found) {
-            found.total = roundMoney(found.total + parseFloat(item.amount ?? 0));
-          } else {
-            acc.push({
-              id: item.categ_id,
-              name: item.name,
-              total: roundMoney(parseFloat(item.amount ?? 0)),
-            });
-          }
-          return acc;
-        }, []);
-    }
-    return legend;
-  };
+  // 🔴 CDT-31: la gráfica quedaba VACÍA al elegir una categoría.
+  //
+  // Acá vivían tres filtros por categoría del lado del cliente —uno para la
+  // gráfica y uno por cada leyenda— y los tres comparaban con `includes()`
+  // estricto contra `item.category_id`. Ese campo lo estampa la API como
+  // CADENA (`UtilsGraph::formatExpenseResultsWithAllMonths` hace
+  // `'' . $category['category_id']`, y un padre sin padre se vuelve `""`),
+  // mientras que las opciones del Select salen de `categI`/`categE`, cuyo `id`
+  // es bigint y viaja como NÚMERO. `[12].includes("12")` es `false`: el filtro
+  // devolvía SIEMPRE un arreglo vacío, la gráfica no dibujaba nada y el total
+  // del título daba 0.
+  //
+  // No se arreglaron las tres comparaciones: se BORRARON. `POST /v3/balances`
+  // ya filtra por categoría en SQL (`UtilsGraph::getEgresosHist`, y el
+  // `getIncomeReport` del lado de ingresos, con
+  // `whereIn('e.category_id', $categ)->orWhereIn('cat.category_id', $categ)`),
+  // así que `ingresosHist`/`egresosHist` llegan filtrados. Volver a filtrarlos
+  // acá era una segunda fuente de verdad que sólo podía equivocarse.
+  //
+  // ⚠️ Las tablas (`TableIngresos`/`TableEgresos`) SÍ siguen recibiendo
+  // `selectcategorias`: ellas arman sus filas desde `categI`/`categE`, que
+  // llega COMPLETO, y sin ese filtro mostrarían las categorías no elegidas en
+  // cero. Ahí la comparación es número contra número —por eso el resumen sí
+  // funcionaba mientras la gráfica no—.
 
   let ingresosContent;
   if (loadingLocal || !loaded) {
@@ -505,16 +476,12 @@ const BalanceGeneral: React.FC = () => {
           <div className={styles.chartContainer}>
             <WidgetGrafIngresos
               ingresos={filtrarHastaMesActual(
-                filtrarPorCategorias(
-                  finanzas?.data.ingresosHist || [],
-                  "category_id",
-                ),
-                "I",
+                finanzas?.data.ingresosHist || [],
               )}
               chartTypes={[charType.filter_charType]}
               h={360}
               title={`Bs ${formatNumber(
-                getLegendIngresos().reduce(
+                legendCategoriasIngresos.reduce(
                   (acc: number, cat: any) => acc + cat.total,
                   0,
                 ),
@@ -525,7 +492,7 @@ const BalanceGeneral: React.FC = () => {
             />
             <div className={styles.legendAndExportWrapper}>
               <div className={styles.legendContainer}>
-                {getLegendIngresos().map((cat, idx) => (
+                {legendCategoriasIngresos.map((cat, idx) => (
                   <div className={styles.legendItem} key={cat.name ?? idx}>
                     <div
                       className={styles.legendColor}
@@ -627,16 +594,12 @@ const BalanceGeneral: React.FC = () => {
           <div className={styles.chartContainer}>
             <WidgetGrafEgresos
               egresos={filtrarHastaMesActual(
-                filtrarPorCategorias(
-                  finanzas?.data.egresosHist || [],
-                  "category_id",
-                ),
-                "E",
+                finanzas?.data.egresosHist || [],
               )}
               chartTypes={[charType.filter_charType]}
               h={360}
               title={`Bs ${formatNumber(
-                getLegendEgresos().reduce(
+                legendCategoriasEgresos.reduce(
                   (acc: number, cat: any) => acc + cat.total,
                   0,
                 ),
@@ -647,7 +610,7 @@ const BalanceGeneral: React.FC = () => {
             />
             <div className={styles.legendAndExportWrapper}>
               <div className={styles.legendContainer}>
-                {getLegendEgresos().map((cat, idx) => (
+                {legendCategoriasEgresos.map((cat, idx) => (
                   <div className={styles.legendItem} key={cat.name ?? idx}>
                     <div
                       className={styles.legendColor}

--- a/src/modulos/Balance/TableEgresos.tsx
+++ b/src/modulos/Balance/TableEgresos.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import TableFinance from "./TableFinance/TableFinance";
+import { idCategoriaPadre } from "./categoriaPadre";
 
 interface CategoriaPrincipal {
   id: string | number;
@@ -70,26 +71,14 @@ const TableEgresos = ({
       });
     });
     subcategorias?.forEach((itemEgreso: ItemEgreso) => {
-      let parentCategoryInProcessedData: FormattedCategoryData | undefined;
-      if (itemEgreso.category_id !== null) {
-        parentCategoryInProcessedData = processedData.find(
-          (cat) => cat.id == itemEgreso.category_id
-        );
-      } else {
-        parentCategoryInProcessedData = processedData.find(
-          (cat) => cat.id == itemEgreso.categ_id
-        );
-      }
+      const idPadre = idCategoriaPadre(itemEgreso);
+      const parentCategoryInProcessedData = processedData.find(
+        (cat) => cat.id == idPadre
+      );
       if (!parentCategoryInProcessedData) {
-        if (itemEgreso.category_id !== null) {
-          console.warn(
-            `EGRESOS: Categoría padre (vía category_id ${itemEgreso.category_id}) no encontrada en la lista de categorías principales para el item ${itemEgreso.name} (ID del item: ${itemEgreso.categ_id})`
-          );
-        } else {
-          console.warn(
-            `EGRESOS: Categoría principal (vía categ_id ${itemEgreso.categ_id}) no encontrada en la lista de categorías principales para el item directo ${itemEgreso.name}`
-          );
-        }
+        console.warn(
+          `EGRESOS: Categoría padre ${idPadre} no encontrada en la lista de categorías principales para el item ${itemEgreso.name} (ID del item: ${itemEgreso.categ_id})`
+        );
         return;
       }
       const amount = parseFloat(itemEgreso.amount) || 0;

--- a/src/modulos/Balance/TableIngresos.tsx
+++ b/src/modulos/Balance/TableIngresos.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import TableFinance from "./TableFinance/TableFinance";
+import { idCategoriaPadre } from "./categoriaPadre";
 interface CategoriaPrincipal {
   id: string | number;
   name: string;
@@ -69,26 +70,14 @@ const TableIngresos = ({
       });
     });
     subcategorias?.forEach((itemIngreso: ItemIngreso) => {
-      let parentCategoryInProcessedData: FormattedCategoryData | undefined;
-      if (itemIngreso.category_id !== null) {
-        parentCategoryInProcessedData = processedData.find(
-          (cat) => cat.id == itemIngreso.category_id
-        );
-      } else {
-        parentCategoryInProcessedData = processedData.find(
-          (cat) => cat.id == itemIngreso.categ_id
-        );
-      }
+      const idPadre = idCategoriaPadre(itemIngreso);
+      const parentCategoryInProcessedData = processedData.find(
+        (cat) => cat.id == idPadre
+      );
       if (!parentCategoryInProcessedData) {
-        if (itemIngreso.category_id !== null) {
-          console.warn(
-            `INGRESOS: Categoría padre (vía category_id ${itemIngreso.category_id}) no encontrada en la lista de categorías principales para el item ${itemIngreso.name} (ID del item: ${itemIngreso.categ_id})`
-          );
-        } else {
-          console.warn(
-            `INGRESOS: Categoría principal (vía categ_id ${itemIngreso.categ_id}) no encontrada en la lista de categorías principales para el item directo ${itemIngreso.name}`
-          );
-        }
+        console.warn(
+          `INGRESOS: Categoría padre ${idPadre} no encontrada en la lista de categorías principales para el item ${itemIngreso.name} (ID del item: ${itemIngreso.categ_id})`
+        );
         return;
       }
       const amount = parseFloat(itemIngreso.amount) || 0;

--- a/src/modulos/Balance/__tests__/balanceCategoriaPadreDirecta.test.tsx
+++ b/src/modulos/Balance/__tests__/balanceCategoriaPadreDirecta.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * CDT-31 (hallazgo del mismo cruce de tipos) — una categoría PADRE con
+ * movimiento directo salía en el resumen con 0.00.
+ *
+ * Las filas del histórico traen `category_id` como CADENA, y cuando la
+ * categoría no tiene padre la API manda `""`, no `null`
+ * (`UtilsGraph::formatExpenseResultsWithAllMonths` hace
+ * `'' . $category['category_id']`). Las tablas preguntaban `!== null`: esas
+ * filas caían en la rama de "soy hija", se buscaba un padre con id `""`, no
+ * aparecía y el `return` descartaba el monto. La categoría se listaba igual
+ * —viene de `categI`/`categE`— pero con total 0.00, y el total de la tabla no
+ * la contaba.
+ *
+ * Se mide con los tipos REALES de la respuesta: ids de categoría numéricos,
+ * `categ_id`/`category_id` en texto y `""` para el padre.
+ *
+ * ## Reinyección verificada (2026-08-14)
+ *
+ * Devolviendo el `if (item.category_id !== null)` de las dos tablas, los dos
+ * casos se ponen ROJOS: "Bs 0.00" donde se esperaba "Bs 5,000.00".
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import TableIngresos from "../TableIngresos";
+import TableEgresos from "../TableEgresos";
+
+/** "Expensas" es categoría padre y recibe el movimiento directamente. */
+const CATEGORIAS = [
+  { id: 12, name: "Mantenimiento" },
+  { id: 13, name: "Expensas" },
+];
+
+const FILAS = [
+  {
+    categ_id: "120",
+    name: "Jardinería",
+    category_id: "12",
+    amount: "800.00",
+    mes: 8,
+  },
+  // 🔴 Padre con movimiento directo: `category_id` llega VACÍO, no nulo.
+  {
+    categ_id: "13",
+    name: "Expensas",
+    category_id: "",
+    amount: "5000.00",
+    mes: 8,
+  },
+];
+
+describe("CDT-31 — categoría padre con movimiento directo", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["ingresos", TableIngresos],
+    ["egresos", TableEgresos],
+  ])("la tabla de %s le suma el monto, no la deja en cero", (_caso, Tabla) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { container } = render(
+      <Tabla
+        title="Total"
+        title2="Total"
+        categorias={CATEGORIAS}
+        subcategorias={FILAS as any}
+      />,
+    );
+
+    // La fila de la categoría padre lleva su monto…
+    expect(container).toHaveTextContent("Expensas");
+    expect(container).toHaveTextContent("5,000.00");
+    // …y el total de la tabla la cuenta: 800 + 5000.
+    expect(container).toHaveTextContent("5,800.00");
+    // Ninguna fila se descartó por el camino.
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/modulos/Balance/__tests__/balanceGraficaPorCategoria.test.tsx
+++ b/src/modulos/Balance/__tests__/balanceGraficaPorCategoria.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * CDT-31 — Flujo de efectivo: al elegir una categoría la gráfica no dibujaba
+ * nada, aunque el resumen de valores de abajo sí mostraba el dato.
+ *
+ * La causa: la API estampa `category_id` como CADENA
+ * (`UtilsGraph::formatExpenseResultsWithAllMonths` hace
+ * `'' . $category['category_id']`; un padre sin padre queda en `""`), y las
+ * opciones del Select salen de `categI`/`categE`, cuyo `id` es bigint y viaja
+ * como NÚMERO. El filtro del cliente comparaba con `includes()` estricto:
+ * `[12].includes("12")` es `false`, así que la gráfica recibía SIEMPRE un
+ * arreglo vacío. Las tablas comparaban contra `categI.id` —número contra
+ * número—, y por eso el resumen seguía bien: ésa es exactamente la asimetría
+ * que reportó el tester.
+ *
+ * Por eso el test entra por la PANTALLA y por el Select de verdad, no llamando
+ * a una función con los tipos ya alineados: el defecto vive justo en el cruce
+ * entre lo que emite el Select (número) y lo que manda la API (cadena). Una
+ * entrada cómoda queda verde con el bug puesto.
+ *
+ * El doble de la API imita al back MEDIDO: filtra por categoría en SQL
+ * (`whereIn('e.category_id', $categ)->orWhereIn('cat.category_id', $categ)`) y
+ * devuelve las filas con `category_id` en texto.
+ *
+ * ## Reinyección verificada (2026-08-14)
+ *
+ * Con `ingresos={filtrarHastaMesActual(filtrarPorCategorias(...,"category_id"))}`
+ * y las leyendas filtrando por `selectcategorias.includes(item.category_id)`,
+ * se ponen ROJOS los cuatro casos: la gráfica recibe 0 filas y el título del
+ * total queda en "Bs 0".
+ */
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/** Filas que captura el doble de la gráfica, para medir qué le llegó. */
+const filasGrafica: { ingresos: any[]; egresos: any[] } = {
+  ingresos: [],
+  egresos: [],
+};
+
+vi.mock("@/mk/hooks/useAxios", async () => {
+  const React = await import("react");
+
+  /**
+   * Categorías padre del condominio. `id` bigint → NÚMERO en el JSON, que es
+   * lo que termina emitiendo el Select.
+   */
+  const CATEGORIAS = [
+    { id: 11, name: "Servicios básicos" },
+    { id: 12, name: "Mantenimiento" },
+    { id: 13, name: "Expensas" },
+  ];
+
+  /**
+   * Filas históricas tal como las arma `UtilsGraph`: `categ_id` y
+   * `category_id` en TEXTO, `amount` en texto y `mes` entero. La última fila
+   * es una categoría padre con movimiento directo: ahí `category_id` llega
+   * como `""` (el `null` de la base concatenado con cadena vacía).
+   */
+  const HIST = [
+    { categ_id: "110", name: "Agua", category_id: "11", amount: "1500.00", mes: 8 },
+    { categ_id: "111", name: "Luz", category_id: "11", amount: "2300.50", mes: 8 },
+    { categ_id: "120", name: "Jardinería", category_id: "12", amount: "800.00", mes: 8 },
+    { categ_id: "13", name: "Expensas", category_id: "", amount: "5000.00", mes: 8 },
+  ];
+
+  /** El filtro del back: la fila entra por su categoría padre o por sí misma. */
+  const filtrarComoElBack = (categ: any) => {
+    const ids = (Array.isArray(categ) ? categ : []).map(String);
+    if (ids.length === 0) return HIST;
+    return HIST.filter(
+      (fila) =>
+        ids.includes(String(fila.category_id)) ||
+        ids.includes(String(fila.categ_id)),
+    );
+  };
+
+  const useAxiosFalso = () => {
+    const [params, setParams] = React.useState<any>({});
+    // El hook de verdad baja `loaded` mientras vuela el request y lo sube al
+    // responder; la pantalla apaga su spinner local con ese flanco.
+    const [loaded, setLoaded] = React.useState(true);
+    const reLoad = React.useCallback((p: any) => {
+      setLoaded(false);
+      setParams(p);
+    }, []);
+    React.useEffect(() => {
+      setLoaded(true);
+    }, [params]);
+
+    const data = React.useMemo(() => {
+      const hist = filtrarComoElBack(params?.filter_categ);
+      return {
+        data: {
+          saldoInicial: "0.00",
+          categI: CATEGORIAS,
+          categE: CATEGORIAS,
+          ingresosHist: hist,
+          egresosHist: hist,
+        },
+      };
+    }, [params]);
+
+    return { data, loaded, reLoad, execute: vi.fn() };
+  };
+
+  return { default: useAxiosFalso };
+});
+
+vi.mock("@/mk/hooks/useAsyncExport/useAsyncExport", () => ({
+  useAsyncExport: () => ({
+    state: { isExporting: false },
+    start: vi.fn(),
+    download: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("@/mk/components/ui/LoadingScreen/LoadingScreen", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/Widgets/WidgetGrafIngresos/WidgetGrafIngresos", () => ({
+  default: ({ ingresos, title }: any) => {
+    filasGrafica.ingresos = ingresos ?? [];
+    return <div data-testid="graf-ingresos">{title}</div>;
+  },
+}));
+
+vi.mock("@/components/Widgets/WidgetGrafEgresos/WidgetGrafEgresos", () => ({
+  default: ({ egresos, title }: any) => {
+    filasGrafica.egresos = egresos ?? [];
+    return <div data-testid="graf-egresos">{title}</div>;
+  },
+}));
+
+vi.mock("@/components/Widgets/WidgetGrafBalance/WidgetGrafBalance", () => ({
+  default: () => <div data-testid="graf-balance" />,
+}));
+
+import Balance from "../Balance";
+
+/** El disparador de un `Select`, buscado por su etiqueta visible. */
+const selectTrigger = (label: string) =>
+  screen.getByText(label).closest("button") as HTMLButtonElement;
+
+/** Abre un `Select` y devuelve el panel de opciones (vive en el portal). */
+const abrirSelect = (label: string) => {
+  fireEvent.click(selectTrigger(label));
+  return within(document.getElementById("portal-root") as HTMLElement);
+};
+
+const elegir = (label: string, opcion: string) =>
+  fireEvent.click(abrirSelect(label).getByText(opcion));
+
+describe("CDT-31 — la gráfica dibuja al filtrar por categoría", () => {
+  beforeEach(() => {
+    const portal = document.createElement("div");
+    portal.id = "portal-root";
+    document.body.appendChild(portal);
+    filasGrafica.ingresos = [];
+    filasGrafica.egresos = [];
+  });
+
+  afterEach(() => {
+    document.getElementById("portal-root")?.remove();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["Ingresos", "graf-ingresos", "ingresos" as const],
+    ["Egresos", "graf-egresos", "egresos" as const],
+  ])(
+    "en %s, elegir una categoría deja las filas de esa categoría en la gráfica",
+    (movimiento, testId, clave) => {
+      render(<Balance />);
+
+      elegir("Tipo de transacción", movimiento);
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+
+      elegir("Categoría", "Servicios básicos");
+
+      // Lo que mide el ticket: la gráfica recibe filas, no un arreglo vacío.
+      expect(filasGrafica[clave]).toHaveLength(2);
+      expect(filasGrafica[clave].map((f: any) => f.name).sort()).toEqual([
+        "Agua",
+        "Luz",
+      ]);
+
+      // Y el total del título sale de esas mismas filas: 1500 + 2300,50.
+      expect(screen.getByTestId(testId)).toHaveTextContent("Bs 3,800.50");
+    },
+  );
+
+  it.each([
+    ["Ingresos", "graf-ingresos", "ingresos" as const],
+    ["Egresos", "graf-egresos", "egresos" as const],
+  ])(
+    "en %s, una categoría padre con movimiento directo (category_id vacío) también dibuja",
+    (movimiento, testId, clave) => {
+      render(<Balance />);
+
+      elegir("Tipo de transacción", movimiento);
+      elegir("Categoría", "Expensas");
+
+      expect(filasGrafica[clave]).toHaveLength(1);
+      expect(filasGrafica[clave][0].category_id).toBe("");
+      expect(screen.getByTestId(testId)).toHaveTextContent("Bs 5,000.00");
+    },
+  );
+
+  it("sin categoría elegida la gráfica recibe todo lo que mandó la API", () => {
+    render(<Balance />);
+
+    elegir("Tipo de transacción", "Egresos");
+
+    expect(filasGrafica.egresos).toHaveLength(4);
+  });
+});

--- a/src/modulos/Balance/categoriaPadre.ts
+++ b/src/modulos/Balance/categoriaPadre.ts
@@ -1,0 +1,23 @@
+/**
+ * Con qué categoría PADRE se agrupa una fila del histórico de balance.
+ *
+ * 🔴 CDT-31: "no tiene padre" NO llega como `null`. La API estampa el campo
+ * como cadena (`UtilsGraph::formatExpenseResultsWithAllMonths` hace
+ * `'' . $category['category_id']`), así que una categoría padre con movimiento
+ * DIRECTO viaja con `category_id: ""`. Las tablas comparaban contra `null` a
+ * secas: esas filas caían en la rama de "soy hija", se buscaba un padre con id
+ * `""`, no existía y el monto se descartaba en silencio — la categoría salía
+ * en la tabla con 0.00 aunque el movimiento estuviera en la base.
+ *
+ * Vive acá y no duplicado en cada tabla porque `TableIngresos` y `TableEgresos`
+ * hacen exactamente lo mismo con la misma respuesta.
+ */
+export const idCategoriaPadre = (item: {
+  categ_id: string | number;
+  category_id?: string | number | null;
+}): string | number =>
+  item.category_id === null ||
+  item.category_id === undefined ||
+  item.category_id === ""
+    ? item.categ_id
+    : item.category_id;


### PR DESCRIPTION
## CDT-31 — lado front

Va junto con **condaty2025-api#254**, que arregla el 500 del mismo ticket. Con la
API sin ese PR la pantalla no dibuja igual.

## Causa raíz

La pantalla volvía a filtrar el histórico por categoría **del lado del cliente**,
con `includes()` estricto contra `item.category_id`, que la API estampa como
**cadena** (`UtilsGraph` hace `'' . $category['category_id']`), mientras que las
opciones del Select salen de `categI`/`categE` con `id` bigint, o sea **número**.

`[12].includes("12")` es `false` → la gráfica y las dos leyendas recibían
**siempre** un arreglo vacío.

El resumen sí funcionaba, y ésa es la asimetría exacta que reporta el ticket: las
tablas comparan contra `categI.id`, número contra número.

Misma familia que CDT-30 (`0 == ""`) y CDT-38 (un filtro que vale 0 nunca viajaba).

## El arreglo: se borró el filtro, no se corrigió tres veces

`POST /v3/balances` **ya filtra por categoría en SQL** (verificado en
`UtilsGraph::getEgresosHist`). El filtro del cliente era una segunda fuente de
verdad que sólo podía equivocarse. Se fue, y las leyendas salen de los memos.

## Segundo defecto, encontrado al escribir el test

Mismo cruce de tipos, misma pantalla, nunca reportado: "sin categoría padre" no
llega como `null`, llega como `""`. Las tablas preguntaban `!== null`, buscaban un
padre con id `""`, no lo encontraban y el `return` **descartaba el monto**.

Medido: una categoría padre con movimiento directo ("Expensas" con 5.000) salía
en **Bs 0.00**, y el total de la tabla tampoco la contaba. Ahora hay una sola
forma de decidir la categoría padre (`categoriaPadre.ts`).

## Archivos

- `src/modulos/Balance/Balance.tsx:396-419`, `:478`, `:596`
- `src/modulos/Balance/categoriaPadre.ts` (nuevo)
- `src/modulos/Balance/TableIngresos.tsx:72` y `TableEgresos.tsx:73`

## Verificación

7 tests nuevos en 2 archivos. Entran por la **pantalla** y por el Select de verdad
(opciones con id numérico) contra un doble de la API que imita al back medido:
devuelve `category_id` en texto y `""` para el padre.

Verificado por reinyección, tres mitades por separado:

1. Filtro de la gráfica devuelto → `expected [] to have a length of 2 but got +0`.
2. Filtro de la leyenda devuelto → `Expected: Bs 3,800.50 / Received: Bs 0.00`.
3. `!== null` devuelto en las tablas → la categoría padre vuelve a Bs 0.00.

**Suite completa: 103 archivos, 689 tests, todos verdes** (base sin estos tests:
101/682). eslint 0 errores en Balance; `tsc` no suma ni un error en el módulo.

## Falta verificar en pantalla

Es una gráfica: en jsdom el widget está mockeado, así que el dibujo real no lo
mide nadie. Flujo de efectivo → Tipo de transacción = Ingresos (y Egresos) →
elegir una categoría: la gráfica debe dibujar barras, la leyenda listar las
subcategorías con montos, y el título del total no decir Bs 0.00. De yapa, una
categoría padre con gasto directo ahora muestra su monto en la tabla.

## Hallazgo anotado, no tocado

`rnGuard` y `rnOwner` consumen el mismo `category_id` en texto y **pueden tener la
misma comparación estricta**. Vale medirlo antes del release.