### PR TITLE
fix(deudas): el dia del vencimiento no esta vencido — new Date("YYYY-MM-DD") se parseaba en UTC (CDT-44)

### DIFF
--- a/src/mk/utils/__tests__/CDT44VencimientoLocal.test.tsx
+++ b/src/mk/utils/__tests__/CDT44VencimientoLocal.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * CDT-44 — el día de VENCIMIENTO se leía en UTC.
+ *
+ * `new Date("2026-08-14")` y `new Date("2026-08-14T00:00:00.000000Z")` son el
+ * MISMO instante: medianoche UTC, o sea las 20:00 del 13 en Bolivia (UTC-4).
+ * Comparado contra un "hoy" local, una deuda que vencía HOY salía "En mora".
+ *
+ * 🔴 En `utils.tsx` eran DOS defectos que se tapaban entre sí:
+ *   1. `const today = new Date()` a nivel de MÓDULO — un instante congelado al
+ *      cargar el bundle, que además nunca cruza la medianoche.
+ *   2. `new Date(due_at)` parseado en UTC.
+ * Una deuda vencida AYER salía bien por casualidad porque el −1 del UTC
+ * cancelaba que `today` no estuviera truncado. Por eso los tests viejos
+ * (`"2000-01-01"` / `"2999-01-01"`) pasaban con el bug puesto: no medían el
+ * borde, medían mil años de distancia.
+ *
+ * Por qué `vi.resetModules()` + `await import()` en cada caso: con el bug
+ * puesto, `today` se evalúa al IMPORTAR el módulo. Un import estático arriba
+ * del archivo lo congelaría con el reloj REAL y el test no mediría el instante
+ * anclado. Reimportar bajo tiempo falso es lo que hace que la reinyección se
+ * ponga roja.
+ */
+process.env.TZ = "America/La_Paz";
+
+import React from "react";
+import { render, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DebtStatus } from "@/types/PaymentType";
+import { getLocalDate, getNowDate } from "@/mk/utils/date";
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({ user: {}, showToast: vi.fn() }),
+}));
+
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/mk/components/ui/Table/Table", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/modulos/Payments/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+
+// 22:00 en La Paz del 14/08; en UTC ya es el 15 — la franja que rompía CDT-43.
+const LAS_22_DEL_14 = new Date("2026-08-15T02:00:00Z");
+// Mediodía del 14: local y UTC son el mismo día. Si el bug fuera "sólo de
+// noche" este caso saldría verde; sale rojo, y eso es lo que prueba que el
+// corrimiento era de las 24 horas.
+const EL_MEDIODIA_DEL_14 = new Date("2026-08-14T16:00:00Z");
+
+const AYER = "2026-08-13";
+const HOY = "2026-08-14";
+const MANANA = "2026-08-15";
+
+// Así llega de verdad: columna `date` con cast `'date'` y sin `serializeDate`.
+const comoLoMandaLaApi = (dia: string) => `${dia}T00:00:00.000000Z`;
+
+const anclarLaFranja = (instante: Date) => {
+  vi.setSystemTime(instante);
+  // Sin este ancla el test pasa en cualquier zona y no mide nada.
+  expect(new Date().getTimezoneOffset()).toBe(240);
+};
+
+const unaUnidadPorCobrar = [
+  { id: 1, debt_id: "d", amount: 100, penalty_amount: 0, status: DebtStatus.PENDING },
+] as any;
+
+const enMora = async (due_at: string) => {
+  vi.resetModules();
+  const { isUnitInDefault } = await import("../utils");
+  return isUnitInDefault({ asignados: unaUnidadPorCobrar, due_at } as any);
+};
+
+describe("CDT-44 · el vencimiento es un día LOCAL, no un instante UTC", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  describe("isUnitInDefault — la fila roja del listado de expensas", () => {
+    it("mediodía del 14: la que vence HOY no está en mora", async () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      expect(await enMora(HOY)).toBe(false);
+      expect(await enMora(comoLoMandaLaApi(HOY))).toBe(false);
+    });
+
+    it("22:00 del 14: la que vence HOY tampoco está en mora", async () => {
+      anclarLaFranja(LAS_22_DEL_14);
+      // El día UTC ya es el 15: el valor que rompía por el otro lado.
+      expect(new Date().toISOString().split("T")[0]).toBe("2026-08-15");
+      expect(await enMora(HOY)).toBe(false);
+      expect(await enMora(comoLoMandaLaApi(HOY))).toBe(false);
+    });
+
+    it("mediodía del 14: la que vence MAÑANA no está en mora", async () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      expect(await enMora(MANANA)).toBe(false);
+    });
+
+    it("22:00 del 14: la que vence MAÑANA tampoco está en mora", async () => {
+      anclarLaFranja(LAS_22_DEL_14);
+      expect(await enMora(MANANA)).toBe(false);
+      expect(await enMora(comoLoMandaLaApi(MANANA))).toBe(false);
+    });
+
+    it("mediodía del 14: la que venció AYER sigue en mora", async () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      expect(await enMora(AYER)).toBe(true);
+      expect(await enMora(comoLoMandaLaApi(AYER))).toBe(true);
+    });
+
+    it("22:00 del 14: la que venció AYER sigue en mora", async () => {
+      anclarLaFranja(LAS_22_DEL_14);
+      expect(await enMora(AYER)).toBe(true);
+    });
+
+    it("sin unidades por cobrar nunca está en mora, aunque haya vencido", async () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      vi.resetModules();
+      const { isUnitInDefault } = await import("../utils");
+      expect(
+        isUnitInDefault({
+          asignados: [
+            { id: 1, debt_id: "d", amount: 100, penalty_amount: 0, status: DebtStatus.PAID },
+          ],
+          due_at: AYER,
+        } as any),
+      ).toBe(false);
+    });
+
+    it("el 'hoy' se relee en cada llamada: la pestaña que cruza la medianoche", async () => {
+      // 23:59 del 14 — con el `today` de módulo, esta importación lo congela.
+      anclarLaFranja(new Date("2026-08-15T03:59:00Z"));
+      vi.resetModules();
+      const { isUnitInDefault } = await import("../utils");
+      const deuda = { asignados: unaUnidadPorCobrar, due_at: HOY } as any;
+      expect(isUnitInDefault(deuda)).toBe(false);
+
+      // Pasa la medianoche SIN recargar la pestaña: ahora sí está vencida.
+      vi.setSystemTime(new Date("2026-08-15T04:01:00Z"));
+      expect(isUnitInDefault(deuda)).toBe(true);
+    });
+  });
+
+  describe("isPastDue — el guard compartido por los tres sitios", () => {
+    // La regla estaba copiada en `isUnitInDefault`, en `ExpensesDetailsView` y
+    // en el `RenderView` del detalle. Ahora es una sola: el test que la protege
+    // vale para los tres.
+    const vencida = async (due_at?: string | null) => {
+      vi.resetModules();
+      const { isPastDue } = await import("../utils");
+      return isPastDue(due_at);
+    };
+
+    it("mediodía del 14: hoy no, mañana no, ayer sí", async () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      expect(await vencida(HOY)).toBe(false);
+      expect(await vencida(MANANA)).toBe(false);
+      expect(await vencida(AYER)).toBe(true);
+    });
+
+    it("22:00 del 14: hoy no, mañana no, ayer sí", async () => {
+      anclarLaFranja(LAS_22_DEL_14);
+      expect(await vencida(comoLoMandaLaApi(HOY))).toBe(false);
+      expect(await vencida(comoLoMandaLaApi(MANANA))).toBe(false);
+      expect(await vencida(comoLoMandaLaApi(AYER))).toBe(true);
+    });
+
+    it("sin fecha de vencimiento nunca está vencida", async () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      expect(await vencida(null)).toBe(false);
+      expect(await vencida(undefined)).toBe(false);
+      expect(await vencida("")).toBe(false);
+    });
+  });
+
+  describe("getLocalDate — el helper que trunca a medianoche LOCAL", () => {
+    it("22:00 del 14: el 'YYYY-MM-DD' pelado es el 14 a las 00:00 locales", () => {
+      anclarLaFranja(LAS_22_DEL_14);
+      const dia = getLocalDate(HOY);
+      expect(dia.getDate()).toBe(14);
+      expect(dia.getHours()).toBe(0);
+      expect(dia.getTime()).toBe(new Date(2026, 7, 14).getTime());
+      // El anti-ejemplo: así lo parseaba el código viejo.
+      expect(new Date(HOY).getDate()).toBe(13);
+      expect(new Date(HOY).getHours()).toBe(20);
+    });
+
+    it("el sobre de la API da exactamente el mismo día que el pelado", () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      expect(getLocalDate(comoLoMandaLaApi(HOY)).getTime()).toBe(
+        getLocalDate(HOY).getTime(),
+      );
+      expect(getLocalDate(HOY).getTime()).toBe(getNowDate().getTime());
+    });
+  });
+
+  describe("detalle de la expensa — el estado que LEE el admin", () => {
+    const deuda = (due_at: string) => ({
+      id: "d-1",
+      status: DebtStatus.PENDING,
+      amount: "150",
+      due_at,
+      month: 8,
+      year: 2026,
+      dpto: { id: 5, nro: "101" },
+      asignados: unaUnidadPorCobrar,
+    });
+
+    const estadoQueSeMuestra = async (item: any) => {
+      vi.resetModules();
+      const { default: RenderView } = await import(
+        "@/modulos/Expenses/ExpensesDetails/RenderView/RenderView"
+      );
+      const { container } = render(
+        <RenderView
+          open
+          item={item}
+          onClose={vi.fn()}
+          execute={vi.fn().mockResolvedValue({ data: { success: false } })}
+        />,
+      );
+      return within(container);
+    };
+
+    it("mediodía del 14: la que vence HOY dice 'Por cobrar', no 'En mora'", async () => {
+      anclarLaFranja(EL_MEDIODIA_DEL_14);
+      const vista = await estadoQueSeMuestra(deuda(comoLoMandaLaApi(HOY)));
+      expect(vista.queryByText("En mora")).toBeNull();
+      expect(vista.getByText("Por cobrar")).toBeTruthy();
+    });
+
+    it("22:00 del 14: la que vence HOY sigue diciendo 'Por cobrar'", async () => {
+      anclarLaFranja(LAS_22_DEL_14);
+      const vista = await estadoQueSeMuestra(deuda(HOY));
+      expect(vista.queryByText("En mora")).toBeNull();
+    });
+
+    it("22:00 del 14: la que venció AYER sí dice 'En mora'", async () => {
+      anclarLaFranja(LAS_22_DEL_14);
+      const vista = await estadoQueSeMuestra(deuda(comoLoMandaLaApi(AYER)));
+      expect(vista.getByText("En mora")).toBeTruthy();
+    });
+  });
+});

