### PR TITLE
feat(areas): el campo de garantia en el formulario del area

### DIFF
--- a/src/modulos/Areas/Areas.tsx
+++ b/src/modulos/Areas/Areas.tsx
@@ -183,6 +183,15 @@ const Areas = () => {
         list: false,
         form: { type: "number" },
       },
+      // El depósito en garantía que pide el área, además del precio. No es
+      // obligatorio: un área con costo puede no pedir garantía.
+      guarantee_amount: {
+        rules: ["number"],
+        api: "ae",
+        label: "Garantía",
+        list: false,
+        form: { type: "number" },
+      },
       is_free: {
         rules: ["required"],
         api: "ae",

--- a/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/FourPart.tsx
@@ -198,6 +198,10 @@ const FourPart = ({ item }: { item: any }) => {
               value={"Bs. " + formatNumber(item?.price)}
             />
             <KeyValue
+              title={"Garantía"}
+              value={"Bs. " + formatNumber(item?.guarantee_amount || 0)}
+            />
+            <KeyValue
               title={"Cantidad máx. de personas"}
               value={item?.max_capacity}
             />

--- a/src/modulos/Areas/RenderForm/Partes/SecondPart.tsx
+++ b/src/modulos/Areas/RenderForm/Partes/SecondPart.tsx
@@ -177,6 +177,10 @@ const SecondPart = ({
       setFormState({
         ...formState,
         price: "",
+        // ⚠️ La garantía también se limpia al pasar el área a gratuita. Si se
+        // queda cargada, el área dice "sin costo" y el servidor le sigue
+        // congelando una garantía a cada reserva.
+        guarantee_amount: 0,
         min_cancel_hours: "",
         penalty_fee: "",
       });
@@ -458,6 +462,15 @@ const SecondPart = ({
             label="Monto (Bs)"
             name="price"
             value={formState?.price}
+            onChange={handleChange}
+            error={errors}
+          />
+          <Br />
+          <Input
+            type="number"
+            label="Garantía (Bs)"
+            name="guarantee_amount"
+            value={formState?.guarantee_amount}
             onChange={handleChange}
             error={errors}
           />

--- a/src/modulos/CreateReserva/Type.ts
+++ b/src/modulos/CreateReserva/Type.ts
@@ -77,6 +77,8 @@ export interface ApiArea {
   available_hours?: Record<string, string[]> | null;
   booking_mode?: number | null;
   price?: string | null;
+  /** Deposito en garantia del area. */
+  guarantee_amount?: string | number | null;
   is_free?: number | null;
   max_booking_duration?: number | null;
   special_restrictions?: string | null;

--- a/src/modulos/Reservas/Type/ReservaType.ts
+++ b/src/modulos/Reservas/Type/ReservaType.ts
@@ -102,6 +102,8 @@ export type ReservationArea = {
   available_days?: string[] | null;
   available_hours?: Record<string, string[]> | null;
   price?: string | number | null;
+  /** Deposito en garantia del area. El servidor lo CONGELA en cada reserva. */
+  guarantee_amount?: string | number | null;
   /**
    * 🔴 Las banderas del área son ENUMS NUMÉRICOS, no booleanos ni strings.
    *


### PR DESCRIPTION
Cierra el hueco que dejó el PR #258 del API: **el servidor ya acepta la garantía y el formulario no la tenía**, así que ningún administrador podía cargarla desde la aplicación.

El campo existe en `origin/prod` y no en `dev`. **No se copió el archivo de producción** — `dev` ya está en enums numéricos y ese archivo todavía usa los chars viejos. Se trajo el campo.

## Qué entra

| archivo | qué |
|---|---|
| `Areas.tsx` | el campo declarado, regla `number` y **sin** `required` — un área con costo puede no pedir garantía |
| `SecondPart` | el input "Garantía (Bs)", debajo del monto y dentro del bloque que sólo aparece cuando el área tiene costo |
| `FourPart` | la garantía en el detalle, al lado del costo |
| `ReservaType`, `CreateReserva/Type` | la columna nueva en los tipos |

⚠️ **El detalle que producción ya tenía y hay que conservar**: al pasar el área de con-costo a gratuita, la garantía se limpia junto con el precio. Si se queda cargada, el área dice "sin costo" y el servidor le sigue congelando una garantía a cada reserva.

## Verificación

- **718 tests, 108 suites, 0 fallas.**
- `tsc --noEmit`: 23 errores, **los mismos 23 que ya están en `dev`** (fixtures de otros módulos, anotados en `HALLAZGOS_CRUZADOS.md`).

🔴 **No pude verificarlo en el navegador**: la pantalla está detrás del login y no tengo sesión. Queda para la revisión visual — el área con costo tiene que mostrar "Garantía (Bs)" debajo del monto, y al marcarla gratuita el campo se limpia.
