### PR TITLE
fix(listados): un request fallido ya no se muestra como datos frescos (CDT-42)

### DIFF
--- a/context/condaty_admin_context.md
+++ b/context/condaty_admin_context.md
@@ -582,6 +582,37 @@ interface UseCrudType {
 - ✅ **Validación de formularios** con reglas personalizables
 - ✅ **Manejo de datos extra** para selects dependientes
 
+##### Los CUATRO estados de la lista (`List`)
+
+Cuál se muestra lo decide el render de `useCrud.tsx`, y son excluyentes: nunca
+salen dos carteles a la vez.
+
+| Estado | Cuándo | Qué se ve |
+|---|---|---|
+| Cargando | `showTableSkeleton` | Esqueleto de filas |
+| Carga inicial fallida | `error` y **sin** filas | "No se pudo cargar el listado." + **Recargar** |
+| 🔴 **Dato desactualizado** | `isStale` y **con** filas | Banner ámbar "No se pudo actualizar: estos datos están desactualizados." + **Reintentar**, y la tabla al 50% de opacidad |
+| Vacío | `data` cargado, cero filas | `EmptyData` |
+
+Aparte, el scroll infinito tiene el renglón de **"No se pudieron cargar más
+resultados."** cuando falla un "cargar más". El banner de dato desactualizado se
+apaga si ese renglón está puesto: los dos dirían lo mismo.
+
+🔴 **Decisión de producto (CDT-42, Alexander)**: ante un refresco fallido el dato
+viejo **se queda visible pero marcado**, no se borra ni se reemplaza por un
+error. Se aceptó con la condición de que el aviso sea **imposible de pasar por
+alto** — de ahí el ámbar sólido y la atenuación de la tabla; un cartel discreto
+deja al usuario igual que antes.
+
+⚠️ El caso muerde en los módulos **sin** scroll infinito (`perPage: -1`), que son
+12 de 40: ahí un refresco conserva las filas. Con scroll infinito el refresco
+arranca por `beginListReset`, que las borra, y cae en el estado de carga inicial
+fallida.
+
+⚠️ **Pendiente**: las pantallas de plata (Balance, dashboard) NO usan este
+tratamiento todavía — un monto viejo atenuado es un número que alguien puede
+cobrar. Está esperando definición de producto.
+
 #### Configuración del useCrud
 ```typescript
 const modConfig: ModCrudType = {
@@ -711,6 +742,15 @@ const fields: Record<string, FieldConfig> = {
 - Cancelación automática de requests
 - Error handling centralizado
 - Interceptors para JWT automático
+- 🔴 **`isStale`**: hay dato viejo en `data` y el último intento de refrescarlo
+  falló. Un request que falla **NO pisa `data`** (a propósito: pisarlo hace
+  desaparecer la lista entera), así que sin esta bandera la pantalla muestra el
+  payload anterior como si fuera fresco — CDT-42.
+  **No es `!!error`**: `error` se limpia al ARRANCAR cada petición, así que un
+  aviso colgado de él parpadea en cada reintento. `isStale` se escribe sólo
+  cuando la petición TERMINA, y únicamente en las que llevan `saveInState`, que
+  son las que refrescan `data`: un guardado o un export que falla no ensucia el
+  dato de la lista.
 
 ##### Utilidades de la Librería
 - **date.tsx**: Utilidades completas de fechas.

--- a/src/mk/components/ui/Table/__tests__/tablaReenviaStyle.test.tsx
+++ b/src/mk/components/ui/Table/__tests__/tablaReenviaStyle.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import React from "react";
+
+/**
+ * `Table` aplica el `style` que le pasan a un nodo del DOM.
+ *
+ * ## Por qué existe este archivo
+ *
+ * La atenuación del dato desactualizado (CDT-42) viaja como
+ * `style={{ opacity: 0.5 }}` desde `useCrud`. El test de `useCrud` no puede
+ * medir el otro lado del cable: ahí `Table` está mockeada, y un mock que
+ * reenvía el `style` **fabrica justo lo que se quiere probar** — si la `Table`
+ * real ignorara el prop, ese test seguiría verde y la tabla saldría a opacidad
+ * plena en las 41 pantallas. El banner se vería; la atenuación, no. Y la mitad
+ * perdida es media condición de producto: el aviso tiene que ser imposible de
+ * pasar por alto.
+ *
+ * Así que el contrato se prueba en dos mitades honestas:
+ *  - `useCrudDatoDesactualizado.test.tsx` afirma que `useCrud` PASA el prop.
+ *  - este archivo afirma que `Table` lo APLICA.
+ *
+ * ⚠️ A propósito con un `style` arbitrario y no con la opacidad de CDT-42: lo
+ * que se pinea es que el prop llegue al DOM, no un valor puntual.
+ */
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    store: {},
+    setStore: vi.fn(),
+    user: { id: 1 },
+    userCan: () => true,
+    showToast: vi.fn(),
+  }),
+}));
+vi.mock("@/mk/hooks/useMediaQuery", () => ({ default: () => false }));
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) mocked[key] = () => null;
+  return mocked;
+});
+
+import Table from "@/mk/components/ui/Table/Table";
+
+const header = [{ key: "name", responsive: "", label: "Nombre" }] as any;
+
+const data = [{ id: "r1", name: "Fila 1" }];
+
+describe("Table: el prop `style` llega al DOM", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("aplica el style recibido a un nodo real", () => {
+    render(
+      <Table
+        header={header}
+        data={data}
+        style={{ opacity: 0.5, outlineWidth: "3px" }}
+      />,
+    );
+
+    const celda = screen.getByText("Fila 1");
+    const conStyle = celda.closest('[style*="opacity"]');
+
+    expect(
+      conStyle,
+      "ningún ancestro de las filas recibió el style: la atenuación de CDT-42 no se vería",
+    ).not.toBeNull();
+    expect(conStyle).toHaveStyle("opacity: 0.5");
+    expect(conStyle).toHaveStyle("outline-width: 3px");
+  });
+
+  it("sin style no inventa opacidad", () => {
+    render(<Table header={header} data={data} />);
+
+    const celda = screen.getByText("Fila 1");
+    expect(celda.closest('[style*="opacity"]')).toBeNull();
+  });
+});

--- a/src/mk/hooks/useAxios.tsx
+++ b/src/mk/hooks/useAxios.tsx
@@ -97,6 +97,21 @@ export type UseAxiosType<T = any> = {
    */
   data: ApiEnvelope<T> | null;
   error: ApiError | "";
+  /**
+   * Hay dato viejo en `data` y el último intento de refrescarlo FALLÓ: lo que
+   * se está mostrando ya no se sabe si sigue siendo cierto.
+   *
+   * 🔴 NO es `!!error`. `error` se limpia al ARRANCAR cada petición (`:171`),
+   * así que un reintento que vuelve a fallar lo apaga y lo prende: el aviso
+   * parpadea. Esta bandera se escribe sólo cuando una petición TERMINA, y por
+   * eso se sostiene sola mientras el reintento está en vuelo.
+   *
+   * ⚠️ Sólo la mueven las peticiones que escriben el estado del hook
+   * (`saveInState`): son las que refrescan `data`. Un `execute` suelto —un
+   * guardado, un export— que falla NO ensucia el dato de la lista, que sigue
+   * siendo tan fresco como era.
+   */
+  isStale: boolean;
   loaded: boolean;
   execute: ExecuteFn<T>;
   reLoad: ReLoadFn;
@@ -118,6 +133,7 @@ const useAxios = <T = any,>(
 ): UseAxiosType<T> => {
   const [data, setData] = useState<ApiEnvelope<T> | null>(null);
   const [error, setError] = useState<ApiError | "">("");
+  const [isStale, setIsStale] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [countAxios, setCountAxios] = useState(0);
   const { contextInstance, waiting, setWaiting }: any =
@@ -195,6 +211,8 @@ const useAxios = <T = any,>(
       });
       if (Act) {
         setData(response.data);
+        // El dato de pantalla se acaba de refrescar: deja de estar viejo.
+        setIsStale(false);
       }
 
       // setData(response.data);
@@ -207,6 +225,10 @@ const useAxios = <T = any,>(
         status: (err as any).response?.status || 0,
       };
       setError(error);
+      // 🔴 Sólo las peticiones que refrescan `data` marcan el dato como viejo.
+      // Y se marca al TERMINAR, nunca al arrancar: así el reintento en vuelo no
+      // apaga el aviso.
+      if (Act) setIsStale(true);
     } finally {
       if (!notWaiting) {
         setLoaded(true);
@@ -265,6 +287,9 @@ const useAxios = <T = any,>(
     cancel,
     data,
     error,
+    // Sin dato en pantalla no hay nada "viejo" que avisar: eso es la carga
+    // inicial fallida, y tiene su propio estado de error.
+    isStale: data !== null && isStale,
     loaded,
     execute,
     reLoad,

--- a/src/mk/hooks/useCrud/__tests__/useCrudDatoDesactualizado.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrudDatoDesactualizado.test.tsx
@@ -45,9 +45,25 @@ import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
  * escribe sólo cuando la petición TERMINA, y por eso se sostiene.
  */
 
+/**
+ * 🔴 El mock NO reenvía `style` al DOM: lo GUARDA.
+ *
+ * La primera versión hacía `<div style={style} />` y después afirmaba
+ * `toHaveStyle("opacity: 0.5")`. Eso no medía nada: el reenvío lo fabricaba el
+ * propio mock, así que el test quedaba verde aunque la `Table` real ignorara el
+ * prop —y entonces el banner sale pero la tabla NO se atenúa, que es media
+ * condición de producto perdida en silencio—.
+ *
+ * Acá se mide lo único que es de `useCrud`: qué prop manda. Que la `Table` de
+ * verdad lo aplique al DOM lo pinea
+ * `src/mk/components/ui/Table/__tests__/tablaReenviaStyle.test.tsx`.
+ */
+const tableProps: { current: any } = { current: undefined };
 vi.mock("@/mk/components/ui/Table/Table", () => ({
-  // Reenvía `style`: la atenuación del dato viejo viaja por ahí.
-  default: ({ style }: any) => <div data-testid="table-mock" style={style} />,
+  default: (props: any) => {
+    tableProps.current = props;
+    return <div data-testid="table-mock" />;
+  },
 }));
 vi.mock("@/mk/components/ui/Pagination/Pagination", () => ({
   default: () => null,
@@ -113,18 +129,28 @@ const respuestaOk = (cuantas = 3) => ({
 
 const fallo = () => Promise.reject(new Error("Network Error"));
 
+const LOTE = 40;
+
+/** La respuesta de un listado con scroll infinito: quedan páginas por pedir. */
+const respuestaConMas = (total = 100) => ({
+  data: { data: filas(LOTE), message: { total } },
+});
+
 /**
- * 🔴 `perPage: -1` a propósito: es el modo SIN scroll infinito, el que usan 12
- * de los 40 módulos, y es exactamente donde vive el bug. Con scroll infinito un
- * refresco arranca por `beginListReset`, que borra las filas de pantalla, así
- * que ahí no hay dato viejo que marcar.
+ * 🔴 `perPage` decide QUÉ RAMA de `useCrud` se ejerce, y son dos distintas:
+ *
+ * - `-1` → sin scroll infinito: `data`/`error`/`isStale` salen de `useAxios`.
+ *   Son 12 de los 40 módulos, y es donde vive el bug: un refresco fallido
+ *   conserva las filas.
+ * - `> 0` → scroll infinito: el hook maneja `manualData`/`manualError`/
+ *   `manualIsStale` por su cuenta, con `saveInState` en false.
  */
-const montar = () => {
+const montar = (perPage = -1) => {
   const runtime: { current: any } = { current: null };
 
   const Comp = () => {
     runtime.current = useCrud({
-      paramsInitial: { page: 1, perPage: -1, fullType: "L", searchBy: "" },
+      paramsInitial: { page: 1, perPage, fullType: "L", searchBy: "" },
       mod,
       fields,
     });
@@ -174,7 +200,7 @@ describe("useCrud: el dato viejo tras un request fallido se marca como desactual
     // 🔴 Acá la tabla se seguía dibujando idéntica a una recién cargada.
     expect(await screen.findByText(AVISO)).toBeInTheDocument();
     expect(screen.getByText("Reintentar")).toBeInTheDocument();
-    expect(screen.getByTestId("table-mock")).toHaveStyle("opacity: 0.5");
+    expect(tableProps.current.style).toEqual({ opacity: 0.5 });
     // Las filas viejas SIGUEN ahí: la opción B es marcarlas, no esconderlas.
     expect(runtime.current.data?.data).toHaveLength(3);
   });
@@ -226,7 +252,7 @@ describe("useCrud: el dato viejo tras un request fallido se marca como desactual
     await waitFor(() =>
       expect(screen.queryByText(AVISO)).not.toBeInTheDocument(),
     );
-    expect(screen.getByTestId("table-mock")).not.toHaveStyle("opacity: 0.5");
+    expect(tableProps.current.style).toBeUndefined();
   });
 
   it("(e) el aviso NO parpadea mientras el reintento está en vuelo", async () => {
@@ -262,5 +288,112 @@ describe("useCrud: el dato viejo tras un request fallido se marca como desactual
     await waitFor(() =>
       expect(screen.queryByText(AVISO)).not.toBeInTheDocument(),
     );
+  });
+});
+
+/**
+ * La rama de scroll infinito (`perPage > 0`, 28 de los 40 módulos) lleva su
+ * propia bandera —`manualIsStale`—, porque no usa `saveInState` y por lo tanto
+ * el `isStale` de `useAxios` nunca se mueve para ella.
+ *
+ * ⚠️ Acá el banner NO puede salir, y es a propósito. En modo infinito lo único
+ * que falla con filas ya dibujadas es el "cargar más": todo otro refresco
+ * arranca por `beginListReset`, que borra las filas antes de pedir. Y el
+ * "cargar más" fallido YA tiene su renglón propio. Por eso la tercera guarda
+ * del banner es `!runtime.loadMoreFailed`: sin ella salen DOS carteles
+ * diciendo lo mismo, porque `fetchInfiniteCrudData` prende `loadMoreFailed` y
+ * `manualIsStale` en el mismo fallo.
+ *
+ * Así que lo que se mide es: la bandera se mueve bien, y aun así el usuario ve
+ * UN solo cartel.
+ */
+describe("useCrud: la bandera de dato viejo en el scroll infinito", () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * 🔴 Esperar el ESQUELETO no es opcional.
+   *
+   * `showTableSkeleton` se sostiene `MIN_TABLE_SKELETON_MS` (300 ms) después de
+   * que la respuesta llegó, y mientras está puesto el banner se apaga por su
+   * PROPIA guarda. La primera versión de estos dos tests afirmaba antes de esos
+   * 300 ms: pasaban en verde con la guarda de `loadMoreFailed` REINYECTADA
+   * afuera, porque lo que suprimía el banner era el esqueleto y no la guarda
+   * que se creía estar midiendo.
+   */
+  const esperarSinEsqueleto = () =>
+    waitFor(() => expect(tableProps.current?.showSkeletonRows).toBe(false));
+
+  const cargarPrimeraPagina = async () => {
+    request.mockResolvedValueOnce(respuestaConMas());
+    const runtime = montar(LOTE);
+
+    await screen.findByTestId("table-mock");
+    await waitFor(() => expect(runtime.current.listHasMore).toBe(true));
+    await esperarSinEsqueleto();
+    expect(runtime.current.isStale).toBe(false);
+
+    return runtime;
+  };
+
+  it("un 'cargar más' fallido prende la bandera pero deja UN SOLO cartel", async () => {
+    const runtime = await cargarPrimeraPagina();
+
+    request.mockImplementationOnce(fallo);
+    await act(async () => {
+      runtime.current.onLoadMore();
+    });
+
+    await waitFor(() => expect(runtime.current.isStale).toBe(true));
+    expect(runtime.current.loadMoreFailed).toBe(true);
+    await esperarSinEsqueleto();
+    // Con el esqueleto apagado y 40 filas dibujadas, lo ÚNICO que puede estar
+    // conteniendo al banner es la guarda de `loadMoreFailed`.
+    expect(tableProps.current.data).toHaveLength(LOTE);
+
+    // 🔴 El renglón de "cargar más", que ya existía. Y NADA más.
+    expect(
+      screen.getByText("No se pudieron cargar más resultados."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(AVISO),
+      "el banner no puede duplicar el aviso que ya da el renglón de cargar más",
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
+
+  it("cuando el 'cargar más' funciona, la bandera se apaga y no queda ningún cartel", async () => {
+    const runtime = await cargarPrimeraPagina();
+
+    request.mockImplementationOnce(fallo);
+    await act(async () => {
+      runtime.current.onLoadMore();
+    });
+    await waitFor(() => expect(runtime.current.isStale).toBe(true));
+
+    request.mockResolvedValueOnce({
+      data: {
+        data: filas(LOTE).map((f, i) => ({ ...f, id: `p2-${i}` })),
+        message: { total: 100 },
+      },
+    });
+    await act(async () => {
+      runtime.current.onLoadMore();
+    });
+
+    // 🔴 Una bandera que no se apaga deja la pantalla marcada para siempre.
+    await waitFor(() => expect(runtime.current.isStale).toBe(false));
+    expect(runtime.current.loadMoreFailed).toBe(false);
+    await esperarSinEsqueleto();
+    expect(
+      screen.queryByText("No se pudieron cargar más resultados."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(AVISO)).not.toBeInTheDocument();
+    expect(screen.queryAllByRole("alert")).toHaveLength(0);
   });
 });

--- a/src/mk/hooks/useCrud/__tests__/useCrudDatoDesactualizado.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrudDatoDesactualizado.test.tsx
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  cleanup,
+  act,
+  waitFor,
+  screen,
+  fireEvent,
+} from "@testing-library/react";
+import React from "react";
+import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
+
+/**
+ * CDT-42: un request que falla NO puede dejar el dato viejo en pantalla como si
+ * fuera fresco.
+ *
+ * ## 🔴 Qué se rompía
+ *
+ * `useAxios` conserva `data` cuando el request falla —a propósito: pisarlo con
+ * null hace desaparecer la lista entera—, así que tras un refresco fallido las
+ * filas viejas siguen dibujadas. Y el render de `useCrud` decide así:
+ *
+ * ```tsx
+ * {showTableSkeleton || filteredData?.length > 0 ? <Table … /> : runtime.error ? …}
+ * ```
+ *
+ * Con filas en pantalla el primer branch gana SIEMPRE, así que el estado de
+ * error —que ya existía, con su texto y su botón "Recargar"— era inalcanzable.
+ * El usuario veía datos viejos, sin un solo aviso, y les creía.
+ *
+ * ## La decisión de producto (Alexander)
+ *
+ * Opción B: el dato viejo se queda visible pero MARCADO. La condición con la
+ * que se aceptó es que el aviso sea imposible de pasar por alto.
+ *
+ * ## Qué pinea este test
+ *
+ * Este archivo NO mockea `useAxios`: corre el hook de verdad contra una
+ * instancia de axios falsa inyectada por `AxiosContext`, así que mide
+ * `isStale` y el render juntos, que es donde vive el bug.
+ *
+ * 🔴 El caso del PARPADEO es el que más cuesta: `error` se limpia al ARRANCAR
+ * cada petición, así que un aviso colgado de `!!error` se apaga apenas el
+ * usuario toca "Reintentar" y se vuelve a prender si falla. `isStale` se
+ * escribe sólo cuando la petición TERMINA, y por eso se sostiene.
+ */
+
+vi.mock("@/mk/components/ui/Table/Table", () => ({
+  // Reenvía `style`: la atenuación del dato viejo viaja por ahí.
+  default: ({ style }: any) => <div data-testid="table-mock" style={style} />,
+}));
+vi.mock("@/mk/components/ui/Pagination/Pagination", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/hooks/useCrud/FormElement", () => ({ default: () => null }));
+vi.mock("@/mk/components/forms/DataSearch/DataSearch", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/data/ImportDataModal/ImportDataModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/DetailModal/DetailModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/NewModal/NewModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/forms/FloatButton/FloatButton", () => ({
+  default: () => null,
+}));
+vi.mock("@/components/NoData/EmptyData", () => ({
+  default: () => <div data-testid="empty-data" />,
+}));
+vi.mock("@/mk/hooks/useMediaQuery", () => ({ default: () => false }));
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) mocked[key] = () => null;
+  return mocked;
+});
+
+import useCrud, { ModCrudType } from "../useCrud";
+
+const AVISO = "No se pudo actualizar: estos datos están desactualizados.";
+const ERROR_INICIAL = "No se pudo cargar el listado.";
+
+const request = vi.fn();
+
+const mod: ModCrudType = {
+  modulo: "reservations",
+  singular: "reserva",
+  plural: "reservas",
+  permiso: "reservations",
+} as ModCrudType;
+
+const fields = {
+  id: { rules: [], api: "e" },
+  name: { rules: [], api: "ae", label: "Nombre", list: {} },
+};
+
+const filas = (cuantas: number) =>
+  Array.from({ length: cuantas }, (_, i) => ({
+    id: `r-${i + 1}`,
+    name: `Fila ${i + 1}`,
+  }));
+
+const respuestaOk = (cuantas = 3) => ({
+  data: { data: filas(cuantas), message: { total: cuantas } },
+});
+
+const fallo = () => Promise.reject(new Error("Network Error"));
+
+/**
+ * 🔴 `perPage: -1` a propósito: es el modo SIN scroll infinito, el que usan 12
+ * de los 40 módulos, y es exactamente donde vive el bug. Con scroll infinito un
+ * refresco arranca por `beginListReset`, que borra las filas de pantalla, así
+ * que ahí no hay dato viejo que marcar.
+ */
+const montar = () => {
+  const runtime: { current: any } = { current: null };
+
+  const Comp = () => {
+    runtime.current = useCrud({
+      paramsInitial: { page: 1, perPage: -1, fullType: "L", searchBy: "" },
+      mod,
+      fields,
+    });
+    const List = runtime.current.List;
+    return <List height="100%" />;
+  };
+
+  render(
+    <AxiosContext.Provider
+      value={
+        {
+          contextInstance: { request },
+          waiting: 0,
+          setWaiting: vi.fn(),
+        } as any
+      }
+    >
+      <Comp />
+    </AxiosContext.Provider>,
+  );
+
+  return runtime;
+};
+
+describe("useCrud: el dato viejo tras un request fallido se marca como desactualizado", () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("(a) falla el refresco con filas en pantalla: sale el aviso y la tabla queda atenuada", async () => {
+    request.mockResolvedValueOnce(respuestaOk());
+
+    const runtime = montar();
+
+    expect(await screen.findByTestId("table-mock")).toBeInTheDocument();
+    expect(screen.queryByText(AVISO)).not.toBeInTheDocument();
+
+    request.mockImplementationOnce(fallo);
+    await act(async () => {
+      await runtime.current.reLoad();
+    });
+
+    // 🔴 Acá la tabla se seguía dibujando idéntica a una recién cargada.
+    expect(await screen.findByText(AVISO)).toBeInTheDocument();
+    expect(screen.getByText("Reintentar")).toBeInTheDocument();
+    expect(screen.getByTestId("table-mock")).toHaveStyle("opacity: 0.5");
+    // Las filas viejas SIGUEN ahí: la opción B es marcarlas, no esconderlas.
+    expect(runtime.current.data?.data).toHaveLength(3);
+  });
+
+  it("(b) falla sin datos previos: el estado de error de siempre, y UN solo cartel", async () => {
+    request.mockImplementation(fallo);
+
+    montar();
+
+    expect(await screen.findByText(ERROR_INICIAL)).toBeInTheDocument();
+    expect(screen.queryByText(AVISO)).not.toBeInTheDocument();
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
+
+  it("(c) primer render, sin error y sin datos: no muestra nada", async () => {
+    let resolver: (v: any) => void = () => {};
+    request.mockImplementationOnce(
+      () => new Promise((resolve) => (resolver = resolve)),
+    );
+
+    montar();
+
+    expect(screen.queryByText(AVISO)).not.toBeInTheDocument();
+    expect(screen.queryByText(ERROR_INICIAL)).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolver(respuestaOk());
+    });
+    expect(await screen.findByTestId("table-mock")).toBeInTheDocument();
+    expect(screen.queryByText(AVISO)).not.toBeInTheDocument();
+  });
+
+  it("(d) falla y después el reintento funciona: el aviso desaparece y la tabla vuelve a plena", async () => {
+    request.mockResolvedValueOnce(respuestaOk());
+    const runtime = montar();
+    await screen.findByTestId("table-mock");
+
+    request.mockImplementationOnce(fallo);
+    await act(async () => {
+      await runtime.current.reLoad();
+    });
+    expect(await screen.findByText(AVISO)).toBeInTheDocument();
+
+    request.mockResolvedValueOnce(respuestaOk(5));
+    await act(async () => {
+      fireEvent.click(screen.getByText("Reintentar"));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText(AVISO)).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("table-mock")).not.toHaveStyle("opacity: 0.5");
+  });
+
+  it("(e) el aviso NO parpadea mientras el reintento está en vuelo", async () => {
+    request.mockResolvedValueOnce(respuestaOk());
+    const runtime = montar();
+    await screen.findByTestId("table-mock");
+
+    request.mockImplementationOnce(fallo);
+    await act(async () => {
+      await runtime.current.reLoad();
+    });
+    expect(await screen.findByText(AVISO)).toBeInTheDocument();
+
+    // El reintento arranca y queda colgado. `useAxios` limpia `error` justo
+    // acá: un aviso colgado de `!!error` se apagaría en este instante.
+    let resolver: (v: any) => void = () => {};
+    request.mockImplementationOnce(
+      () => new Promise((resolve) => (resolver = resolve)),
+    );
+    act(() => {
+      runtime.current.reLoad();
+    });
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+    expect(
+      screen.queryByText(AVISO),
+      "el aviso tiene que sostenerse mientras el reintento está en vuelo",
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      resolver(respuestaOk());
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(AVISO)).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -43,6 +43,7 @@ import {
   IconTrash,
   IconExport,
   IconFilter,
+  IconAlertCircle,
 } from "@/components/layout/icons/IconsBiblioteca";
 import DataSearch from "@/mk/components/forms/DataSearch/DataSearch";
 import FormElement from "./FormElement";
@@ -508,6 +509,7 @@ const useCrud = ({
     execute,
     loaded: axiosLoaded,
     error: axiosError,
+    isStale: axiosIsStale,
   } = useAxios(
     useInfiniteList ? null : "/" + mod.modulo,
     "GET",
@@ -517,11 +519,22 @@ const useCrud = ({
   const [manualData, setManualData] = useState<any>(null);
   const [manualLoaded, setManualLoaded] = useState(!useInfiniteList);
   const [manualError, setManualError]: any = useState("");
+  /**
+   * El gemelo de `isStale` de `useAxios` para el scroll infinito, que no usa
+   * `saveInState`: acá el dato de pantalla es `listRows`, y lo maneja este hook.
+   *
+   * 🔴 Se escribe SÓLO cuando el request termina (`fetchInfiniteCrudData`), no
+   * cuando arranca. `manualError` sí se limpia al arrancar —`setManualError("")`
+   * un poco más abajo—, y colgar el aviso de él lo haría parpadear en cada
+   * reintento fallido.
+   */
+  const [manualIsStale, setManualIsStale] = useState(false);
   const latestRequestIdRef = useRef(0);
   const lastResolvedParamsRef = useRef<Record<string, any>>(params);
   const data = useInfiniteList ? manualData : axiosData;
   const loaded = useInfiniteList ? manualLoaded : axiosLoaded;
   const error = useInfiniteList ? manualError : axiosError;
+  const isStale = useInfiniteList ? manualIsStale : axiosIsStale;
   const [listRows, setListRows] = useState<any[]>([]);
   const [listTotal, setListTotal] = useState(0);
   const [listHasMore, setListHasMore] = useState(false);
@@ -651,6 +664,9 @@ const useCrud = ({
         setManualData(result.data);
       }
       setManualError(result.error);
+      // Al TERMINAR: si falló, lo que quedó en pantalla es dato viejo; si
+      // respondió, se refrescó y deja de serlo.
+      setManualIsStale(!!result.error);
       setManualLoaded(true);
       return result;
     },
@@ -2239,6 +2255,7 @@ const useCrud = ({
     data: resolvedData,
     loaded,
     error,
+    isStale,
     searchs,
     params,
     mod,
@@ -2479,6 +2496,30 @@ const useCrud = ({
         return () => window.clearTimeout(timeout);
       }, [shouldRequestTableSkeleton, showTableSkeleton]);
 
+      /**
+       * 🔴 CDT-42: el request falló pero las filas viejas siguen en pantalla.
+       *
+       * El estado de error de más abajo (`listErrorState`) es INALCANZABLE en
+       * este caso: con filas, el primer branch del ternario se lleva el render
+       * y la tabla se dibuja igual que si el dato fuera fresco. El usuario ve
+       * datos viejos sin un solo aviso.
+       *
+       * Las tres condiciones que lo apagan, y por qué:
+       *
+       * - `showTableSkeleton`: mientras carga no hay nada que avisar todavía.
+       * - `filteredData?.length > 0`: sin filas gana el estado de error de
+       *   siempre. Cubre también el primer render (`error` en `""`, `data` en
+       *   `[]`), donde no hay ni error ni filas.
+       * - `loadMoreFailed`: el "cargar más" fallido YA tiene su propio renglón
+       *   (`loadMoreErrorRow`); sin esto salen dos carteles diciendo lo mismo,
+       *   porque `fetchInfiniteCrudData` prende las dos banderas a la vez.
+       */
+      const showStaleBanner =
+        !!runtime.isStale &&
+        !showTableSkeleton &&
+        filteredData?.length > 0 &&
+        !runtime.loadMoreFailed;
+
       let emptyContent;
       if (props.onRenderEmpty) {
         emptyContent = props.onRenderEmpty();
@@ -2528,8 +2569,35 @@ const useCrud = ({
           {runtime.openList && (
             <div className={styles.contentRow}>
               <section className={styles.contentMain}>
+                {showStaleBanner && (
+                  <div className={styles.staleBanner} role="alert">
+                    <IconAlertCircle size={28} />
+                    <div className={styles.staleBannerText}>
+                      <p>
+                        No se pudo actualizar: estos datos están
+                        desactualizados.
+                      </p>
+                      <span>
+                        Es la última información que se pudo cargar y puede
+                        haber cambiado. No tomes decisiones con esto sin
+                        reintentar.
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.loadMoreErrorRetry}
+                      onClick={() => runtime.reLoad()}
+                    >
+                      Reintentar
+                    </button>
+                  </div>
+                )}
                 {showTableSkeleton || filteredData?.length > 0 ? (
                   <Table
+                    // La atenuación del dato viejo. Sólo opacidad: un `filter`
+                    // acá crearía un containing block y movería cualquier
+                    // descendiente posicionado de la tabla.
+                    style={showStaleBanner ? { opacity: 0.5 } : undefined}
                     data={showTableSkeleton ? [] : sortedData}
                     onRowClick={
                       props.onRowClick

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -196,6 +196,8 @@ type UseCrudType = {
   setSearchs: Function;
   data: any;
   loaded: boolean;
+  /** Hay dato viejo en pantalla y el último intento de refrescarlo falló. */
+  isStale: boolean;
   setAction: Function;
   reLoad: Function;
   execute: Function;
@@ -2890,6 +2892,8 @@ const useCrud = ({
     setSearchs,
     data: resolvedData,
     loaded,
+    /** Hay dato viejo en pantalla y el último intento de refrescarlo falló. */
+    isStale,
     setAction,
     reLoad: reloadCrudList,
     execute,

--- a/src/mk/hooks/useCrud/useCrudStyle.module.css
+++ b/src/mk/hooks/useCrud/useCrudStyle.module.css
@@ -147,6 +147,64 @@
   color: var(--cWhiteV3);
 }
 
+/*
+ * El aviso de DATO DESACTUALIZADO (CDT-42): el request falló pero las filas
+ * viejas siguen en pantalla.
+ *
+ * 🔴 Va en ámbar SÓLIDO, no en un gris discreto. La decisión de producto fue
+ * "dejar el dato viejo visible pero marcado", y eso sólo sirve si el aviso es
+ * imposible de pasar por alto: un cartel tenue deja al usuario exactamente
+ * igual que antes y encima con la sensación de que está arreglado.
+ *
+ * Vive FUERA del área que scrollea la tabla, así que no se va de la vista.
+ */
+.staleBanner {
+  display: flex;
+  align-items: center;
+  gap: var(--spM);
+  flex: 0 0 auto;
+  padding: 12px var(--spM);
+  margin-bottom: var(--spS, 8px);
+  border-radius: var(--bRadiusS, 8px);
+  border: 2px solid var(--cWarning);
+  background-color: var(--cWarning);
+  /* Texto oscuro sobre el ámbar: ~10:1 de contraste. */
+  color: #1a1a1a;
+}
+
+.staleBannerText {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.staleBannerText > p {
+  font-size: var(--sM);
+  font-weight: 900;
+}
+
+.staleBannerText > span {
+  font-size: var(--sS, 12px);
+}
+
+/*
+ * El botón reusa `.loadMoreErrorRetry` (misma forma y tamaño que el resto de
+ * los reintentos), pero ahí el borde y el texto son blancos y sobre el ámbar
+ * no se leerían.
+ */
+.staleBanner button {
+  flex: 0 0 auto;
+  border-color: rgba(0, 0, 0, 0.55);
+  color: #1a1a1a;
+  font-weight: 700;
+}
+
+.staleBanner button:hover {
+  border-color: #1a1a1a;
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
 /* El renglón de "no se pudo cargar más" del scroll infinito, con su reintento. */
 .loadMoreErrorRow {
   display: flex;


### PR DESCRIPTION
## Qué pasaba

Cuando un request fallaba, `useAxios` **no limpiaba `data`**: la pantalla se quedaba mostrando el payload de la consulta anterior, **sin ningún aviso**. El usuario veía números que ya no correspondían a lo que había pedido, y no tenía forma de saberlo.

Es lo que hizo invisible el error 500 del Balance en CDT-31: el tester no vio un mensaje de error, vio tablas con datos viejos y una gráfica vacía, y **reportó el bug equivocado**.

## Lo que el ticket decía mal

**El hook ya exponía el error** (`useAxios.tsx:120`). Lo que faltaba no era información, era **renderizarla**: de 116 desestructuraciones, sólo **9** leen `error`.

Y el agujero exacto estaba acá (`useCrud.tsx`):

```tsx
{showTableSkeleton || filteredData?.length > 0 ? <Table/> : runtime.error ? <estado de error/> : …}
```

Con filas viejas en pantalla, la `Table` gana y el estado de error **ya escrito**, con su texto y su botón "Recargar", es **inalcanzable**. Estaba construido y no se veía nunca.

## La decisión de producto

Alexander eligió **opción B**: dejar el dato viejo visible pero **marcado como desactualizado**, con la condición explícita de que **el aviso sea imposible de pasar por alto**.

Banner ámbar sólido de ancho completo, fuera del área que scrollea, con título en negro peso 900, la bajada *"No tomes decisiones con esto sin reintentar"*, botón **Reintentar**, y la tabla al 50% de opacidad.

## Todo aditivo

`isStale` es un campo nuevo en el retorno de `useAxios`. **Ninguno de los 61 archivos consumidores se rompe**: quien no lo lea, ni se entera.

🔴 **`isStale` no es derivado.** La fórmula obvia —`data !== null && !!error`— hace **parpadear** el aviso, porque `error` se limpia al *arrancar* cada request: durante el reintento el cartel desaparece justo cuando más falta hace. Es estado que se escribe **al terminar** la petición. Sticky por construcción, sin timers.

Segundo filtro: sólo las peticiones con `saveInState` mueven la bandera. Los módulos comparten un `useAxios` entre la lista, los guardados y los exports — sin eso, un guardado fallido marcaba la lista como vieja siendo que estaba fresca.

## Tres guardas en el banner, y la tercera era real

`!showTableSkeleton && filteredData?.length > 0 && !runtime.loadMoreFailed`

La última evita **dos carteles a la vez**: el "cargar más" fallido ya tiene su propio renglón, y sin ella salían juntos.

## El test que parecía medir y no medía

Los primeros tests de esa guarda quedaron verdes **y siguieron verdes con el bug reinyectado**. La reinyección estaba bien aplicada; el test estaba mal: afirmaba justo después de que la bandera se prendía, pero el esqueleto de la tabla se sostiene **300 ms** (`MIN_TABLE_SKELETON_MS`). Lo que suprimía el banner era **el esqueleto, no la guarda**.

Los otros casos no tenían el problema **por casualidad**: usan `findByText`, que pollea hasta 1000 ms. **La diferencia entre medir y no medir estaba en qué matcher se eligió.** Se agregó un `esperarSinEsqueleto()` explícito.

Lo mismo con la atenuación: el test mockeaba la tabla con `({style}) => <div style={style}/>`, o sea el mock **fabricaba** el forwarding que decía verificar. Ahora el mock **guarda** los props (que es lo único que le toca a `useCrud`) y un test aparte usa el **`Table` real** para comprobar que un `style` arbitrario llega al DOM. Con el `Table` real roto, el archivo de `useCrud` quedaba verde: ése era el agujero.

## Verificación

- **743 tests verdes / 111 archivos** (antes 739/110). `tsc --noEmit`: **23** = baseline.
- Cada arreglo verificado por **reinyección**, con el mensaje literal del rojo.
- Code review `gentle-ai`: recibo **aprobado**, lineage `review-058847c1b2a7851a`, cero blockers.

## Alcance: lo que NO entra

- **`Balance` y el dashboard financiero.** Muestran **montos, no filas**, y ahí un número viejo atenuado es un número que alguien puede cobrar. Hay una pregunta abierta con Alexander (B1 vs B2) y va en otro commit.
- **`Reel.tsx:93-95`** ya hace `setContents([])` en el error: limpia por su cuenta, en silencio. Atenuar ahí sería no-op. Necesita su propio ticket.

## Corrección de alcance, medida

El bug mordía en **12 de 40 módulos** (los que no usan scroll infinito), no en 41. Los otros 28 borran las filas antes de pedir, así que ya caían en el estado de error explícito. El arreglo los cubre a todos desde el punto compartido, pero el problema era más chico de lo que decía el ticket.

## Pendiente para QA

Cualquier listado **sin scroll infinito** (Unidades, Bancos, Categorías): cortar la red después de la primera carga y disparar un refresco. Que el banner ámbar salga, que la tabla quede atenuada pero **legible**, y que "Reintentar" lo apague al funcionar.

## Anotado, no tocado

- Un tercer caso de test que sugirió la revisión: el refresco *de todos los días* (cambiar de página o de filtro) con `isStale` ya en true. Los tests actuales disparan con `reLoad()`/`onLoadMore()` explícitos.
- `git ls-files -s` da modo **100755** en `useAxios.tsx`, `useCrud.tsx`, `Table.tsx` y `context/condaty_admin_context.md`. Viene de antes, pero hace que el sobre de riesgo le eche la culpa del "cambio ejecutable" a un markdown. Va en ticket propio.