--- a/src/mk/utils/__tests__/expenseSummarizers.test.ts
+++ b/src/mk/utils/__tests__/expenseSummarizers.test.ts
@@ -39,6 +39,9 @@ describe("expense summarizers — numeric DebtStatus", () => {
     expect(unitsPayable(asignados)).toBe(2);
   });
 
+  // 🔴 Este caso NO mide el borde del día: con mil años de distancia pasa con
+  // el bug de CDT-44 puesto y sin él. El borde (vence hoy / mañana / ayer, a
+  // mediodía y a las 22:00) está en `CDT44VencimientoLocal.test.tsx`.
   it("isUnitInDefault is true only when there are payable units and it is past due", () => {
     const pastDue = "2000-01-01";
     const future = "2999-01-01";

--- a/src/mk/utils/date.tsx
+++ b/src/mk/utils/date.tsx
@@ -458,6 +458,21 @@ export const getNow = (): string => {
  */
 export const getNowDate = (): Date => new Date(`${getNow()}T00:00:00`);
 
+/**
+ * El DÍA CALENDARIO que trae una fecha del back, como medianoche LOCAL.
+ *
+ * 🔴 `new Date("2026-08-14")` y `new Date("2026-08-14T00:00:00.000000Z")` son el
+ * MISMO instante: medianoche **UTC**, o sea las 20:00 del 13 en Bolivia. Las
+ * columnas `date` del back (`due_at`, con cast `'date'`) llegan en ese formato,
+ * así que comparar `new Date(due_at)` contra el hoy local corre un día entero.
+ *
+ * El par para comparar un día calendario es `getLocalDate(x) < getNowDate()`:
+ * los dos lados truncados a medianoche local. Medido en CDT-44, donde una deuda
+ * que vencía HOY se pintaba "En mora" las 24 horas del día.
+ */
+export const getLocalDate = (dateStr: string | null): Date =>
+  new Date(`${getDateStr(dateStr)}T00:00:00`);
+
 export const getDateDesdeHasta = (date: any, locale?: AppLocale) => {
   const fechaActual = new Date();
   //convertir fechaActual a hora local

--- a/src/mk/utils/utils.tsx
+++ b/src/mk/utils/utils.tsx
@@ -1,4 +1,5 @@
 import { DebtStatus } from "@/types/PaymentType";
+import { getLocalDate, getNowDate } from "@/mk/utils/date";
 
 export const setParamsCrud = (
   modulo: string,
@@ -241,7 +242,6 @@ interface Debt {
   year: number;
 }
 
-const today = new Date();
 export const units = (unidades: AssignedList) => {
   return unidades.length;
 };
@@ -285,8 +285,28 @@ export const unitsPayable = (unidades: AssignedList) => {
   });
   return cont;
 };
+/**
+ * ¿El día de vencimiento YA PASÓ? El día del vencimiento NO está vencido.
+ *
+ * 🔴 La regla estaba copiada en tres lugares y en los tres con los mismos DOS
+ * defectos que se tapaban entre sí (CDT-44):
+ *   1. `const today = new Date()` a nivel de MÓDULO: se evaluaba una sola vez al
+ *      cargar el bundle. Una pestaña abierta que cruzaba la medianoche seguía
+ *      anclada al día anterior.
+ *   2. `today` era un INSTANTE sin truncar y `new Date(due_at)` se parseaba en
+ *      UTC (las 20:00 del día ANTERIOR en Bolivia).
+ * Una deuda vencida ayer salía bien por CASUALIDAD: el corrimiento −1 del UTC
+ * cancelaba que `today` no estuviera truncado. Pero la que vencía HOY salía "En
+ * mora" las 24 horas del día, y la que vencía MAÑANA a partir de las 20:00.
+ * Arreglar una sola mitad no alcanza: los dos lados van truncados a medianoche
+ * LOCAL, y el "hoy" se lee en CADA llamada.
+ */
+export const isPastDue = (due_at?: string | null): boolean =>
+  !!due_at && getLocalDate(due_at) < getNowDate();
+
+/** Está en mora cuando queda algo por cobrar y el vencimiento ya pasó. */
 export const isUnitInDefault = (props: Debt) => {
-  return unitsPayable(props?.asignados) > 0 && new Date(props?.due_at) < today;
+  return unitsPayable(props?.asignados) > 0 && isPastDue(props?.due_at);
 };
 export const sumPenalty = (unidades: AssignedList) => {
   let sum: number = 0;

--- a/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
+++ b/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
@@ -20,7 +20,7 @@ import { WidgetDashCard } from "@/components/Widgets/WidgetsDashboard/WidgetDash
 import DateRangeFilterModal from "@/components/DateRangeFilterModal/DateRangeFilterModal";
 import FormatBsAlign from "@/mk/utils/FormatBsAlign";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
-import { hasMaintenanceValue } from "@/mk/utils/utils";
+import { hasMaintenanceValue, isPastDue } from "@/mk/utils/utils";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { DebtStatus, DEBT_STATUS_TEXT, getDebtStatusText } from "@/types/PaymentType";
 
@@ -99,13 +99,11 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
   const { user } = useAuth();
   const getDisplayStatus = (item: any) => {
     const numericStatus = Number(item?.status);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    if (numericStatus === DebtStatus.PENDING && item.due_at) {
-      const dueDate = new Date(item.due_at);
-      if (today > dueDate) {
-        return { text: "En mora", code: DebtStatus.OVERDUE };
-      }
+    // La regla de mora es UNA sola y vive en `isPastDue`: acá estaba copiada y
+    // leía el vencimiento en UTC, así que la que vencía HOY salía "En mora" las
+    // 24 horas del día (CDT-44).
+    if (numericStatus === DebtStatus.PENDING && isPastDue(item?.due_at)) {
+      return { text: "En mora", code: DebtStatus.OVERDUE };
     }
 
     // 🔴 Acá había un `switch` con 5 de los 10 estados y un `default` que

--- a/src/modulos/Expenses/ExpensesDetails/RenderView/RenderView.tsx
+++ b/src/modulos/Expenses/ExpensesDetails/RenderView/RenderView.tsx
@@ -12,7 +12,7 @@ import Table from "@/mk/components/ui/Table/Table";
 import { paymentsApi } from "../../../Payments/api";
 import { DebtStatus } from "@/types/PaymentType";
 import { useAuth } from "@/mk/contexts/AuthProvider";
-import { maintenanceAmountFor } from "@/mk/utils/utils";
+import { isPastDue, maintenanceAmountFor } from "@/mk/utils/utils";
 
 const RenderView = (props: {
   open: boolean;
@@ -71,13 +71,11 @@ const RenderView = (props: {
   };
   const getStatus = (item: any) => {
     const numericStatus = Number(item?.status);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    if (numericStatus === DebtStatus.PENDING && item.due_at) {
-      const dueDate = new Date(item.due_at);
-      if (today > dueDate) {
-        return { text: "En mora", code: DebtStatus.OVERDUE };
-      }
+    // La regla de mora es UNA sola y vive en `isPastDue`: acá estaba copiada y
+    // leía el vencimiento en UTC, así que la que vencía HOY salía "En mora" las
+    // 24 horas del día (CDT-44).
+    if (numericStatus === DebtStatus.PENDING && isPastDue(item?.due_at)) {
+      return { text: "En mora", code: DebtStatus.OVERDUE };
     }
     switch (numericStatus) {
       case DebtStatus.PENDING:


### PR DESCRIPTION
## Qué pasaba

`new Date("2026-08-14")` **no** es la medianoche local: la forma solo-fecha se parsea como medianoche **UTC**. En Bolivia (UTC-4) eso son las **20:00 del día anterior**.

Comparado contra un "hoy" local, una deuda que vencía **hoy** se pintaba **"En mora" las 24 horas del día del vencimiento**. No es la franja de 4 horas de CDT-43: acá el corrimiento vale todo el día, todos los días.

## El sitio con la trampa

En `utils.tsx` había **dos defectos que se compensaban**:

```ts
const today = new Date();                                  // módulo, SIN truncar
new Date(props?.due_at) < today                            // parseado en UTC
```

1. `today` era una **constante a nivel de módulo**: se evaluaba una vez al cargar el bundle y **nunca se actualizaba**. Una pestaña abierta que cruzaba la medianoche seguía anclada a ayer.
2. `today` era un **instante sin truncar**, no un día, y `due_at` venía corrido un día hacia atrás por el parseo UTC.

**Medido: arreglar sólo el parseo no cambiaba nada** — seguía dando 24 de 24 horas mal el día del vencimiento. Y mover `today` sin arreglar el parseo lo **empeoraba**. Por eso las dos mitades van en el mismo commit.

Hoy, una deuda vencida **ayer** salía bien **por casualidad**: el corrimiento −1 cancelaba que `today` no estuviera truncado.

## El arreglo, y por qué consolida

La misma regla estaba **copiada literal en los tres sitios**, con los mismos dos defectos — que es exactamente cómo nació este ticket. Queda un guard único:

```ts
export const isPastDue = (due_at?: string | null): boolean =>
  !!due_at && getLocalDate(due_at) < getNowDate();
```

Los tres llamadores lo usan. **El diff quedó más chico que parchear cada copia**: los dos `getStatus`/`getDisplayStatus` de Expenses pasaron de 8 líneas a 3.

Se agregó `getLocalDate()` (`date.tsx:473`), el par de `getNowDate()` para una fecha que viene del back.

⚠️ `due_at` es columna `date` con cast `'date'` y no hay `serializeDate` en la API, así que llega como `"...T00:00:00.000000Z"`. En JS eso es medianoche UTC igual que el string pelado: **el defecto no dependía del formato del sobre**.

## 🔴 Cambio de comportamiento esperado — no es una regresión

Una deuda que vence **hoy** deja de mostrarse "En mora" durante el día del vencimiento, y deja de pintar la fila de rojo. Recién al día siguiente pasa a "En mora".

**El día del vencimiento no está vencido.** Afecta tres pantallas: listado de Expensas, detalle de expensa, y el modal de detalle de la unidad.

## Fuera de alcance, medido

El ticket listaba cinco sitios. **Dos estaban mal, y el error era del ticket:**

- `mk/utils/validate/Rules.tsx:172-177` — **falso positivo**. Es `new Date(year, month - 1, day)`: construcción por **componentes**, o sea medianoche local, con los dos lados truncados. Cero horas malas. Tocarlo habría sido una regresión sobre `EventsAdmin`, el único formulario que usa esa regla.
- `CreateReserva.tsx:301` — ya resuelto por CDT-43.

También quedan **sin tocar a propósito** `SharedDebts/RenderForm:209-210` e `IndividualDebts/RenderForm:181-182`: comparan dos fechas **corridas igual**, así que hoy dan bien. Arreglar una sola de las dos **introduciría** el bug.

## Verificación

- **734 tests verdes / 109 archivos** (baseline 718/108). `tsc --noEmit`: **23** = baseline.
- Tests con `TZ=America/La_Paz` y la franja anclada con `getTimezoneOffset() === 240`. Casos: vence hoy, vence mañana, venció ayer — **al mediodía y a las 22:00**.
- 🔴 Las **dos mitades reinyectadas por separado**: **7 rojos cada una**, incluido el caso del **mediodía**. Eso prueba que el corrimiento era de 24 horas y que ninguna mitad sola arregla nada.
- El test que ya existía (`expenseSummarizers.test.ts`) probaba con `"2000-01-01"` y `"2999-01-01"`: pasaba con el bug puesto y sin él. Se le agregó el caso del borde.
- Code review `gentle-ai`: recibo **aprobado**, lineage `review-0d191dc8f7803dad`, gate `post-apply` = `allow`.

## Pendiente para QA

**Expensas → detalle de una expensa con vencimiento HOY.** Que el Estado diga "Por cobrar" y la fila no salga roja; y que una vencida **ayer** siga en "En mora". Vale mirarlo también **después de las 20:00**, que es la franja que rompía por el otro lado.

## Anotado, no tocado

- `Balance/Balance.tsx:270-271` — `new Date(fecha + "T00:00:00-04:00")`: el offset de Bolivia **hardcodeado**. Anda porque acá no hay horario de verano.
- `rulesApp.tsx:39` — `new Date(dateString + "T00:00:00Z")`, con **`Z`**: parsea en UTC.
- `DebtsManager/TabComponents/constants.ts:126` — una **cuarta** implementación de la regla de mora, comparando strings. Es correcta, pero candidata a unificarse con `isPastDue`.
- `getLocalDate` declara `string | null` heredando la firma de `getDateStr`, y con `null` devuelve un `Invalid Date` en silencio. Hoy es inalcanzable (`isPastDue` corta antes con `!!due_at`). No se estrecha acá porque el comportamiento viene de `getDateStr`, que es pre-existente y de uso amplio: arreglar sólo el envoltorio daría una sensación falsa de estar resuelto.