### PR TITLE
Bancos: enums numéricos desde 1, en lockstep con el API

### DIFF
--- a/src/modulos/BankAccounts/BankAccounts.tsx
+++ b/src/modulos/BankAccounts/BankAccounts.tsx
@@ -8,7 +8,11 @@ import useCrud from "@/mk/hooks/useCrud/useCrud";
 import RenderForm from "./RenderForm/RenderForm";
 import RenderView from "./RenderView/RenderView";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
-import { BankAccountStatus, BANK_ACCOUNT_STATUS_LABELS } from "./Type/BankType";
+import {
+  BankAccountStatus,
+  BANK_ACCOUNT_STATUS_LABELS,
+  getAssignmentLabels,
+} from "./Type/BankType";
 import { bankAccountsApi } from "./api";
 import { getBankAccountsMod } from "./config/bankAccountsMod";
 
@@ -76,22 +80,9 @@ const BankAccounts = () => {
           required: true,
         },
         list: {
-          onRender: ({ item }: Record<string, any>) => {
-            return (
-              <p>
-                {["Expensa", "Reserva", "Principal"]
-                  .filter((label, index) => {
-                    const flags = [
-                      item?.is_expense,
-                      item?.is_reserve,
-                      item?.is_main,
-                    ];
-                    return flags[index] > 0;
-                  })
-                  .join(", ") || "-/-"}
-              </p>
-            );
-          },
+          onRender: ({ item }: Record<string, any>) => (
+            <p>{getAssignmentLabels(item)}</p>
+          ),
         },
       },
       status: {

--- a/src/modulos/BankAccounts/RenderView/RenderView.tsx
+++ b/src/modulos/BankAccounts/RenderView/RenderView.tsx
@@ -7,7 +7,7 @@ import { formatNumber } from "@/mk/utils/numbers";
 import RenderForm from "../RenderForm/RenderForm";
 import SkeletonAdapterComponent from "@/mk/components/ui/LoadingScreen/SkeletonAdapter";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
-import { BankAccountStatus } from "../Type/BankType";
+import { BankAccountStatus, getAssignmentLabels } from "../Type/BankType";
 import { bankAccountsApi } from "../api";
 
 const RenderView = (props: any) => {
@@ -171,16 +171,7 @@ const RenderView = (props: any) => {
                 <div className={styles.bankDetailField}>
                   <p className={styles.bankDetailLabel}>Asignada a</p>
                   <div className={styles.bankDetailValue}>
-                    {["Expensa", "Reserva", "Principal"]
-                      .filter((label, index) => {
-                        const flags = [
-                          item?.is_expense,
-                          item?.is_reserve,
-                          item?.is_main,
-                        ];
-                        return flags[index] > 0;
-                      })
-                      .join(", ") || "-/-"}
+                    {getAssignmentLabels(item)}
                   </div>
                 </div>
 

--- a/src/modulos/BankAccounts/Type/BankType.tsx
+++ b/src/modulos/BankAccounts/Type/BankType.tsx
@@ -54,16 +54,16 @@ export const BANK_ACCOUNT_STATUS_LABELS = {
  * también es mayor que cero, así que las dos habrían pintado las tres
  * etiquetas en todas las cuentas y ninguna habría salido con "-/-".
  *
- * Espeja al `CONCAT_WS` de `BankAccountRepository`, que es el que arma la
- * misma columna para el listado y el reporte.
+ * Espeja al `CONCAT_WS` de `BankAccountController::sqlDeLaAsignacion()`, que
+ * es el que arma la misma columna para el listado y el reporte.
  */
 export const getAssignmentLabels = (item: {
   is_expense?: unknown;
   is_reserve?: unknown;
   is_main?: unknown;
 }): string => {
-  const asignada = (valor: unknown) =>
-    Number(valor) === BankAccountAssignment.YES;
+  const isAssigned = (value: unknown) =>
+    Number(value) === BankAccountAssignment.YES;
 
   return (
     [
@@ -72,7 +72,7 @@ export const getAssignmentLabels = (item: {
       ["Principal", item?.is_main],
     ] as const
   )
-    .filter(([, valor]) => asignada(valor))
+    .filter(([, value]) => isAssigned(value))
     .map(([label]) => label)
     .join(", ") || "-/-";
 };

--- a/src/modulos/BankAccounts/Type/BankType.tsx
+++ b/src/modulos/BankAccounts/Type/BankType.tsx
@@ -1,16 +1,38 @@
+/**
+ * Los enums de Bancos, espejo de `app/Modules/Banks/Enums/` del API.
+ *
+ * 🔴 `INACTIVE` valía 0 en los dos estados. Desde el 2026-08-15 los enums del
+ * proyecto arrancan en 1, y acá el motivo es concreto: el filtro de estados de
+ * esta misma pantalla declara `{ id: BankAccountStatus.INACTIVE }`, y `0 == ""`
+ * es `true` en JavaScript. El `Select` compartido llegó a auto-elegir la opción
+ * con id 0 como si el usuario la hubiera tocado (CDT-30).
+ */
 export enum BankAccountType {
   CURRENT = 1,
   SAVINGS = 2,
 }
 
 export enum BankAccountStatus {
-  INACTIVE = 0,
   ACTIVE = 1,
+  INACTIVE = 2,
 }
 
 export enum BankEntityStatus {
-  INACTIVE = 0,
   ACTIVE = 1,
+  INACTIVE = 2,
+}
+
+/**
+ * Si la cuenta está designada para un uso — `is_main`, `is_reserve`,
+ * `is_expense`.
+ *
+ * 🔴 Eran tres `number` con 1 = sí. Ahora el 1 es **NO**: cualquier
+ * comparación contra el número crudo quedó al revés. Lo lee
+ * `usePaymentsForm` para preseleccionar la cuenta destino del pago.
+ */
+export enum BankAccountAssignment {
+  NO = 1,
+  YES = 2,
 }
 
 export const BANK_ACCOUNT_TYPE_LABELS = {
@@ -22,6 +44,38 @@ export const BANK_ACCOUNT_STATUS_LABELS = {
   [BankAccountStatus.INACTIVE]: "Deshabilitada",
   [BankAccountStatus.ACTIVE]: "Habilitada",
 } as const;
+
+/**
+ * Los usos a los que está asignada una cuenta, como los pinta el listado.
+ *
+ * 🔴 Este cálculo estaba escrito DOS VECES, palabra por palabra, en
+ * `BankAccounts.tsx` y en `RenderView/RenderView.tsx`, y las dos copias
+ * filtraban con `flags[index] > 0`. Con `BankAccountAssignment` el "no"
+ * también es mayor que cero, así que las dos habrían pintado las tres
+ * etiquetas en todas las cuentas y ninguna habría salido con "-/-".
+ *
+ * Espeja al `CONCAT_WS` de `BankAccountRepository`, que es el que arma la
+ * misma columna para el listado y el reporte.
+ */
+export const getAssignmentLabels = (item: {
+  is_expense?: unknown;
+  is_reserve?: unknown;
+  is_main?: unknown;
+}): string => {
+  const asignada = (valor: unknown) =>
+    Number(valor) === BankAccountAssignment.YES;
+
+  return (
+    [
+      ["Expensa", item?.is_expense],
+      ["Reserva", item?.is_reserve],
+      ["Principal", item?.is_main],
+    ] as const
+  )
+    .filter(([, valor]) => asignada(valor))
+    .map(([label]) => label)
+    .join(", ") || "-/-";
+};
 
 export interface BankEntityItem {
   id: string | number;
@@ -43,11 +97,10 @@ export interface BankAccountItem {
   ci_holder: string;
   alias_holder: string;
   images?: string | string[] | any;
-  has_image?: number;
   initial_amount?: number;
-  is_main?: number;
-  is_reserve?: number;
-  is_expense?: number;
+  is_main?: BankAccountAssignment | number;
+  is_reserve?: BankAccountAssignment | number;
+  is_expense?: BankAccountAssignment | number;
   status?: BankAccountStatus | number;
   bank_entity?: BankEntityItem;
   [key: string]: any;

--- a/src/modulos/BankEntities/__tests__/BankEntities.test.tsx
+++ b/src/modulos/BankEntities/__tests__/BankEntities.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/mk/contexts/AuthProvider", () => ({
 }));
 
 import BankEntities from "../BankEntities";
+import { BankEntityStatus } from "@/modulos/BankAccounts/Type/BankType";
 
 describe("BankEntities", () => {
   beforeEach(() => {
@@ -88,7 +89,13 @@ describe("BankEntities", () => {
     for (const opcion of sinTodos) {
       expect(typeof opcion.id).toBe("number");
     }
-    expect(sinTodos.map((o: any) => o.id).sort()).toEqual([0, 1]);
+    // ⚠️ Los valores salen del enum, no de una lista escrita a mano. La
+    // versión anterior fijaba `[0, 1]` y el día del renumerado a 1/2 se puso
+    // roja diciendo "esperaba 0" — que es un número que ya no existe en
+    // ninguna parte del sistema.
+    expect(sinTodos.map((o: any) => o.id).sort()).toEqual(
+      [BankEntityStatus.ACTIVE, BankEntityStatus.INACTIVE].sort()
+    );
   });
 
   it("el select del formulario manda los mismos números que el filtro", () => {
@@ -96,7 +103,9 @@ describe("BankEntities", () => {
 
     const delForm = camposRecibidos?.status?.form?.options ?? [];
 
-    expect(delForm.map((o: any) => o.id).sort()).toEqual([0, 1]);
+    expect(delForm.map((o: any) => o.id).sort()).toEqual(
+      [BankEntityStatus.ACTIVE, BankEntityStatus.INACTIVE].sort()
+    );
   });
 
   it("le pasa a useCrud el mod del catálogo compartido", () => {

--- a/src/modulos/BankEntities/__tests__/bankEntitiesMod.test.ts
+++ b/src/modulos/BankEntities/__tests__/bankEntitiesMod.test.ts
@@ -112,8 +112,23 @@ describe("BankEntities: el estado va numérico", () => {
     expect(fuente).toContain("BankEntityStatus.INACTIVE");
   });
 
-  it("los valores del enum son los que espera la columna", () => {
+  /**
+   * 🔴 Ningún case puede valer 0. Es la regla del proyecto y acá tiene un
+   * motivo medido: `0 == ""` es `true` en JavaScript, y el `Select` compartido
+   * llegó a auto-elegir la opción con id 0 como si el usuario la hubiera
+   * tocado (CDT-30). Este test no fija los números uno por uno —eso sería otra
+   * lista que mantener— sino la invariante.
+   */
+  it("ningún valor del enum arranca en 0", () => {
     expect(BankEntityStatus.ACTIVE).toBe(1);
-    expect(BankEntityStatus.INACTIVE).toBe(0);
+
+    const valores = Object.values(BankEntityStatus).filter(
+      (v) => typeof v === "number"
+    ) as number[];
+
+    expect(valores.length).toBeGreaterThan(0);
+    for (const valor of valores) {
+      expect(valor).toBeGreaterThanOrEqual(1);
+    }
   });
 });

--- a/src/modulos/Outlays/RenderForm/RenderForm.tsx
+++ b/src/modulos/Outlays/RenderForm/RenderForm.tsx
@@ -10,6 +10,10 @@ import UploadFileV3 from "@/mk/components/forms/UploadFileV3/UploadFileV3";
 import { checkRules } from "@/mk/utils/validate/Rules";
 import { FORM_PAYMENT_METHODS } from "@/modulos/Payments/Type/PaymentType";
 import { getNow } from "@/mk/utils/date";
+// 🔴 `is_main == 1` quedó acá cuando el enum se renumeró: desde el 2026-08-15
+// el 1 es NO. La pantalla de Egresos elegía como cuenta destino exactamente las
+// cuentas NO asignadas, sin error y sin log. Es camino de plata.
+import { BankAccountAssignment } from "@/modulos/BankAccounts/Type/BankType";
 
 interface Category {
   id: number | string;
@@ -305,7 +309,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
       (subcat) => subcat.id === _formState.subcategory_id
     );
     const mainAccount: any = extraData?.bankAccounts?.find(
-      (bank: any) => bank.is_main == 1
+      (bank: any) => Number(bank.is_main) === BankAccountAssignment.YES
     );
 
     const resolvedDefault =
@@ -367,7 +371,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
       (subcat) => subcat.id === _formState.subcategory_id
     );
     const mainAccount: any = extraData?.bankAccounts?.find(
-      (bank: any) => bank.is_main == 1
+      (bank: any) => Number(bank.is_main) === BankAccountAssignment.YES
     );
 
     if (searchSubcategory?.bank_account_id) return searchSubcategory.bank_account_id;

--- a/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
+++ b/src/modulos/Payments/__tests__/usePaymentsForm.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { usePaymentsForm } from "../hooks/usePaymentsForm";
 import { FormPaymentType, PaymentMethod } from "../Type/PaymentType";
 import { paymentsApi } from "../api";
+import { BankAccountAssignment } from "@/modulos/BankAccounts/Type/BankType";
 
 const mockExecute = vi.fn();
 const mockShowToast = vi.fn();
@@ -136,7 +137,7 @@ describe("usePaymentsForm", () => {
       dptos: [{ id: 5, nro: "101", description: "Dpto 101", homeowner: { id: 9, name: "Mario" } }],
       categories: [],
       client_config: { cat_expensas: 100, cat_reservations: 200, cat_forgiveness: 300 },
-      bankAccounts: [{ id: 7, is_expense: 1 }],
+      bankAccounts: [{ id: 7, is_expense: BankAccountAssignment.YES }],
       subcategories: [],
     },
     execute: mockExecute,
@@ -699,7 +700,7 @@ describe("usePaymentsForm", () => {
         dptos: [{ id: 5, nro: "101", description: "Dpto 101", homeowner: { id: 9, name: "Mario" } }],
         categories: [],
         client_config: { cat_expensas: 100, cat_reservations: 200, cat_forgiveness: 300 },
-        bankAccounts: [{ id: 7, is_expense: 1 }],
+        bankAccounts: [{ id: 7, is_expense: BankAccountAssignment.YES }],
         subcategories: [],
       },
       execute: localExecute,

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -1051,24 +1051,24 @@ export const usePaymentsForm = (
     // **1 es NO** y 2 es SÍ: con la comparación vieja, este formulario habría
     // elegido como cuenta destino del pago exactamente las cuentas NO
     // asignadas — sin error, sin log y con el pago cobrado igual.
-    const asignada = (valor: unknown) =>
-      Number(valor) === BankAccountAssignment.YES;
+    const isAssigned = (value: unknown) =>
+      Number(value) === BankAccountAssignment.YES;
 
     const existBankAccount = extraData?.bankAccounts?.find((item: any) =>
-      asignada(item.is_main)
+      isAssigned(item.is_main)
     )?.id;
 
     switch (formState.type) {
       case FormPaymentType.EXPENSE: {
         const id =
-          extraData?.bankAccounts?.find((i: any) => asignada(i.is_expense))?.id ||
+          extraData?.bankAccounts?.find((i: any) => isAssigned(i.is_expense))?.id ||
           existBankAccount;
         bank_account_id = id;
         break;
       }
       case FormPaymentType.RESERVATION: {
         const id =
-          extraData?.bankAccounts?.find((i: any) => asignada(i.is_reserve))?.id ||
+          extraData?.bankAccounts?.find((i: any) => isAssigned(i.is_reserve))?.id ||
           existBankAccount;
         bank_account_id = id;
         break;

--- a/src/modulos/Payments/hooks/usePaymentsForm.ts
+++ b/src/modulos/Payments/hooks/usePaymentsForm.ts
@@ -6,6 +6,7 @@ import { paymentsApi } from "../api";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { FormPaymentType } from "../Type/PaymentType";
 import { CategoryFixed } from "@/modulos/Categories/Type/CategoryType";
+import { BankAccountAssignment } from "@/modulos/BankAccounts/Type/BankType";
 
 export interface Dpto {
   id: string | number;
@@ -1044,21 +1045,30 @@ export const usePaymentsForm = (
       owner_id = titular?.id;
     }
     let bank_account_id;
-    const existBankAccount = extraData?.bankAccounts?.find(
-      (item: any) => item.is_main == 1
+
+    // 🔴 Las tres asignaciones se comparaban con `== 1`. Desde el 2026-08-15
+    // `bank_accounts.is_main` y compañía son `BankAccountAssignment`, donde
+    // **1 es NO** y 2 es SÍ: con la comparación vieja, este formulario habría
+    // elegido como cuenta destino del pago exactamente las cuentas NO
+    // asignadas — sin error, sin log y con el pago cobrado igual.
+    const asignada = (valor: unknown) =>
+      Number(valor) === BankAccountAssignment.YES;
+
+    const existBankAccount = extraData?.bankAccounts?.find((item: any) =>
+      asignada(item.is_main)
     )?.id;
 
     switch (formState.type) {
       case FormPaymentType.EXPENSE: {
         const id =
-          extraData?.bankAccounts?.find((i: any) => i.is_expense == 1)?.id ||
+          extraData?.bankAccounts?.find((i: any) => asignada(i.is_expense))?.id ||
           existBankAccount;
         bank_account_id = id;
         break;
       }
       case FormPaymentType.RESERVATION: {
         const id =
-          extraData?.bankAccounts?.find((i: any) => i.is_reserve == 1)?.id ||
+          extraData?.bankAccounts?.find((i: any) => asignada(i.is_reserve))?.id ||
           existBankAccount;
         bank_account_id = id;
         break;


### PR DESCRIPTION
Espeja el renumerado de enums de [condaty2025-api#260](https://github.com/mariogfos/condaty2025-api/pull/260). **Van juntos**: la base cambia de valores en el mismo release.

## Por qué el renumerado se ve mejor desde acá

El filtro de estados de Cuentas Bancarias declara `{ id: BankAccountStatus.INACTIVE }`, y con `INACTIVE = 0` esa opción vale cero. `0 == ""` es `true` en JavaScript, y el `Select` compartido llegó a auto-elegirla como si el usuario la hubiera tocado (CDT-30).

## Lo que había que cambiar en lockstep o quedaba al revés, en silencio

🔴 **`usePaymentsForm` elegía la cuenta destino del pago con `is_main == 1`.** Ese 1 ahora es **NO**: el formulario habría preseleccionado exactamente las cuentas **no** asignadas, y el pago se cobraba igual contra la cuenta equivocada.

🔴 **Lo mismo en Egresos** (`Outlays/RenderForm.tsx`, dos veces) — lo encontró el review 4R en un barrido de los cuatro repos. Si el condominio tiene una sola cuenta y es la principal, no encontraba ninguna y el egreso iba con `bank_account_id` en `null`.

**La columna "Asignado a" filtraba con `flags[index] > 0`.** El caso NO también es mayor que cero, así que las tres etiquetas se habrían pintado en todas las cuentas y ninguna habría salido con `-/-`. Ese cálculo estaba escrito **dos veces palabra por palabra** —`BankAccounts.tsx` y `RenderView.tsx`—; va una sola vez en `getAssignmentLabels`.

## Y tres tests que fijaban `[0, 1]` a mano

Se pusieron rojos pidiendo un número que ya no existe en ninguna parte del sistema. Pasan a recorrer los cases del enum, y el de `bankEntitiesMod` pinea la invariante que importa: **ningún case puede valer 0**.

## Verificación

**718 tests / 108 suites**, `tsc` en los mismos 23 errores de la línea de base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)