### PR TITLE
fix(pagos): precargar la fecha de cobro con el reloj local, no con UTC (CDT-36)

### DIFF
--- a/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
@@ -16,6 +16,7 @@ import {
   MONTHS_ES,
   formatToDayDDMMYYYY,
   formatToDayFdMYH,
+  getNow,
 } from "@/mk/utils/date";
 import { getFullName } from "@/mk/utils/string";
 import { getTitular } from "@/mk/utils/adapters";
@@ -335,7 +336,10 @@ const RenderView: React.FC<RenderViewProps> = ({
     const owner_id = titular?.id;
 
     return {
-      paid_at: new Date().toISOString().split("T")[0],
+      // Fecha LOCAL (Bolivia, UTC-4). Con toISOString() el cobro desde el
+      // detalle de deuda abría precargado con la fecha de mañana después de
+      // las 20:00.
+      paid_at: getNow(),
       dpto_id: debtDetail?.dpto?.nro,
       category_id: finalCategoryId,
       subcategory_id: subcategoryId,

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/__tests__/CDT36PaidAtFechaLocal.test.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/__tests__/CDT36PaidAtFechaLocal.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * CDT-36 — cobrar desde el detalle de deuda precargaba la fecha con el reloj
+ * UTC. Bolivia es UTC-4: después de las 20:00 `toISOString()` ya devuelve el
+ * día siguiente, y ese valor viaja como `item.paid_at` al formulario de pago.
+ *
+ * La zona horaria del proceso se fija acá mismo: si el runner corre en UTC la
+ * franja rota no existe. El primer `expect` verifica que quedó aplicada
+ * (offset 240) — si no, el test falla en vez de pasar por casualidad.
+ */
+process.env.TZ = "America/La_Paz";
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import RenderView from "../RenderView/RenderView";
+
+const capturedFormProps: any[] = [];
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({
+    data: null,
+    execute: vi.fn().mockResolvedValue({ data: { success: false } }),
+    loaded: true,
+  }),
+}));
+
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/modulos/Payments/RenderForm/RenderForm", () => ({
+  default: (props: any) => {
+    capturedFormProps.push(props);
+    return <div data-testid="payment-form" />;
+  },
+}));
+
+vi.mock("@/modulos/Payments/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+vi.mock("@/modulos/Expenses/ExpensesDetails/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+vi.mock("@/modulos/Reservas/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+
+const deuda = {
+  id: "d-1",
+  status: 1, // PENDING → muestra "Registrar Pago"
+  type: 0,
+  amount: "150",
+  due_at: "2026-09-30",
+  dpto: { id: 5, nro: "101", homeowner: { id: 9, name: "Mario" } },
+  subcategory: { id: 11, name: "Otras deudas" },
+};
+
+const abrirFormularioDeCobro = () => {
+  render(
+    <RenderView open item={deuda} onClose={vi.fn()} extraData={{ dptos: [] }} />,
+  );
+  fireEvent.click(screen.getByText("Registrar Pago"));
+  return capturedFormProps.at(-1)?.item;
+};
+
+describe("CDT-36 · cobrar desde el detalle de deuda precarga la fecha LOCAL", () => {
+  beforeEach(() => {
+    capturedFormProps.length = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("22:30 de Bolivia (ya es el día siguiente en UTC) precarga el día local", () => {
+    vi.setSystemTime(new Date("2026-08-15T02:30:00Z"));
+
+    expect(new Date().getTimezoneOffset()).toBe(240);
+    expect(new Date().toISOString().split("T")[0]).toBe("2026-08-15");
+
+    expect(abrirFormularioDeCobro()?.paid_at).toBe("2026-08-14");
+  });
+
+  it("mediodía: local y UTC coinciden y sigue dando el mismo día", () => {
+    vi.setSystemTime(new Date("2026-08-14T16:00:00Z"));
+
+    expect(new Date().getTimezoneOffset()).toBe(240);
+    expect(new Date().toISOString().split("T")[0]).toBe("2026-08-14");
+
+    expect(abrirFormularioDeCobro()?.paid_at).toBe("2026-08-14");
+  });
+});

--- a/src/modulos/Payments/__tests__/CDT36PaidAtFechaLocal.test.ts
+++ b/src/modulos/Payments/__tests__/CDT36PaidAtFechaLocal.test.ts
@@ -1,0 +1,74 @@
+/**
+ * CDT-36 — el formulario de cobros precargaba la fecha con el reloj UTC.
+ *
+ * Bolivia es UTC-4: entre las 20:00 y la medianoche `toISOString()` ya devuelve
+ * el día SIGUIENTE, así que el admin abría el form con la fecha de mañana y la
+ * guardaba sin mirar. El test falsea el reloj DENTRO de esa franja (22:30 de
+ * Bolivia = 02:30 UTC del día siguiente) y exige el día local.
+ *
+ * La zona horaria del proceso se fija acá mismo (`process.env.TZ`): si el
+ * runner corre en UTC la franja rota no existe y el test pasaría por
+ * casualidad. El primer `expect` de cada caso verifica que la zona quedó
+ * aplicada (offset 240) — si no, el test falla en vez de mentir.
+ */
+process.env.TZ = "America/La_Paz";
+
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { usePaymentsForm } from "../hooks/usePaymentsForm";
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({ store: { Unitstype: null } }),
+}));
+
+const makeProps = () =>
+  ({
+    item: null,
+    extraData: { dptos: [], categories: [], bankAccounts: [], subcategories: [] },
+    execute: vi.fn().mockResolvedValue({ data: { success: true } }),
+    showToast: vi.fn(),
+    reLoad: vi.fn(),
+    onClose: vi.fn(),
+  }) as any;
+
+describe("CDT-36 · usePaymentsForm precarga paid_at con la fecha LOCAL", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("22:30 de Bolivia (ya es el día siguiente en UTC) precarga el día local", () => {
+    vi.setSystemTime(new Date("2026-08-15T02:30:00Z"));
+
+    // La zona horaria quedó realmente aplicada y estamos en la franja rota.
+    expect(new Date().getTimezoneOffset()).toBe(240);
+    expect(new Date().toISOString().split("T")[0]).toBe("2026-08-15");
+
+    const { result } = renderHook(() => usePaymentsForm(makeProps(), false));
+
+    expect(result.current.formState.paid_at).toBe("2026-08-14");
+  });
+
+  it("mediodía: local y UTC coinciden y sigue dando el mismo día", () => {
+    vi.setSystemTime(new Date("2026-08-14T16:00:00Z"));
+
+    expect(new Date().getTimezoneOffset()).toBe(240);
+    expect(new Date().toISOString().split("T")[0]).toBe("2026-08-14");
+
+    const { result } = renderHook(() => usePaymentsForm(makeProps(), false));
+
+    expect(result.current.formState.paid_at).toBe("2026-08-14");
+  });
+
+  it("si el item ya trae paid_at, gana el del item", () => {
+    vi.setSystemTime(new Date("2026-08-15T02:30:00Z"));
+
+    const props = { ...makeProps(), item: { paid_at: "2026-01-09" } };
+    const { result } = renderHook(() => usePaymentsForm(props, false));
+
+    expect(result.current.formState.paid_at).toBe("2026-01-09");
+  });
+});

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { getFullName } from "@/mk/utils/string";
-import { MONTHS_S } from "@/mk/utils/date";
+import { MONTHS_S, getNow } from "@/mk/utils/date";
 import { getTitular } from "@/mk/utils/adapters";
 import { paymentsApi } from "../api";
 import { useAuth } from "@/mk/contexts/AuthProvider";
