### PR TITLE
fix(fechas): el dia de HOY sale del reloj local, no del UTC (CDT-43)

### DIFF
--- a/context/condaty_admin_context.md
+++ b/context/condaty_admin_context.md
@@ -713,7 +713,12 @@ const fields: Record<string, FieldConfig> = {
 - Interceptors para JWT automático
 
 ##### Utilidades de la Librería
-- **date.tsx**: Utilidades completas de fechas
+- **date.tsx**: Utilidades completas de fechas.
+  🔴 El día de HOY sale SIEMPRE de `getNow()` (día calendario en la zona del
+  usuario, con el caso SSR resuelto). `new Date().toISOString()` devuelve el día
+  en **UTC** y en Bolivia (UTC-4) adelanta un día entre las 20:00 y la
+  medianoche — CDT-36 y CDT-43. Para un **instante** (`created_at`, chat,
+  cronómetros) `toISOString()` sí es lo correcto.
 - **numbers.tsx**: Formateo de números y monedas
 - **string.tsx**: Manipulación de strings
 - **images.tsx**: Procesamiento de imágenes

--- a/context/condaty_admin_context.md
+++ b/context/condaty_admin_context.md
@@ -719,6 +719,10 @@ const fields: Record<string, FieldConfig> = {
   en **UTC** y en Bolivia (UTC-4) adelanta un día entre las 20:00 y la
   medianoche — CDT-36 y CDT-43. Para un **instante** (`created_at`, chat,
   cronómetros) `toISOString()` sí es lo correcto.
+  🔴 Si necesitás un `Date` y no un string, usá `getNowDate()`. **Nunca
+  `new Date(getNow())`**: un `"YYYY-MM-DD"` pelado se parsea como medianoche
+  UTC, o sea las 20:00 del día ANTERIOR en Bolivia — corrido 4 horas las 24
+  horas del día.
 - **numbers.tsx**: Formateo de números y monedas
 - **string.tsx**: Manipulación de strings
 - **images.tsx**: Procesamiento de imágenes

--- a/src/components/validators/rulesApp.tsx
+++ b/src/components/validators/rulesApp.tsx
@@ -1,6 +1,7 @@
 import { ValidFunctionType } from "@/mk/utils/validate/Rules";
 import { getIdentityDocumentCode } from "@/i18n/identity";
 import { getCurrentClientLocale } from "@/i18n/runtime";
+import { getNow } from "@/mk/utils/date";
 
 const formatDate = (date: Date) => date.toISOString().split("T")[0];
 
@@ -99,7 +100,7 @@ export const validDateGreater: ValidFunctionType = (
   let compareDate =
     param && param[0]
       ? normalizeDateToUTC(field ? field[param[0]] : "")
-      : normalizeDateToUTC(new Date().toISOString());
+      : normalizeDateToUTC(getNow());
 
   if (!compareDate) return "La fecha de comparación no es válida";
 
@@ -127,9 +128,10 @@ export const validDateFuture: ValidFunctionType = (
     return "La fecha ingresada no es válida";
   }
 
-  // Obtener la fecha actual en UTC sin la parte de la hora
-  let today = new Date();
-  today.setUTCHours(0, 0, 0, 0); // Asegurar que solo comparamos fechas, sin horas
+  // CDT-43: el ancla es el día LOCAL (Bolivia, UTC-4) normalizado igual que el
+  // valor del input. Truncar el reloj en UTC adelantaba un día entre las 20:00
+  // y la medianoche, y rechazaba "mañana" como si no fuera futuro.
+  const today = normalizeDateToUTC(getNow()) as Date;
 
   // console.log("rules day", date, today);
 
@@ -151,7 +153,7 @@ export const validDateLess: ValidFunctionType = (
   let compareDate =
     param && param[0]
       ? normalizeDateToUTC(field ? field[param[0]] : "")
-      : normalizeDateToUTC(new Date().toISOString());
+      : normalizeDateToUTC(getNow());
 
   if (!compareDate) return "La fecha de comparación no es válida";
 

--- a/src/mk/utils/date.tsx
+++ b/src/mk/utils/date.tsx
@@ -446,6 +446,18 @@ export const getNow = (): string => {
   // return new Date().toISOString().substring(0, 10);
 };
 
+/**
+ * La MEDIANOCHE LOCAL del día de hoy, como `Date`.
+ *
+ * 🔴 No usar `new Date(getNow())`. Un `"YYYY-MM-DD"` pelado se parsea como
+ * medianoche **UTC**, o sea las 20:00 del día ANTERIOR en Bolivia: queda
+ * corrido 4 horas las 24 horas del día, peor que el bug que se quería
+ * arreglar. La `T00:00:00` **sin `Z`** es la que fuerza el parseo local.
+ * Medido en la review de CDT-43, donde ese `new Date(getNow())` entró como
+ * regresión en Events y Surveys.
+ */
+export const getNowDate = (): Date => new Date(`${getNow()}T00:00:00`);
+
 export const getDateDesdeHasta = (date: any, locale?: AppLocale) => {
   const fechaActual = new Date();
   //convertir fechaActual a hora local

--- a/src/mk/utils/date.tsx
+++ b/src/mk/utils/date.tsx
@@ -428,6 +428,18 @@ export const getDateStrMesShort = (
 //   return `${date[2]} ${MONTHS_S[parseInt(date[1])]} ${date[0]}, ${time}`;
 // };
 
+/**
+ * El día de HOY (YYYY-MM-DD) en la zona del usuario — helper CANÓNICO.
+ *
+ * 🔴 `new Date().toISOString()` devuelve el día en UTC. Bolivia es UTC-4, así
+ * que entre las 20:00 y la medianoche ese cálculo da MAÑANA: cuatro horas por
+ * día en las que el admin cree que es otro día. Medido en CDT-36 (precargaba
+ * `paid_at` con el día siguiente) y en CDT-43 (una deuda que vencía HOY se
+ * pintaba "En mora" después de las 20:00).
+ *
+ * Para un INSTANTE (`created_at`, un mensaje de chat, un cronómetro)
+ * `toISOString()` sigue siendo lo correcto; esto es sólo para el día calendario.
+ */
 export const getNow = (): string => {
   const fec: any = convertirFechaUTCaLocal(new Date().toISOString());
   return fec.toISOString().substring(0, 10);

--- a/src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx
+++ b/src/modulos/Areas/MaintenanceModal/MaintenanceModal.tsx
@@ -14,6 +14,7 @@ import { IconX } from "@/components/layout/icons/IconsBiblioteca";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import SkeletonAdapterComponent from "@/mk/components/ui/LoadingScreen/SkeletonAdapter";
 import { ReservationStatus } from "@/modulos/Reservas/Type/ReservaType";
+import { getNow } from "@/mk/utils/date";
 
 interface Props {
   open: boolean;
@@ -218,12 +219,12 @@ const MaintenanceModal = ({ open, onClose, areas }: Props) => {
                   error={errors}
                   value={formState?.date_at}
                   onChange={handleChange}
-                  min={new Date().toISOString().split("T")[0] + "T00:00"}
+                  min={getNow() + "T00:00"}
                 />
                 <Input
                   label="Fecha de finalización"
                   type="datetime-local"
-                  min={new Date().toISOString().split("T")[0] + "T00:00"}
+                  min={getNow() + "T00:00"}
                   name="date_end"
                   error={errors}
                   value={formState?.date_end}

--- a/src/modulos/CreateReserva/CreateReserva.tsx
+++ b/src/modulos/CreateReserva/CreateReserva.tsx
@@ -51,15 +51,31 @@ interface FormErrors {
   telefono_responsable?: string;
   email_responsable?: string;
 }
+// 🔴 El orden es el de `Date.getDay()`: DOMINGO primero. No lo "arregles" a
+// lunes-primero: se indexa siempre con `getDay()`. Las cadenas tienen que
+// coincidir con las de `available_days`, que el admin elige en
+// `Areas/RenderForm/Partes/SecondPart.tsx` (con acentos).
 const weekDay = [
+  "Domingo",
   "Lunes",
   "Martes",
   "Miércoles",
   "Jueves",
   "Viernes",
   "Sábado",
-  "Domingo",
 ];
+
+/**
+ * El nombre del día de la semana de un `"YYYY-MM-DD"`, leído en zona LOCAL.
+ *
+ * 🔴 La `T00:00:00` **sin `Z`** es la que fuerza el parseo local: un
+ * `"YYYY-MM-DD"` pelado se lee como medianoche UTC y en Bolivia (UTC-4)
+ * devuelve el día ANTERIOR. Antes había dos errores acá que se cancelaban
+ * exactamente — el array arrancaba en lunes y la fecha venía corrida un día —
+ * así que "arreglar" cualquiera de las dos mitades sola rompía la pantalla.
+ */
+export const diaDeLaSemanaDe = (fecha: string): string =>
+  weekDay[new Date(`${fecha}T00:00:00`).getDay()];
 const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
   const [currentStep, setCurrentStep] = useState<number>(1);
   const [formState, setFormState] = useState<FormState>(initialState);
@@ -299,19 +315,11 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
   const nextStep = (): void => {
     if (currentStep === 1) {
       const dateNow = getNow();
-      const day = new Date(dateNow).getDay();
-      const weekday = [
-        "Lunes",
-        "Martes",
-        "Miércoles",
-        "Jueves",
-        "Viernes",
-        "Sábado",
-        "Domingo",
-      ];
 
       if (
-        selectedAreaDetails?.available_days?.includes(weekday[day]) &&
+        selectedAreaDetails?.available_days?.includes(
+          diaDeLaSemanaDe(dateNow),
+        ) &&
         !formState?.fecha
       ) {
         handleDateChange(dateNow);
@@ -711,7 +719,7 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
                     >
                       <IconCalendar />
                       <p>
-                        {weekDay[new Date(formState.fecha).getDay()] +
+                        {diaDeLaSemanaDe(formState.fecha) +
                           ", " +
                           getDateStrMes(formState.fecha)}
                       </p>

--- a/src/modulos/CreateReserva/CreateReserva.tsx
+++ b/src/modulos/CreateReserva/CreateReserva.tsx
@@ -28,6 +28,7 @@ import HeaderBack from "@/mk/components/ui/HeaderBack/HeaderBack";
 import { formatBs, formatNumber } from "@/mk/utils/numbers";
 import Tooltip from "@/mk/components/ui/Tooltip/Tooltip";
 import RenderView from "../DebtsManager/TabComponents/AllDebts/RenderView/RenderView";
+import { getNow } from "@/mk/utils/date";
 
 const initialState: FormState = {
   unidad: "",
@@ -123,7 +124,7 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
         "GET",
         {
           area_id: formState?.area_social || "none",
-          date_at: date || new Date().toISOString()?.split("T")[0],
+          date_at: date || getNow(),
           owner_id:
             ownerId ||
             extraData?.dptos?.find(
@@ -251,7 +252,7 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
     let daysAvailable = [];
     let unavailableSlots = [];
 
-    if (dateString == new Date().toISOString().split("T")?.[0]) {
+    if (dateString == getNow()) {
       daysAvailable = dataDay?.available.filter(
         (d: any) => parseInt(d.split("-")[1]) > new Date().getHours(),
       );
@@ -297,7 +298,7 @@ const CreateReserva = ({ extraData, setOpenList, onClose, reLoad }: any) => {
   };
   const nextStep = (): void => {
     if (currentStep === 1) {
-      const dateNow = new Date().toISOString().split("T")?.[0];
+      const dateNow = getNow();
       const day = new Date(dateNow).getDay();
       const weekday = [
         "Lunes",

--- a/src/modulos/CreateReserva/__tests__/CDT43WeekdayLocal.test.ts
+++ b/src/modulos/CreateReserva/__tests__/CDT43WeekdayLocal.test.ts
@@ -1,0 +1,98 @@
+/**
+ * CDT-43 — el día de la semana con el que se decide si HOY es un día
+ * disponible del área.
+ *
+ * Acá vivían DOS errores que se cancelaban exactamente:
+ *   1. el array arrancaba en "Lunes", pero `getDay()` devuelve 0 = domingo;
+ *   2. `new Date("YYYY-MM-DD")` se parsea como medianoche UTC y en Bolivia
+ *      (UTC-4) devuelve el día ANTERIOR.
+ * Corrido +1 y corrido -1 daban el nombre correcto. Funcionaba, pero el
+ * próximo que "arreglara" cualquiera de las dos mitades rompía la pantalla
+ * sin tocar nada relacionado.
+ *
+ * Este test mide las dos mitades JUNTAS contra el array real del módulo:
+ * si alguna vuelve a correrse, se pone en rojo.
+ *
+ * La zona se fija acá y se ANCLA con el offset: sin el ancla el test pasaría
+ * en cualquier zona horaria y no mediría nada.
+ */
+process.env.TZ = "America/La_Paz";
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { diaDeLaSemanaDe } from "../CreateReserva";
+import { getNow } from "@/mk/utils/date";
+
+// Exactamente lo que hace nextStep(): el resolver REAL del módulo.
+const diaDeHoy = () => diaDeLaSemanaDe(getNow());
+
+const anclarLaFranja = (instante: string) => {
+  vi.setSystemTime(new Date(instante));
+  expect(new Date().getTimezoneOffset()).toBe(240);
+};
+
+describe("CDT-43 · el día de la semana de HOY en CreateReserva", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  // Los dos extremos del array: un corrimiento en cualquier dirección se ve acá.
+  describe("domingo (índice 0) y lunes (índice 1)", () => {
+    it("domingo 2026-08-09 al mediodía", () => {
+      anclarLaFranja("2026-08-09T16:00:00Z");
+      expect(diaDeHoy()).toBe("Domingo");
+    });
+
+    it("domingo 2026-08-09 a las 22:00 (en UTC ya es lunes)", () => {
+      anclarLaFranja("2026-08-10T02:00:00Z");
+      expect(new Date().toISOString().split("T")[0]).toBe("2026-08-10");
+      expect(diaDeHoy()).toBe("Domingo");
+    });
+
+    it("lunes 2026-08-10 al mediodía", () => {
+      anclarLaFranja("2026-08-10T16:00:00Z");
+      expect(diaDeHoy()).toBe("Lunes");
+    });
+
+    it("lunes 2026-08-10 a las 22:00 (en UTC ya es martes)", () => {
+      anclarLaFranja("2026-08-11T02:00:00Z");
+      expect(new Date().toISOString().split("T")[0]).toBe("2026-08-11");
+      expect(diaDeHoy()).toBe("Lunes");
+    });
+  });
+
+  it("los 7 días de la semana, al mediodía y a las 22:00", () => {
+    const semana = [
+      ["2026-08-09", "Domingo"],
+      ["2026-08-10", "Lunes"],
+      ["2026-08-11", "Martes"],
+      ["2026-08-12", "Miércoles"],
+      ["2026-08-13", "Jueves"],
+      ["2026-08-14", "Viernes"],
+      ["2026-08-15", "Sábado"],
+    ];
+
+    for (const [fecha, esperado] of semana) {
+      // mediodía local = 16:00 UTC; 22:00 local = 02:00 UTC del día siguiente.
+      anclarLaFranja(`${fecha}T16:00:00Z`);
+      expect(diaDeHoy()).toBe(esperado);
+
+      const siguiente = new Date(`${fecha}T00:00:00Z`);
+      siguiente.setUTCDate(siguiente.getUTCDate() + 1);
+      anclarLaFranja(`${siguiente.toISOString().split("T")[0]}T02:00:00Z`);
+      expect(diaDeHoy()).toBe(esperado);
+    }
+  });
+
+  it("las cadenas coinciden con las de available_days (con acentos)", () => {
+    // Las elige el admin en Areas/RenderForm/Partes/SecondPart.tsx.
+    const available_days = ["Miércoles", "Sábado"];
+
+    anclarLaFranja("2026-08-12T16:00:00Z"); // miércoles
+    expect(available_days.includes(diaDeHoy())).toBe(true);
+
+    anclarLaFranja("2026-08-15T16:00:00Z"); // sábado
+    expect(available_days.includes(diaDeHoy())).toBe(true);
+
+    anclarLaFranja("2026-08-14T16:00:00Z"); // viernes: no está disponible
+    expect(available_days.includes(diaDeHoy())).toBe(false);
+  });
+});

--- a/src/modulos/DashDptos/UnitFinanceHistory/UnitFinanceHistory.tsx
+++ b/src/modulos/DashDptos/UnitFinanceHistory/UnitFinanceHistory.tsx
@@ -7,7 +7,7 @@ import EmptyData from "@/components/NoData/EmptyData";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
 import { TableSkeleton } from "@/mk/components/ui/Skeleton/Skeleton";
 import FormatBsAlign from "@/mk/utils/FormatBsAlign";
-import { MONTHS_S, getDateStrMes, getDateStrMesShort } from "@/mk/utils/date";
+import { MONTHS_S, getDateStrMes, getDateStrMesShort, getNow } from "@/mk/utils/date";
 import { getPaymentStatusConfig } from "@/modulos/Payments/Type/PaymentType";
 import { DebtStatus } from "@/types/PaymentType";
 import {
@@ -135,7 +135,7 @@ const normalizeDebtRow = (row: any) => ({
 const resolveDebtStatus = (row: any): number => {
   const status = getDebtNumericStatus(row);
   const dueAtString = row?.due_at || "";
-  const todayString = new Date().toISOString().split("T")[0];
+  const todayString = getNow();
 
   if (status === DebtStatus.PENDING && dueAtString && dueAtString < todayString) {
     return DebtStatus.OVERDUE;

--- a/src/modulos/DashDptos/UnitFinanceHistory/__tests__/UnitFinanceHistory.test.ts
+++ b/src/modulos/DashDptos/UnitFinanceHistory/__tests__/UnitFinanceHistory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { MONTHS_S } from "@/mk/utils/date";
+import { MONTHS_S, getNow } from "@/mk/utils/date";
 import { DebtStatus } from "@/types/PaymentType";
 import {
   getPaymentStatusConfig,
@@ -58,7 +58,7 @@ const getDebtNumericStatus = (row: any): number => {
 const resolveDebtStatus_numeric = (row: any): number => {
   const status = getDebtNumericStatus(row);
   const dueAtString = row?.due_at || "";
-  const todayString = new Date().toISOString().split("T")[0];
+  const todayString = getNow();
 
   if (status === DebtStatus.PENDING && dueAtString && dueAtString < todayString) {
     return DebtStatus.OVERDUE;

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/AllDebts.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useEffect, useState } from "react";
 import useCrud, { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
 import useCrudUtils from "../../../shared/useCrudUtils";
-import { getDateStrMesShort } from "@/mk/utils/date";
+import { getDateStrMesShort, getNow } from "@/mk/utils/date";
 import RenderForm from "./RenderForm/RenderForm";
 import RenderView from "./RenderView/RenderView";
 import { IconCategories } from "@/components/layout/icons/IconsBiblioteca";
@@ -550,7 +550,7 @@ const AllDebts: React.FC<AllDebtsProps> = ({ onExtraDataChange }) => {
     const numericStatus = Number.isFinite(rawStatus) && rawStatus > 0 ? rawStatus : DebtStatus.PENDING;
     // getStatusConfig applies the overdue rule internally
     const dueAtString = item?.due_at;
-    const displayStatus = dueAtString && dueAtString < new Date().toISOString().split("T")[0] && numericStatus === DebtStatus.PENDING
+    const displayStatus = dueAtString && dueAtString < getNow() && numericStatus === DebtStatus.PENDING
       ? DebtStatus.OVERDUE
       : numericStatus;
 

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
@@ -77,9 +77,6 @@ const RenderView: React.FC<RenderViewProps> = ({
     string | number | null
   >(getResolvedPaymentId(item));
 
-  // Declarar la variable today
-  const today = new Date();
-
   const { data, execute, loaded } = useAxios(
     "/v3/debt-dptos",
     "GET",
@@ -104,7 +101,7 @@ const RenderView: React.FC<RenderViewProps> = ({
 
   // Numeric overdue rule: PENDING + past dueDate => OVERDUE
   const resolveStatus = (status: number, dueDate?: string): number => {
-    const todayString = new Date().toISOString().split("T")[0];
+    const todayString = getNow();
     if (dueDate && dueDate < todayString && status === DebtStatus.PENDING) {
       return DebtStatus.OVERDUE;
     }

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/__tests__/CDT43FechaDeHoyLocal.test.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/__tests__/CDT43FechaDeHoyLocal.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * CDT-43 — el día de HOY se sacaba del reloj con `new Date().toISOString()`,
+ * que devuelve el día en UTC. Bolivia es UTC-4: entre las 20:00 y la medianoche
+ * ese cálculo ya da MAÑANA. Cuatro horas por día en que el admin cree que es
+ * otro día.
+ *
+ * El peor caso no es un valor precargado sino un ESTADO QUE SE MUESTRA: una
+ * deuda que vence HOY se pintaba "En mora" a partir de las 20:00. El usuario ve
+ * una mentira sobre su propia deuda.
+ *
+ * La zona horaria se fija acá mismo y se ANCLA con el offset: si el runner
+ * corriera en UTC la franja rota no existiría y el test pasaría por casualidad.
+ */
+process.env.TZ = "America/La_Paz";
+
+import React from "react";
+import { render, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import RenderView from "../RenderView/RenderView";
+import { getStatusConfig, DEBT_STATUS_CONFIG } from "../../constants";
+import {
+  validDateFuture,
+  validDateGreater,
+  validDateLess,
+} from "@/components/validators/rulesApp";
+import { DebtStatus } from "@/types/PaymentType";
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({ data: null, execute: vi.fn(), loaded: true }),
+}));
+
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/modulos/Payments/RenderForm/RenderForm", () => ({
+  default: () => <div />,
+}));
+vi.mock("@/modulos/Payments/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+vi.mock("@/modulos/Expenses/ExpensesDetails/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+vi.mock("@/modulos/Reservas/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+
+// 22:30 en La Paz del 14/08; en UTC ya es el 15.
+const LA_NOCHE_DEL_14 = new Date("2026-08-15T02:30:00Z");
+// mediodía del 14: local y UTC coinciden, el control sano.
+const EL_MEDIODIA_DEL_14 = new Date("2026-08-14T16:00:00Z");
+
+const deudaQueVenceHoy = {
+  id: "d-1",
+  status: DebtStatus.PENDING,
+  type: 0,
+  amount: "150",
+  due_at: "2026-08-14",
+  dpto: { id: 5, nro: "101", homeowner: { id: 9, name: "Mario" } },
+  subcategory: { id: 11, name: "Otras deudas" },
+};
+
+const estadoQueSeMuestra = (item: any) => {
+  const { container } = render(
+    <RenderView open item={item} onClose={vi.fn()} extraData={{ dptos: [] }} />,
+  );
+  return within(container);
+};
+
+const anclarLaFranja = (instante: Date) => {
+  vi.setSystemTime(instante);
+  // Sin este ancla el test pasa en cualquier zona horaria y no mide nada.
+  expect(new Date().getTimezoneOffset()).toBe(240);
+};
+
+describe("CDT-43 · el día de HOY es el LOCAL, no el UTC", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  describe("estado que se muestra en el detalle de deuda", () => {
+    it("22:30 del 14: una deuda que vence HOY no está en mora", () => {
+      anclarLaFranja(LA_NOCHE_DEL_14);
+      // El día UTC ya es el 15: ese es exactamente el valor que rompía.
+      expect(new Date().toISOString().split("T")[0]).toBe("2026-08-15");
+
+      const vista = estadoQueSeMuestra(deudaQueVenceHoy);
+
+      expect(vista.queryByText("En mora")).toBeNull();
+      expect(vista.getByText("Por cobrar")).toBeTruthy();
+    });
+
+    it("22:30 del 14: una deuda vencida AYER sigue en mora", () => {
+      anclarLaFranja(LA_NOCHE_DEL_14);
+
+      const vista = estadoQueSeMuestra({
+        ...deudaQueVenceHoy,
+        due_at: "2026-08-13",
+      });
+
+      expect(vista.getByText("En mora")).toBeTruthy();
+    });
+
+    it("mediodía del 14: la que vence hoy tampoco está en mora", () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+
+      const vista = estadoQueSeMuestra(deudaQueVenceHoy);
+
+      expect(vista.queryByText("En mora")).toBeNull();
+    });
+  });
+
+  describe("getStatusConfig — la regla de mora compartida", () => {
+    it("22:30 del 14: vence hoy → color de PENDING, no de OVERDUE", () => {
+      anclarLaFranja(LA_NOCHE_DEL_14);
+
+      expect(getStatusConfig(DebtStatus.PENDING, "2026-08-14")).toEqual(
+        DEBT_STATUS_CONFIG[DebtStatus.PENDING],
+      );
+      expect(getStatusConfig(DebtStatus.PENDING, "2026-08-13")).toEqual(
+        DEBT_STATUS_CONFIG[DebtStatus.OVERDUE],
+      );
+    });
+  });
+
+  describe("rulesApp — el validador de fechas de TODOS los formularios", () => {
+    it("22:30 del 14: MAÑANA es una fecha futura válida", () => {
+      anclarLaFranja(LA_NOCHE_DEL_14);
+
+      expect(validDateFuture("2026-08-15", [])).toBe("");
+      expect(validDateFuture("2026-08-14", [])).not.toBe("");
+    });
+
+    it("22:30 del 14: HOY no es menor que hoy ni mayor que hoy", () => {
+      anclarLaFranja(LA_NOCHE_DEL_14);
+
+      expect(validDateGreater("2026-08-14", [])).toBe("");
+      expect(validDateLess("2026-08-14", [])).toBe("");
+      expect(validDateGreater("2026-08-13", [])).not.toBe("");
+    });
+
+    it("mediodía del 14: el mismo comportamiento", () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+
+      expect(validDateFuture("2026-08-15", [])).toBe("");
+      expect(validDateGreater("2026-08-14", [])).toBe("");
+    });
+  });
+});

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/__tests__/CDT43FechaDeHoyLocal.test.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/__tests__/CDT43FechaDeHoyLocal.test.tsx
@@ -24,6 +24,7 @@ import {
   validDateLess,
 } from "@/components/validators/rulesApp";
 import { DebtStatus } from "@/types/PaymentType";
+import { getNow, getNowDate } from "@/mk/utils/date";
 
 vi.mock("@/mk/contexts/AuthProvider", () => ({
   useAuth: () => ({ showToast: vi.fn() }),
@@ -124,6 +125,38 @@ describe("CDT-43 · el día de HOY es el LOCAL, no el UTC", () => {
       expect(getStatusConfig(DebtStatus.PENDING, "2026-08-13")).toEqual(
         DEBT_STATUS_CONFIG[DebtStatus.OVERDUE],
       );
+    });
+  });
+
+  describe("getNowDate — la MEDIANOCHE LOCAL, no la UTC", () => {
+    // Regresión encontrada en la review: `new Date(getNow())` parsea el
+    // "YYYY-MM-DD" pelado como medianoche UTC, o sea las 20:00 del día
+    // ANTERIOR en Bolivia. Queda corrido 4 horas las 24 horas del día — peor
+    // que el bug original, que sólo fallaba de 20:00 a medianoche.
+    it("22:30 del 14: es el 14 a las 00:00 locales", () => {
+      anclarLaFranja(LA_NOCHE_DEL_14);
+
+      const hoy = getNowDate();
+
+      expect(hoy.getFullYear()).toBe(2026);
+      expect(hoy.getMonth()).toBe(7); // agosto
+      expect(hoy.getDate()).toBe(14);
+      expect(hoy.getHours()).toBe(0);
+      expect(hoy.getTime()).toBe(new Date(2026, 7, 14).getTime());
+
+      // El anti-ejemplo: así se veía la regresión.
+      expect(new Date(getNow()).getDate()).toBe(13);
+      expect(new Date(getNow()).getHours()).toBe(20);
+    });
+
+    it("mediodía del 14: sigue siendo el 14 a las 00:00 locales", () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+
+      const hoy = getNowDate();
+
+      expect(hoy.getDate()).toBe(14);
+      expect(hoy.getHours()).toBe(0);
+      expect(hoy.getTime()).toBe(new Date(2026, 7, 14).getTime());
     });
   });
 

--- a/src/modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx
+++ b/src/modulos/DebtsManager/TabComponents/Forgiveness/Forgiveness.tsx
@@ -5,7 +5,7 @@ import { getFullName } from '@/mk/utils/string';
 import React, { useEffect, useMemo } from 'react';
 import styles from './Forgiveness.module.css';
 import { IconCategories } from '@/components/layout/icons/IconsBiblioteca';
-import { getDateStrMesShort } from '@/mk/utils/date';
+import { getDateStrMesShort, getNow } from '@/mk/utils/date';
 import RenderForm from './RenderForm/RenderForm';
 import { formatBs } from '@/mk/utils/numbers';
 import { DebtStatus } from '@/types/PaymentType';
@@ -118,7 +118,7 @@ const Forgiveness = ({
           onRender: ({ item }: any) => {
             const numericStatus = Number(item?.status);
             const isOverdue =
-              item?.due_at < new Date().toISOString().split('T')[0] &&
+              item?.due_at < getNow() &&
               numericStatus === DebtStatus.PENDING;
             const displayStatus = isOverdue ? DebtStatus.OVERDUE : numericStatus;
             // getStatusConfig aplica la regla de mora (PENDING + vencido → OVERDUE)

--- a/src/modulos/DebtsManager/TabComponents/Forgiveness/RenderForm/RenderForm.tsx
+++ b/src/modulos/DebtsManager/TabComponents/Forgiveness/RenderForm/RenderForm.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useState } from "react";
 import { formatBs } from "../../../../../mk/utils/numbers";
 import KeyValue from "@/mk/components/ui/KeyValue/KeyValue";
 import Br from "@/components/Detail/Br";
+import { getNow } from "@/mk/utils/date";
 
 const RenderForm = ({
   open,
@@ -274,7 +275,7 @@ const RenderForm = ({
           value={formState?.due_at}
           onChange={handleChange}
           error={errors}
-          min={new Date().toISOString().split("T")[0]}
+          min={getNow()}
         />
       </div>
       <div style={{ display: "flex", justifyContent: "space-between" }}>

--- a/src/modulos/DebtsManager/TabComponents/Forgiveness/RenderView/RenderView.tsx
+++ b/src/modulos/DebtsManager/TabComponents/Forgiveness/RenderView/RenderView.tsx
@@ -1,6 +1,6 @@
 import DataModal from '@/mk/components/ui/DataModal/DataModal';
 import Table from '@/mk/components/ui/Table/Table';
-import { getDateStrMesShort } from '@/mk/utils/date';
+import { getDateStrMesShort, getNow } from '@/mk/utils/date';
 import { formatBs } from '@/mk/utils/numbers';
 import { getFullName } from '@/mk/utils/string';
 import React from 'react';
@@ -93,7 +93,7 @@ const RenderView = ({ open, onClose, item, onDel, onEdit }: any) => {
   const getStatus = (item: any) => {
     const numericStatus = Number(item?.status);
     if (
-      item?.due_at < new Date().toISOString().split('T')[0] &&
+      item?.due_at < getNow() &&
       numericStatus === DebtStatus.PENDING
     ) {
       return DebtStatus.OVERDUE;
@@ -109,7 +109,7 @@ const RenderView = ({ open, onClose, item, onDel, onEdit }: any) => {
     DebtStatus.SUBMITTED,
     DebtStatus.CANCELLED,
   ].includes(numericStatus);
-  const isOverdue = item?.due_at < new Date().toISOString().split('T')[0];
+  const isOverdue = item?.due_at < getNow();
   return (
     <DataModal
       title="Detalle de condonación"

--- a/src/modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/IndividualDebts/IndividualDebts.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useEffect, useState } from 'react';
 import useCrud, { ModCrudType } from '@/mk/hooks/useCrud/useCrud';
 import useCrudUtils from '../../../shared/useCrudUtils';
-import { getDateStrMes, getDateStrMesShort, MONTHS } from '@/mk/utils/date';
+import { getDateStrMes, getDateStrMesShort, getNow, MONTHS } from '@/mk/utils/date';
 import RenderForm from './RenderForm/RenderForm';
 import { IconCategories } from '@/components/layout/icons/IconsBiblioteca';
 import FormatBsAlign from '@/mk/utils/FormatBsAlign';
@@ -428,7 +428,7 @@ const IndividualDebts: React.FC<IndividualDebtsProps> = ({
     const rawStatus = Number(item?.status);
     const numericStatus = Number.isFinite(rawStatus) && rawStatus > 0 ? rawStatus : DebtStatus.PENDING;
     const dueAtString = item?.due_at;
-    const todayString = new Date().toISOString().split('T')[0];
+    const todayString = getNow();
     const displayStatus = dueAtString && dueAtString < todayString && numericStatus === DebtStatus.PENDING
       ? DebtStatus.OVERDUE
       : numericStatus;

--- a/src/modulos/DebtsManager/TabComponents/IndividualDebts/RenderForm/RenderForm.tsx
+++ b/src/modulos/DebtsManager/TabComponents/IndividualDebts/RenderForm/RenderForm.tsx
@@ -11,6 +11,7 @@ import { hasMaintenanceValue, UnitsType } from '@/mk/utils/utils';
 import styles from './RenderForm.module.css';
 import { IconArrowDown, IconQuestion } from '@/components/layout/icons/IconsBiblioteca';
 import { checkRules } from '@/mk/utils/validate/Rules';
+import { getNow } from "@/mk/utils/date";
 
 interface DebtFormState {
   id?: string | number;
@@ -62,8 +63,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
   action,
 }) => {
   const [_formState, _setFormState] = useState<DebtFormState>(() => {
-    const today = new Date();
-    const formattedDate = today.toISOString().split('T')[0];
+    const formattedDate = getNow();
     return {
       ...(item || {}),
       begin_at: (item && item.begin_at) || formattedDate,
@@ -111,8 +111,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
       return;
     }
     if (!isInitialized && open) {
-      const today = new Date();
-      const formattedDate = today.toISOString().split('T')[0];
+      const formattedDate = getNow();
 
       _setFormState({
         ...(item || {}),
@@ -237,8 +236,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
 
   const onCloseModal = useCallback(() => {
     setIsInitialized(false);
-    const today = new Date();
-    const formattedDate = today.toISOString().split('T')[0];
+    const formattedDate = getNow();
     _setFormState({
       begin_at: formattedDate,
       due_at: '',
@@ -293,8 +291,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
   useEffect(() => {
     if (!open && isInitialized) {
       setIsInitialized(false);
-      const today = new Date();
-      const formattedDate = today.toISOString().split('T')[0];
+      const formattedDate = getNow();
       _setFormState({
         begin_at: formattedDate,
         due_at: '',

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/RenderForm/RenderForm.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/RenderForm/RenderForm.tsx
@@ -14,6 +14,7 @@ import {
   IconQuestion,
 } from "@/components/layout/icons/IconsBiblioteca";
 import { checkRules } from "@/mk/utils/validate/Rules";
+import { getNow } from "@/mk/utils/date";
 
 interface DebtFormState {
   id?: string | number;
@@ -64,8 +65,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
   user,
 }) => {
   const [_formState, _setFormState] = useState<DebtFormState>(() => {
-    const today = new Date();
-    const formattedDate = today.toISOString().split("T")[0];
+    const formattedDate = getNow();
     return {
       id: (item && item.id) || undefined,
       ...(item || {}),
@@ -117,8 +117,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
       return;
     }
     if (!isInitialized && open) {
-      const today = new Date();
-      const formattedDate = today.toISOString().split("T")[0];
+      const formattedDate = getNow();
 
       let categoryId = (item && item.category_id) || "";
       if (!categoryId && item?.subcategory_id) {
@@ -278,8 +277,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
 
   const onCloseModal = useCallback(() => {
     setIsInitialized(false);
-    const today = new Date();
-    const formattedDate = today.toISOString().split("T")[0];
+    const formattedDate = getNow();
     _setFormState({
       begin_at: formattedDate,
       due_at: "",

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
@@ -2,7 +2,7 @@
 import React, { useMemo, useEffect, useState } from "react";
 import useCrud, { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
 import useCrudUtils from "../../../shared/useCrudUtils";
-import { getDateStrMesShort } from "@/mk/utils/date";
+import { getDateStrMesShort, getNow } from "@/mk/utils/date";
 import RenderForm from "./RenderForm/RenderForm";
 import { IconCategories } from "@/components/layout/icons/IconsBiblioteca";
 import FormatBsAlign from "@/mk/utils/FormatBsAlign";
@@ -555,7 +555,7 @@ const SharedDebts: React.FC<SharedDebtsProps> = ({ onExtraDataChange }) => {
     const rawStatus = Number(item?.status);
     const numericStatus = Number.isFinite(rawStatus) && rawStatus > 0 ? rawStatus : DebtStatus.PENDING;
     const dueAtString = item?.due_at;
-    const todayString = new Date().toISOString().split("T")[0];
+    const todayString = getNow();
     const displayStatus = dueAtString && dueAtString < todayString && numericStatus === DebtStatus.PENDING
       ? DebtStatus.OVERDUE
       : numericStatus;

--- a/src/modulos/DebtsManager/TabComponents/constants.ts
+++ b/src/modulos/DebtsManager/TabComponents/constants.ts
@@ -1,5 +1,6 @@
 import { DebtStatus } from "@/types/PaymentType";
 import { maintenanceAmountFor } from "@/mk/utils/utils";
+import { getNow } from "@/mk/utils/date";
 
 // ---------------------------------------------------------------------------
 // Numeric-native debt status maps — keyed by DebtStatus enum (int 1-10)
@@ -120,8 +121,7 @@ export const getStatusText = (status: number): string => {
 // Overdue rule: PENDING + past dueDate => treat as OVERDUE for display
 export const getStatusConfig = (status: number, dueDate?: string): { color: string; bgColor: string } => {
   let finalStatus = status;
-  const today = new Date();
-  const todayString = today.toISOString().split('T')[0];
+  const todayString = getNow();
   const due = dueDate ?? null;
 
   if (due && due < todayString && status === DebtStatus.PENDING) {

--- a/src/modulos/Events/RenderView/RenderView.tsx
+++ b/src/modulos/Events/RenderView/RenderView.tsx
@@ -18,10 +18,10 @@ import Table from "@/mk/components/ui/Table/Table";
 import HorizontalProgresiveBar from "@/mk/components/ui/HorizontalProgresiveBar/HorizontalProgresiveBar";
 import { lComDestinies, RandomsColors } from "@/mk/utils/utils";
 import {
-  GMT,
   getDateStrMes,
   getDateTimeStrMes,
   getUTCNow,
+  getNow,
 } from "@/mk/utils/date";
 import StatsCard from "@/mk/components/ui/StatsCard/StatsCard";
 import EventStatsCard from "@/mk/components/ui/EventsStatsCard/EventStatsCards";
@@ -39,9 +39,9 @@ const RenderView = (props: {
   const extraData = props?.extraData;
   const entidad = ["", "", "Lista", "Departamento", "Municipio", "Barrio"];
 
-  let hoy: any = new Date();
-  hoy.setHours(hoy.getHours() - GMT);
-  hoy = new Date(hoy.getFullYear(), hoy.getMonth(), hoy.getDate());
+  // CDT-43: el dia de HOY es el LOCAL (Bolivia UTC-4). Desplazar el reloj a UTC
+  // adelantaba un dia entre las 20:00 y la medianoche.
+  const hoy: any = new Date(getNow());
 
   const [sexGraphData, setSexGraphData] = useState<any>({
     labels: [],

--- a/src/modulos/Events/RenderView/RenderView.tsx
+++ b/src/modulos/Events/RenderView/RenderView.tsx
@@ -21,7 +21,7 @@ import {
   getDateStrMes,
   getDateTimeStrMes,
   getUTCNow,
-  getNow,
+  getNowDate,
 } from "@/mk/utils/date";
 import StatsCard from "@/mk/components/ui/StatsCard/StatsCard";
 import EventStatsCard from "@/mk/components/ui/EventsStatsCard/EventStatsCards";
@@ -41,7 +41,7 @@ const RenderView = (props: {
 
   // CDT-43: el dia de HOY es el LOCAL (Bolivia UTC-4). Desplazar el reloj a UTC
   // adelantaba un dia entre las 20:00 y la medianoche.
-  const hoy: any = new Date(getNow());
+  const hoy: any = getNowDate();
 
   const [sexGraphData, setSexGraphData] = useState<any>({
     labels: [],

--- a/src/modulos/Outlays/RenderForm/RenderForm.tsx
+++ b/src/modulos/Outlays/RenderForm/RenderForm.tsx
@@ -9,6 +9,7 @@ import Toast from "@/mk/components/ui/Toast/Toast";
 import UploadFileV3 from "@/mk/components/forms/UploadFileV3/UploadFileV3";
 import { checkRules } from "@/mk/utils/validate/Rules";
 import { FORM_PAYMENT_METHODS } from "@/modulos/Payments/Type/PaymentType";
+import { getNow } from "@/mk/utils/date";
 
 interface Category {
   id: number | string;
@@ -81,8 +82,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
   onSave,
 }) => {
   const [_formState, _setFormState] = useState<OutlayFormState>(() => {
-    const today = new Date();
-    const formattedDate = today.toISOString().split("T")[0];
+    const formattedDate = getNow();
     return {
       ...(item || {}),
       ...(item || {}),
@@ -115,8 +115,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
       return;
     }
     if (!isInitialized && open) {
-      const today = new Date();
-      const formattedDate = today.toISOString().split("T")[0];
+      const formattedDate = getNow();
       _setFormState({
         ...(item || {}),
         date_at: (item && item.date_at) || formattedDate,
@@ -274,7 +273,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
   const onCloseModal = useCallback(() => {
     setIsInitialized(false);
     _setFormState((prev) => ({
-      date_at: new Date().toISOString().split("T")[0],
+      date_at: getNow(),
       type: "",
       category_id: "",
       subcategory_id: "",

--- a/src/modulos/Surveys/components/RenderForm/RenderForm.tsx
+++ b/src/modulos/Surveys/components/RenderForm/RenderForm.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import Input from "@/mk/components/forms/Input/Input";
 import TextArea from "@/mk/components/forms/TextArea/TextArea";
 import Button from "@/mk/components/forms/Button/Button";
-import { getDateTimeStrMes, getNow } from "@/mk/utils/date";
+import { getDateTimeStrMes, getNowDate } from "@/mk/utils/date";
 import { checkRules, hasErrors } from "@/mk/utils/validate/Rules";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import SurveyQuestionTypePanel from "../SurveyQuestionTypePanel/SurveyQuestionTypePanel";
@@ -102,7 +102,7 @@ const RenderForm = ({
   const disabled = () => {
     // CDT-43: el dia de HOY es el LOCAL (Bolivia UTC-4). Desplazar el reloj a UTC
     // adelantaba un dia entre las 20:00 y la medianoche.
-    const hoy: any = new Date(getNow());
+    const hoy: any = getNowDate();
     return item?.scheduled_at && new Date(item?.scheduled_at) <= hoy;
   };
 

--- a/src/modulos/Surveys/components/RenderForm/RenderForm.tsx
+++ b/src/modulos/Surveys/components/RenderForm/RenderForm.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import Input from "@/mk/components/forms/Input/Input";
 import TextArea from "@/mk/components/forms/TextArea/TextArea";
 import Button from "@/mk/components/forms/Button/Button";
-import { GMT, getDateTimeStrMes } from "@/mk/utils/date";
+import { getDateTimeStrMes, getNow } from "@/mk/utils/date";
 import { checkRules, hasErrors } from "@/mk/utils/validate/Rules";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import SurveyQuestionTypePanel from "../SurveyQuestionTypePanel/SurveyQuestionTypePanel";
@@ -100,9 +100,9 @@ const RenderForm = ({
   };
 
   const disabled = () => {
-    let hoy: any = new Date();
-    hoy.setHours(hoy.getHours() - GMT);
-    hoy = new Date(hoy.getFullYear(), hoy.getMonth(), hoy.getDate());
+    // CDT-43: el dia de HOY es el LOCAL (Bolivia UTC-4). Desplazar el reloj a UTC
+    // adelantaba un dia entre las 20:00 y la medianoche.
+    const hoy: any = new Date(getNow());
     return item?.scheduled_at && new Date(item?.scheduled_at) <= hoy;
   };
 


### PR DESCRIPTION
## Qué pasaba

`new Date().toISOString()` devuelve el día en **UTC**. Bolivia es UTC-4, así que entre las 20:00 y la medianoche ese cálculo daba el día de **mañana**: cuatro horas por día en las que el admin creía que era otro día.

El caso peor no era un campo precargado sino un **estado que se muestra**: después de las 20:00, una deuda que vencía **hoy** se pintaba **"En mora"**.

## Qué se cambió

30 sitios pasados al helper canónico `getNow()` (`src/mk/utils/date.tsx`), en **tres** patrones distintos:

| Patrón | Dónde |
|---|---|
| `new Date().toISOString().split("T")[0]` | el que nombraba el ticket |
| `const today = new Date()` | `constants.ts`, `SharedDebts/RenderForm`, `IndividualDebts/RenderForm` |
| `hoy.setHours(hoy.getHours() - GMT)` | `Events/RenderView`, `Surveys/RenderForm` |

El tercero no lo encuentra ningún `grep` de `toISOString`.

Se agregó `getNowDate()` (`date.tsx:459`) para el día calendario local. La `T00:00:00` **sin `Z`** es la que fuerza el parseo local: un `"YYYY-MM-DD"` pelado se lee como medianoche **UTC**, que es el mismo defecto por la otra punta.

En `CreateReserva` el día de la semana se unificó en `diaDeLaSemanaDe()` (`:77`). Ahí había **dos errores que se cancelaban exactamente**: el array arrancaba en `"Lunes"` (corrido +1 contra `getDay()`, que devuelve 0 = domingo) y la fecha se parseaba como UTC (corrido −1). Salía bien por casualidad, y arreglar cualquiera de las dos mitades sola rompía la pantalla. La misma pareja vivía **dos veces** en el archivo.

## Qué NO se tocó, a propósito

Los timestamps de **instante**, donde `toISOString()` es correcto: chat, `acta_uploaded_at` de Asambleas, `SurveyAnswerForm`, y `rulesApp.tsx:249` (`normalizeDateTimeToUTC` compara instantes, no días calendario).

## Verificación

- **107 archivos / 709 tests verdes**. `tsc --noEmit`: **29** = baseline exacto de `dev`.
- Tests con `TZ=America/La_Paz` y la franja anclada con `getTimezoneOffset() === 240`. Sin ese ancla el test pasa en cualquier zona y no mide nada.
- Cada arreglo verificado **por reinyección**. En `CreateReserva` las dos mitades por separado dieron rojo **en direcciones opuestas** (`"Lunes"` = +1 del array, `"Sábado"` = −1 de la fecha): esa asimetría es la prueba de que la cancelación se fue.
- Los casos cubren **el mediodía** y no sólo la franja nocturna — un test que sólo mide 20:00–24:00 no distingue "corrido siempre" de "falla sólo de noche".

## Pendiente para QA

Verificación en pantalla **después de las 20:00 hora Bolivia** (o con el reloj de la máquina movido):

1. **Deudas → Todas / Individuales / Compartidas / Condonaciones**: una deuda que vence hoy debe decir "Por cobrar", no "En mora" — en la lista y en el detalle.
2. **Dashboard de unidad → Historial financiero**: lo mismo.
3. **Nueva reserva** y **Áreas → Mantenimiento**: el `min` del campo de fecha debe permitir hoy.
4. **Nueva reserva**: al pasar del paso 1 al 2, si hoy es día habilitado del área la fecha debe autocompletarse; y el resumen debe mostrar el día de la semana correcto.

## Queda vivo, en otro ticket

Familia hermana, mismo parseo UTC pero **24 h/día**: `Expenses/ExpensesDetails` (×2), `mk/utils/utils.tsx:244,289` (además es constante de **módulo**: se congela al cargar la página), `mk/utils/validate/Rules.tsx:174-177`, `CreateReserva.tsx:301`.

Code review `gentle-ai`: recibo **aprobado**, lineage `review-cdt43-2a729eac`. Cero blockers.