@@ -251,7 +251,10 @@ export const usePaymentsForm = (
     const isAmountLocked = item?.isAmountLocked || false;
 
     return {
-      paid_at: item?.paid_at || new Date().toISOString().split("T")[0],
+      // El reloj del navegador es UTC: entre las 20:00 y la medianoche de
+      // Bolivia (UTC-4) `toISOString()` ya devuelve MAÑANA y el pago se
+      // guardaba con la fecha equivocada. getNow() da el día LOCAL.
+      paid_at: item?.paid_at || getNow(),
       type: item?.type,
       file: item?.file || null,
       url_file: Array.isArray(item?.url_file) ? item.url_file : [],


### PR DESCRIPTION
CDT-36, parte del front.

Los dos formularios de cobro precargaban `paid_at` con `new Date().toISOString().split("T")[0]`. `toISOString()` devuelve la fecha en **UTC**, y Bolivia es **UTC-4**: entre las 20:00 y la medianoche el campo abria con la fecha de **manana**, y el administrador la guardaba sin mirar.

Cuatro horas por dia en que el formulario nacia con el dia equivocado.

## El arreglo ya existia

`getNow()` en `src/mk/utils/date.tsx:431` convierte a local y ademas resuelve el caso SSR (`GMT = -4` cuando el offset del servidor da 0). Hasta ahora lo usaba **un solo archivo** en todo el repo.

Dos lugares cambiados:

- `src/modulos/Payments/hooks/usePaymentsForm.ts:257`
- `src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx:341` (cobrar desde el detalle de deuda)

## Alcance: solo esos dos

El mismo patron aparece en **30 lineas de 16 archivos**. Todo el resto va en **CDT-43**, aparte. Tocar `rulesApp.tsx` — el validador de fechas compartido, que tiene el mismo defecto — mueve el comportamiento de todos los formularios a la vez, y eso no puede entrar escondido dentro de un cambio de un modulo.

## El test, que es la parte dificil

Un test que no falsea el reloj no mide nada. Y si el runner corre en UTC, la franja rota **no se reproduce** y el test pasaria por casualidad.

Por eso cada archivo fija `process.env.TZ = "America/La_Paz"` y **ancla la franja con dos aserciones**:

```ts
expect(new Date().getTimezoneOffset()).toBe(240);
expect(new Date().toISOString().split("T")[0]).toBe("2026-08-15");
```

Si el proceso corriera en UTC, esas dos fallan: el test no puede pasar fuera de la franja. Se corrio tambien con `TZ=UTC` heredada del shell y siguio midiendo la franja.

5 casos: 22:30 de Bolivia (02:30 UTC del dia siguiente), mediodia como control, y el item que ya trae `paid_at`.

Verificado por reinyeccion — devolviendo `toISOString()` en los dos lugares:

```
AssertionError: expected 2026-08-15 to be 2026-08-14
Tests  2 failed | 3 passed (5)
```

`tsc --noEmit`: 29 errores en el candidato, 29 en `origin/dev`. Cero nuevos.

Sin migracion.

## Falta la prueba en pantalla

Con el reloj de la maquina **despues de las 20:00** (Bolivia):

1. Pagos → *Nuevo pago*: el campo Fecha tiene que mostrar HOY, no manana.
2. Deudas → abrir una deuda por cobrar → *Registrar Pago*: mismo chequeo.