### PR TITLE
feat(invitation): enums numéricos en la pestaña de QR, con el primer test de su espejo

### DIFF
--- a/src/modulos/Activities/QrTab/QrTab.tsx
+++ b/src/modulos/Activities/QrTab/QrTab.tsx
@@ -7,6 +7,13 @@ import useCrud, { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
 import NotAccess from "@/components/auth/NotAccess/NotAccess";
 import { IconGroupsQr, IconSingleQr } from "@/components/layout/icons/IconsBiblioteca";
 import RenderView from "./RenderView/RenderView";
+import {
+  INVITATION_TYPE_LABELS,
+  InvitationStatus,
+  InvitationType,
+  esEstado,
+  esTipo,
+} from "./invitationEnums";
 
 interface QRTabProps {
   paramsInitial: any;
@@ -19,23 +26,14 @@ interface QRTabProps {
 }
 
 /**
- * Los tres tipos de invitación, con las palabras que ya usa el detalle.
- *
- * ⚠️ Las mismas que imprime `InvitacionesExportConfig` en el back: la lista y
- * el reporte tienen que decir lo mismo.
- */
-const INVITATION_TYPE_LABELS: Record<string, string> = {
-  I: "Individual",
-  G: "Grupal",
-  F: "Frecuente",
-};
-
-/**
  * ⚠️ Los valores viajan al back en `filterBy` y los interpreta
  * `InvitationController::porEstado()`. Son las palabras que la lista MUESTRA,
- * no los cuatro chars de `invitations.status` —'O', 'A', 'I', 'X'— que el
- * usuario no ve por ningún lado: un filtro que hable otro idioma que la
- * columna filtra por algo distinto de lo que se está mirando.
+ * no los cuatro valores de `invitations.status` —USED, ACTIVE, INACTIVE,
+ * CANCELLED— que el usuario no ve por ningún lado: un filtro que hable otro
+ * idioma que la columna filtra por algo distinto de lo que se está mirando.
+ *
+ * 🔴 Por eso este filtro NO cambió con la migración a enums numéricos: nunca
+ * mandó el valor de la columna.
  */
 const getStatusOptions = () => [
   { id: "ALL", name: "Todos" },
@@ -44,9 +42,19 @@ const getStatusOptions = () => [
   { id: "ANULADA", name: "Anulada" },
 ];
 
+/**
+ * ⚠️ Los ids van como NÚMERO, no como el string que devolvería
+ * `Object.entries` —las claves de un objeto son strings siempre, aunque se
+ * hayan escrito numéricas—. El back lo tolera porque castea, pero el `Select`
+ * compartido compara el id contra el valor del form con `==`, y mezclar `"2"`
+ * con `2` en esa comparación es la clase de cosa que después nadie encuentra.
+ */
 const getTypeOptions = () => [
   { id: "ALL", name: "Todos" },
-  ...Object.entries(INVITATION_TYPE_LABELS).map(([id, name]) => ({ id, name })),
+  ...Object.entries(INVITATION_TYPE_LABELS).map(([id, name]) => ({
+    id: Number(id),
+    name,
+  })),
 ];
 // Función actualizada para obtener las opciones de período
 const getPeriodOptions = () => [
@@ -181,9 +189,11 @@ const QRTab: React.FC<QRTabProps> = ({ paramsInitial, onRowClick }) => {
             //
             // El ícono solo no alcanza para distinguir tres cosas, así que va
             // con su nombre al lado. El reporte usa las mismas palabras.
-            const type = props.item.type;
-            const esGrupal = type === "G";
-            const label = INVITATION_TYPE_LABELS[type] ?? INVITATION_TYPE_LABELS.I;
+            const type = Number(props.item.type);
+            const esGrupal = esTipo(type, InvitationType.GROUP);
+            const label =
+              INVITATION_TYPE_LABELS[type] ??
+              INVITATION_TYPE_LABELS[InvitationType.INDIVIDUAL];
 
             return (
               <div className={styles.invitationTypeIcon} title={label}>
@@ -214,7 +224,7 @@ const QRTab: React.FC<QRTabProps> = ({ paramsInitial, onRowClick }) => {
             let statusLabel = "Activa";
             let statusClass = "statusA";
 
-            if (props.item.status === "X") {
+            if (esEstado(props.item.status, InvitationStatus.CANCELLED)) {
               statusLabel = "Anulada";
               statusClass = "statusX";
             } else if (props.item.access && props.item.access.length === 0) {

--- a/src/modulos/Activities/QrTab/QrTab.tsx
+++ b/src/modulos/Activities/QrTab/QrTab.tsx
@@ -56,13 +56,28 @@ const getTypeOptions = () => [
     name,
   })),
 ];
-// Función actualizada para obtener las opciones de período
+/**
+ * 🔴 Los códigos son los CORTOS, y el cambio no es cosmético.
+ *
+ * Hasta el 2026-08-15 este filtro mandaba `week`/`lweek`/`month`/`lmonth`, y
+ * el API los traducía con una tabla propia a los cortos que entiende
+ * `PeriodFilterService`. Esa traducción era lo ÚNICO que había dejado al
+ * filtro de fechas de Invitaciones afuera de la unificación de 2026-08-04 — y
+ * por eso seguía arrastrando los dos bugs que se arreglaron allá: en enero
+ * "mes pasado" devolvía cero filas, y parado un día 31 devolvía el mes actual.
+ *
+ * Con los códigos cortos el listado usa el mismo filtro que los otros 44
+ * módulos y la copia desaparece.
+ *
+ * ⚠️ `t` (Todos) no es un período: el back lo ignora porque no matchea ningún
+ * caso, que es exactamente lo que tiene que pasar.
+ */
 const getPeriodOptions = () => [
   { id: "t", name: "Todos" },
-  { id: "week", name: "Esta Semana" },
-  { id: "lweek", name: "Ant. Semana" },
-  { id: "month", name: "Este Mes" },
-  { id: "lmonth", name: "Ant. Mes" }
+  { id: "w", name: "Esta Semana" },
+  { id: "lw", name: "Ant. Semana" },
+  { id: "m", name: "Este Mes" },
+  { id: "lm", name: "Ant. Mes" }
 ];
 
 const QRTab: React.FC<QRTabProps> = ({ paramsInitial, onRowClick }) => {

--- a/src/modulos/Activities/QrTab/QrTab.tsx
+++ b/src/modulos/Activities/QrTab/QrTab.tsx
@@ -9,10 +9,9 @@ import { IconGroupsQr, IconSingleQr } from "@/components/layout/icons/IconsBibli
 import RenderView from "./RenderView/RenderView";
 import {
   INVITATION_TYPE_LABELS,
-  InvitationStatus,
   InvitationType,
-  esEstado,
-  esTipo,
+  esAnulada,
+  esGrupal,
 } from "./invitationEnums";
 
 interface QRTabProps {
@@ -205,14 +204,14 @@ const QRTab: React.FC<QRTabProps> = ({ paramsInitial, onRowClick }) => {
             // El ícono solo no alcanza para distinguir tres cosas, así que va
             // con su nombre al lado. El reporte usa las mismas palabras.
             const type = Number(props.item.type);
-            const esGrupal = esTipo(type, InvitationType.GROUP);
+            const grupal = esGrupal(type);
             const label =
               INVITATION_TYPE_LABELS[type] ??
               INVITATION_TYPE_LABELS[InvitationType.INDIVIDUAL];
 
             return (
               <div className={styles.invitationTypeIcon} title={label}>
-                {esGrupal ? (
+                {grupal ? (
                   <IconGroupsQr className={styles.groupIcon} />
                 ) : (
                   <IconSingleQr className={styles.singleIcon} />
@@ -239,7 +238,7 @@ const QRTab: React.FC<QRTabProps> = ({ paramsInitial, onRowClick }) => {
             let statusLabel = "Activa";
             let statusClass = "statusA";
 
-            if (esEstado(props.item.status, InvitationStatus.CANCELLED)) {
+            if (esAnulada(props.item.status)) {
               statusLabel = "Anulada";
               statusClass = "statusX";
             } else if (props.item.access && props.item.access.length === 0) {

--- a/src/modulos/Activities/QrTab/RenderView/RenderView.tsx
+++ b/src/modulos/Activities/QrTab/RenderView/RenderView.tsx
@@ -11,12 +11,7 @@ import {
   IconArrowRight,
   IconArrowLeft,
   IconGenericQr} from "@/components/layout/icons/IconsBiblioteca";
-import {
-  InvitationStatus,
-  InvitationType,
-  esEstado,
-  esTipo,
-} from "../invitationEnums";
+import {esAnulada, esGrupal, esIndividual} from "../invitationEnums";
 
 interface RenderViewProps {
   open: boolean;
@@ -38,7 +33,7 @@ const RenderView: React.FC<RenderViewProps> = ({
 
   // Determinar el estado de la invitación
   const getStatusInfo = () => {
-    if (esEstado(item?.status, InvitationStatus.CANCELLED)) {
+    if (esAnulada(item?.status)) {
       return {
         label: "Anulada",
         className: styles.statusCancelled
@@ -69,7 +64,7 @@ const RenderView: React.FC<RenderViewProps> = ({
       <div className={styles.container}>
         <div className={styles.iconHeader}>
           <div className={styles.iconCircle}>
-            {esTipo(item?.type, InvitationType.GROUP) ? (
+            {esGrupal(item?.type) ? (
               <IconGroupsQr className={styles.qrIcon} />
             ) : (
               <IconSingleQr className={styles.qrIcon} />
@@ -91,7 +86,7 @@ const RenderView: React.FC<RenderViewProps> = ({
           <div className={styles.detailRow}>
             <div className={styles.label}>Tipo:</div>
             <div className={styles.value}>
-              {esTipo(item?.type, InvitationType.GROUP) ? "Grupal" : "Individual"}
+              {esGrupal(item?.type) ? "Grupal" : "Individual"}
             </div>
           </div>
 
@@ -124,7 +119,7 @@ const RenderView: React.FC<RenderViewProps> = ({
           )}
 
           {/* Mostrar invitados si es una invitación grupal */}
-          {esTipo(item?.type, InvitationType.GROUP) && item?.guests && item?.guests.length > 0 && (
+          {esGrupal(item?.type) && item?.guests && item?.guests.length > 0 && (
             <>
               <div className={styles.guestsHeader}>
                 <div className={styles.guestsTitle}>Invitados ({item.guests.length})</div>
@@ -159,7 +154,7 @@ const RenderView: React.FC<RenderViewProps> = ({
           )}
 
           {/* Para invitaciones individuales, mostrar el acceso */}
-          {esTipo(item?.type, InvitationType.INDIVIDUAL) && item?.access && (
+          {esIndividual(item?.type) && item?.access && (
             <div className={styles.detailRow}>
               <div className={styles.label}>Acceso:</div>
               <div className={styles.value}>

--- a/src/modulos/Activities/QrTab/RenderView/RenderView.tsx
+++ b/src/modulos/Activities/QrTab/RenderView/RenderView.tsx
@@ -11,6 +11,12 @@ import {
   IconArrowRight,
   IconArrowLeft,
   IconGenericQr} from "@/components/layout/icons/IconsBiblioteca";
+import {
+  InvitationStatus,
+  InvitationType,
+  esEstado,
+  esTipo,
+} from "../invitationEnums";
 
 interface RenderViewProps {
   open: boolean;
@@ -32,7 +38,7 @@ const RenderView: React.FC<RenderViewProps> = ({
 
   // Determinar el estado de la invitación
   const getStatusInfo = () => {
-    if (item?.status === "X") {
+    if (esEstado(item?.status, InvitationStatus.CANCELLED)) {
       return {
         label: "Anulada",
         className: styles.statusCancelled
@@ -63,7 +69,7 @@ const RenderView: React.FC<RenderViewProps> = ({
       <div className={styles.container}>
         <div className={styles.iconHeader}>
           <div className={styles.iconCircle}>
-            {item?.type === "G" ? (
+            {esTipo(item?.type, InvitationType.GROUP) ? (
               <IconGroupsQr className={styles.qrIcon} />
             ) : (
               <IconSingleQr className={styles.qrIcon} />
@@ -85,7 +91,7 @@ const RenderView: React.FC<RenderViewProps> = ({
           <div className={styles.detailRow}>
             <div className={styles.label}>Tipo:</div>
             <div className={styles.value}>
-              {item?.type === "G" ? "Grupal" : "Individual"}
+              {esTipo(item?.type, InvitationType.GROUP) ? "Grupal" : "Individual"}
             </div>
           </div>
 
@@ -118,7 +124,7 @@ const RenderView: React.FC<RenderViewProps> = ({
           )}
 
           {/* Mostrar invitados si es una invitación grupal */}
-          {item?.type === "G" && item?.guests && item?.guests.length > 0 && (
+          {esTipo(item?.type, InvitationType.GROUP) && item?.guests && item?.guests.length > 0 && (
             <>
               <div className={styles.guestsHeader}>
                 <div className={styles.guestsTitle}>Invitados ({item.guests.length})</div>
@@ -153,7 +159,7 @@ const RenderView: React.FC<RenderViewProps> = ({
           )}
 
           {/* Para invitaciones individuales, mostrar el acceso */}
-          {item?.type === "I" && item?.access && (
+          {esTipo(item?.type, InvitationType.INDIVIDUAL) && item?.access && (
             <div className={styles.detailRow}>
               <div className={styles.label}>Acceso:</div>
               <div className={styles.value}>

--- a/src/modulos/Activities/QrTab/__tests__/invitationEnums.test.ts
+++ b/src/modulos/Activities/QrTab/__tests__/invitationEnums.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INVITATION_TYPE_LABELS,
+  InvitationStatus,
+  InvitationType,
+  esAnulada,
+  esEstado,
+  esFrecuente,
+  esGrupal,
+  esIndividual,
+  esTipo,
+} from "../invitationEnums";
+
+/**
+ * 🔴 Los números son un CONTRATO con el API, y este archivo era el único de los
+ * cuatro espejos que no tenía **ningún** test.
+ *
+ * Los valores tienen que coincidir con `app/Modules/Invitation/Enums/*.php`.
+ * Nada lo verifica al compilar: los repos no se compilan juntos y el payload
+ * entra al front como `any`.
+ */
+describe("los valores, contra el API", () => {
+  it("InvitationType", () => {
+    expect(InvitationType.INDIVIDUAL).toBe(1);
+    expect(InvitationType.GROUP).toBe(2);
+    expect(InvitationType.FREQUENT).toBe(3);
+  });
+
+  it("InvitationStatus", () => {
+    expect(InvitationStatus.ACTIVE).toBe(1);
+    expect(InvitationStatus.INACTIVE).toBe(2);
+    expect(InvitationStatus.USED).toBe(3);
+    expect(InvitationStatus.CANCELLED).toBe(4);
+  });
+
+  /**
+   * ⚠️ Ningún case vale 0, y no es casualidad: `0 == ""` es `true` en
+   * JavaScript y el `Select` compartido del admin auto-elige la opción con id 0
+   * como si el usuario la hubiera tocado. Ya mordió una vez (CDT-30).
+   */
+  it("ningún case vale 0", () => {
+    const todos = [
+      ...Object.values(InvitationType),
+      ...Object.values(InvitationStatus),
+    ];
+    expect(todos).not.toContain(0);
+  });
+
+  /** Las mismas palabras que imprime `InvitacionesExportConfig` en el back. */
+  it("las etiquetas cubren los tres tipos", () => {
+    expect(INVITATION_TYPE_LABELS[InvitationType.INDIVIDUAL]).toBe("Individual");
+    expect(INVITATION_TYPE_LABELS[InvitationType.GROUP]).toBe("Grupal");
+    expect(INVITATION_TYPE_LABELS[InvitationType.FREQUENT]).toBe("Frecuente");
+  });
+});
+
+/**
+ * 🔴 El caso que motivó los helpers: el mismo campo llega como número o como
+ * string según por dónde pasó. Un `===` pelado falla en el segundo caso sin
+ * ningún error y ninguna fila resulta grupal.
+ */
+describe("los helpers toleran número y string", () => {
+  it.each([
+    ["número", 2],
+    ["string", "2"],
+  ])("reconoce una grupal que llegó como %s", (_etiqueta, valor) => {
+    expect(esTipo(valor, InvitationType.GROUP)).toBe(true);
+    expect(esTipo(valor, InvitationType.INDIVIDUAL)).toBe(false);
+  });
+
+  /**
+   * 🔴 Sin la guarda de null, `Number(null)` es **0** y una invitación sin
+   * `type` matchearía cualquier comparación contra 0.
+   */
+  it("un campo ausente no matchea nada", () => {
+    for (const vacio of [null, undefined]) {
+      expect(esTipo(vacio, InvitationType.GROUP)).toBe(false);
+      expect(esEstado(vacio, InvitationStatus.ACTIVE)).toBe(false);
+    }
+  });
+
+  it("la letra vieja ya no matchea", () => {
+    expect(esTipo("G", InvitationType.GROUP)).toBe(false);
+    expect(esEstado("X", InvitationStatus.CANCELLED)).toBe(false);
+  });
+});
+
+/**
+ * 🔴 **Este bloque es el que mide de verdad.**
+ *
+ * Que la traducción funcione no dice nada sobre si cada pantalla pide el case
+ * correcto. Y acá el agujero era el más grande de los cuatro repos: `esTipo` y
+ * `esEstado` reciben un `number` pelado, así que `esEstado(x,
+ * InvitationType.GROUP)` compila —compara un estado contra un tipo— y `tsc` no
+ * dice nada. En rnOwner y rnGuard eso al menos es un error de tipo.
+ *
+ * Cada predicado se afirma contra **todos** los cases, no sólo contra el suyo:
+ * afirmar únicamente `esGrupal(2) === true` sigue pasando si alguien lo
+ * reescribe como `>= 2`.
+ */
+describe("los predicados con nombre — que cada pantalla pida el case correcto", () => {
+  const TIPOS = [
+    ["individual", InvitationType.INDIVIDUAL],
+    ["grupal", InvitationType.GROUP],
+    ["frecuente", InvitationType.FREQUENT],
+  ] as const;
+
+  it.each(TIPOS)("esGrupal sólo con una %s", (etiqueta, tipo) => {
+    expect(esGrupal(tipo)).toBe(etiqueta === "grupal");
+  });
+
+  it.each(TIPOS)("esIndividual sólo con una %s", (etiqueta, tipo) => {
+    expect(esIndividual(tipo)).toBe(etiqueta === "individual");
+  });
+
+  it.each(TIPOS)("esFrecuente sólo con una %s", (etiqueta, tipo) => {
+    expect(esFrecuente(tipo)).toBe(etiqueta === "frecuente");
+  });
+
+  it.each([
+    ["activa", InvitationStatus.ACTIVE],
+    ["inactiva", InvitationStatus.INACTIVE],
+    ["usada", InvitationStatus.USED],
+    ["anulada", InvitationStatus.CANCELLED],
+  ] as const)("esAnulada sólo con una %s", (etiqueta, estado) => {
+    expect(esAnulada(estado)).toBe(etiqueta === "anulada");
+  });
+
+  it("toleran el string y descartan el vacío", () => {
+    expect(esGrupal("2")).toBe(true);
+    expect(esAnulada("4")).toBe(true);
+    expect(esGrupal(null)).toBe(false);
+    expect(esAnulada(undefined)).toBe(false);
+  });
+});

--- a/src/modulos/Activities/QrTab/invitationEnums.ts
+++ b/src/modulos/Activities/QrTab/invitationEnums.ts
@@ -58,3 +58,28 @@ export const esTipo = (valor: unknown, tipo: number): boolean =>
 
 export const esEstado = (valor: unknown, estado: number): boolean =>
   valor !== null && valor !== undefined && Number(valor) === estado;
+
+/**
+ * 🔴 Los predicados con nombre existen para que el enum se nombre UNA vez.
+ *
+ * `esTipo` y `esEstado` reciben un `number` pelado, así que acá ni siquiera hay
+ * la media red que dan los enums de TypeScript en las apps de React Native:
+ * `esEstado(x, InvitationType.GROUP)` compila perfecto y compara el estado
+ * contra un tipo. Y equivocarse de case dentro del mismo enum compila en
+ * cualquier caso.
+ *
+ * Medido el 2026-08-15 sobre la rama de la migración: cambiar el case en
+ * `RenderView.tsx` no ponía **nada** en rojo, porque este archivo no tenía un
+ * solo test. Ahora `__tests__/invitationEnums.test.ts` lo fija.
+ */
+export const esGrupal = (tipo: unknown): boolean =>
+  esTipo(tipo, InvitationType.GROUP);
+
+export const esIndividual = (tipo: unknown): boolean =>
+  esTipo(tipo, InvitationType.INDIVIDUAL);
+
+export const esFrecuente = (tipo: unknown): boolean =>
+  esTipo(tipo, InvitationType.FREQUENT);
+
+export const esAnulada = (estado: unknown): boolean =>
+  esEstado(estado, InvitationStatus.CANCELLED);

--- a/src/modulos/Activities/QrTab/invitationEnums.ts
+++ b/src/modulos/Activities/QrTab/invitationEnums.ts
@@ -1,0 +1,60 @@
+/**
+ * Los enums de invitaciones, espejo de los del API.
+ *
+ * 🔴 **Eran chars y ahora son números.** `invitations.status` y
+ * `invitations.type` se migraron a enum numérico desde 1 el 2026-08-15, con su
+ * migración de datos sobre 10.682 filas. Este archivo existe para que la
+ * comparación esté escrita UNA vez: antes había `=== "G"` suelto en dos
+ * componentes y una tabla de etiquetas por char en un tercero.
+ *
+ * ⚠️ Los valores tienen que coincidir exactamente con
+ * `app/Modules/Invitation/Enums/InvitationStatus.php` y `InvitationType.php`.
+ * No hay nada que verifique eso automáticamente: el payload llega por HTTP y
+ * entra al front como `any`.
+ *
+ * ## Por qué desde 1 y no desde 0
+ *
+ * `0 == ""` es `true` en JavaScript, y el `Select` compartido del admin
+ * auto-elige la opción con id 0 como si el usuario la hubiera tocado. Ya mordió
+ * una vez (CDT-30) y sobrevivió a `tsc`, a eslint y a cinco checks: lo encontró
+ * abrir la pantalla.
+ */
+
+export const InvitationStatus = {
+  ACTIVE: 1,
+  INACTIVE: 2,
+  USED: 3,
+  CANCELLED: 4,
+} as const;
+
+export const InvitationType = {
+  INDIVIDUAL: 1,
+  GROUP: 2,
+  FREQUENT: 3,
+} as const;
+
+/**
+ * ⚠️ Las mismas palabras que imprime `InvitacionesExportConfig` en el back: la
+ * lista y el reporte tienen que decir lo mismo.
+ */
+export const INVITATION_TYPE_LABELS: Record<number, string> = {
+  [InvitationType.INDIVIDUAL]: "Individual",
+  [InvitationType.GROUP]: "Grupal",
+  [InvitationType.FREQUENT]: "Frecuente",
+};
+
+/**
+ * 🔴 Compara contra el número **sin importar si llegó como número o como
+ * string**.
+ *
+ * El payload entra al front sin tipo —`useAxios` devuelve `data: any`— y el
+ * mismo campo aparece como `2` o como `"2"` según por dónde pasó: un JSON del
+ * listado lo trae numérico, pero un valor que viajó por la URL de un filtro
+ * vuelve como texto. Un `===` pelado contra el número falla en el segundo caso
+ * **sin ningún error**: simplemente ninguna fila es grupal.
+ */
+export const esTipo = (valor: unknown, tipo: number): boolean =>
+  valor !== null && valor !== undefined && Number(valor) === tipo;
+
+export const esEstado = (valor: unknown, estado: number): boolean =>
+  valor !== null && valor !== undefined && Number(valor) === estado;

--- a/src/types/__tests__/enums/enumsSsotSync.test.ts
+++ b/src/types/__tests__/enums/enumsSsotSync.test.ts
@@ -40,11 +40,21 @@ import {
   AccessTaxiMark,
 } from '@/modulos/Activities/AccessTab/shared/accessEnums';
 
+// Invitaciones: migradas a enum numérico desde 1 el 2026-08-15. El admin sólo
+// consume dos de los cuatro — no muestra la configuración horaria ni la lista
+// de invitados de una grupal, que son de rnOwner y rnGuard.
+import {
+  InvitationStatus,
+  InvitationType,
+} from '@/modulos/Activities/QrTab/invitationEnums';
+
 const LOCAL_ENUMS: Record<string, Record<string, number | string>> = {
   AccessType,
   AccessStoredStatus,
   AccessConfirmation,
   AccessTaxiMark,
+  InvitationStatus,
+  InvitationType,
   ReservationStatus,
   PaymentStatus,
   PaymentMethod,

--- a/src/types/__tests__/enums/enumsSsotSync.test.ts
+++ b/src/types/__tests__/enums/enumsSsotSync.test.ts
@@ -67,6 +67,27 @@ const LOCAL_ENUMS: Record<string, Record<string, number | string>> = {
   SurveyStatus,
 };
 
+const APP = 'admin';
+
+/**
+ * 🔴 Desde la versión 1.2.0 el nombre canónico de un case es el que usa el
+ * **API**, y cada front declara el suyo en `aliasesByApp`.
+ *
+ * Antes era al revés: el canónico era el nombre de los fronts y el API
+ * declaraba sus alias — o sea que el JSON decía que la fuente eran los fronts.
+ * Es la misma confusión que dejó al API un mes entero fuera del contrato,
+ * cuando el que manda es el PHP: es lo que está guardado en la base.
+ *
+ * Un alias significa que el **valor** coincide y el nombre del case no. Acá los
+ * cuatro enums de Access son el caso grande: el API los tiene en castellano
+ * (`SinQr`) y los tres fronts en inglés (`WITHOUT_QR`). Medido el 2026-08-15,
+ * unificarlos por rename toca **507 call sites** y ninguno de los dos nombres
+ * está mal, así que no hay corrección que ganar: se unifican cuando Access se
+ * migre a Mk2, que es cuando se tocan sus call sites igual.
+ */
+const nombreLocal = (enumSsot: any, ssotName: string): string =>
+  enumSsot.aliasesByApp?.[APP]?.[ssotName] ?? ssotName;
+
 describe('Enums SSoT sync (admin vs cross-app SSoT)', () => {
   it('JSON SSoT es válido y tiene la estructura esperada', () => {
     expect(ssot.version).toBeDefined();
@@ -79,7 +100,7 @@ describe('Enums SSoT sync (admin vs cross-app SSoT)', () => {
       it(`existe en admin y todos los valores matchean el SSoT`, () => {
         const localEnum = LOCAL_ENUMS[enumName];
         if (!localEnum) {
-          if (!enumSsot.apps.includes('admin')) {
+          if (!enumSsot.apps.includes(APP)) {
             return; // skip silencioso — admin no consume este enum
           }
           throw new Error(
@@ -88,19 +109,22 @@ describe('Enums SSoT sync (admin vs cross-app SSoT)', () => {
         }
 
         for (const ssotVal of enumSsot.values) {
-          const localVal = localEnum[ssotVal.name];
+          const local = nombreLocal(enumSsot, ssotVal.name);
+          const localVal = localEnum[local];
           expect(
             localVal,
-            `${enumName}.${ssotVal.name} debería ser ${JSON.stringify(ssotVal.value)} (SSoT), pero el enum local retorna ${JSON.stringify(localVal)}`
+            `${enumName}.${local} debería ser ${JSON.stringify(ssotVal.value)} (SSoT lo llama ${ssotVal.name}), pero el enum local retorna ${JSON.stringify(localVal)}`
           ).toBe(ssotVal.value);
         }
       });
 
       it(`admin no tiene valores extra que no estén en el SSoT`, () => {
         const localEnum = LOCAL_ENUMS[enumName];
-        if (!localEnum || !enumSsot.apps.includes('admin')) return;
+        if (!localEnum || !enumSsot.apps.includes(APP)) return;
 
-        const ssotNames = new Set(enumSsot.values.map((v) => v.name));
+        const ssotNames = new Set(
+          enumSsot.values.map((v) => nombreLocal(enumSsot, v.name))
+        );
         for (const localKey of Object.keys(localEnum)) {
           // Filter TypeScript reverse-mappings en enums numéricos:
           // Para `enum X { A = 1 }`, el runtime también tiene `X[1] = "A"`.

--- a/tests/__fixtures__/enums-ssot.json
+++ b/tests/__fixtures__/enums-ssot.json
@@ -1,12 +1,12 @@
 {
   "$schema": "./enums-ssot.schema.json",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lastUpdated": "2026-08-15",
   "maintainer": "Condaty cross-app team",
-  "source": "SSoT canónico de los enums compartidos entre condaty-api, admin, rnGuard y rnOwner. Cada repo mantiene su enum local sincronizado con un test de reflection contra esta fuente. NO es runtime: se usa sólo en CI/tests para detectar drift.\n\nDesde 1.1.0 el API entra al contrato con la app `api`, y ésa es la diferencia que importa: hasta 1.0.0 esto pineaba que los tres fronts coincidieran ENTRE ELLOS, no que coincidieran con las columnas. Tres fronts de acuerdo y los tres equivocados contra el API era exactamente el caso que no se podía detectar. El PHP es la fuente real: es lo que está guardado en la base.",
+  "source": "SSoT canónico de los enums compartidos entre condaty-api, admin, rnGuard y rnOwner. Cada repo mantiene su enum local sincronizado con un test de reflection contra esta fuente. NO es runtime: se usa sólo en CI/tests para detectar drift.\n\n🔴 Desde 1.2.0 los nombres canónicos de los cases son los del API, y cada front declara sus alias en `aliasesByApp`. Antes era al revés —el canónico era el nombre de los fronts— y eso decía justo al contrario de dónde está la verdad: el PHP es lo que está guardado en la base. Esa inversión no es cosmética: mientras el SSoT trató a los fronts como fuente, el API estuvo un mes entero FUERA del contrato sin que se notara.\n\nLa CLAVE de cada enum sigue siendo el nombre con el que lo llaman los fronts (`AccessType`), porque es la clave del `LOCAL_ENUMS` de cada uno. El nombre de la clase en PHP va en `apiClass`.",
   "sync": {
     "strategy": "manual-copy",
-    "rationale": "Repos privados, sin registry npm compartido. El SSoT se versiona en humandistor (Makromania) y se copia a cada repo cuando cambia. El test de reflection detecta drift si alguien modifica el enum local sin actualizar el SSoT.\n\n⚠️ La copia manual es el eslabón débil y no hay nada que la fuerce: si actualizás este archivo y no lo copiás, los repos siguen midiendo contra la versión vieja y NO se ponen rojos. Por eso `version` se sube en el mismo commit y cada test la afirma: una copia vieja tiene otra `version` y se nota.",
+    "rationale": "Repos privados, sin registry npm compartido. El SSoT se versiona en humandirector (Makromania) y se copia a cada repo cuando cambia. El test de reflection detecta drift si alguien modifica el enum local sin actualizar el SSoT.\n\n⚠️ La copia manual es el eslabón débil y no hay nada que la fuerce: si actualizás este archivo y no lo copiás, los repos siguen midiendo contra la versión vieja y NO se ponen rojos. Por eso `version` se sube en el mismo commit y cada test la afirma: una copia vieja tiene otra `version` y se nota.",
     "copyCommand": "cp ~/Desktop/Makromania/.makromania/projects/condaty/sprints/enums-ssot.json <repo>/tests/__fixtures__/enums-ssot.json   # en condaty-api el destino es tests/Fixtures/enums-ssot.json",
     "apps": [
       "condaty-api",
@@ -19,256 +19,735 @@
     "AccessType": {
       "type": "int",
       "comment": "Cómo entró un visitante — `accesses.type`. En el API se llama `TipoDeAcceso` y sus cases están en castellano: ver `aliasesByApp`.\n\n🔴 Estos cuatro enums de Access estaban importados en el `LOCAL_ENUMS` de los tres fronts desde el 2026-07-15 y el SSoT NUNCA los declaró, así que el test los saltaba en silencio: eran cuatro enums que nadie comparaba, en el módulo cuyo flip de chars ya mordió tres veces. Entran al contrato el 2026-08-15.",
-      "apps": ["api", "admin", "rnGuard", "rnOwner"],
-      "aliasesByApp": {
-        "api": {
-          "WITHOUT_QR": "SinQr",
-          "QR_INDIVIDUAL": "QrIndividual",
-          "QR_GROUP": "QrGrupal",
-          "QR_FREQUENT": "QrFrecuente",
-          "ORDER": "Pedido",
-          "QR_KEY": "LlaveQr"
-        }
-      },
-      "aliasesComment": "Los VALORES coinciden en los cuatro repos; los nombres de los cases no. El API los tiene en castellano porque el módulo Access se escribió así, y los fronts en inglés. Se declara el alias en vez de renombrar: el rename toca los call sites de Access, que todavía no se migró a Mk2.",
+      "apps": [
+        "api",
+        "admin",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "WITHOUT_QR", "value": 1, "comment": "SinQr" },
-        { "name": "QR_INDIVIDUAL", "value": 2, "comment": "QrIndividual" },
-        { "name": "QR_GROUP", "value": 3, "comment": "QrGrupal" },
-        { "name": "QR_FREQUENT", "value": 4, "comment": "QrFrecuente" },
-        { "name": "ORDER", "value": 5, "comment": "Pedido" },
-        { "name": "QR_KEY", "value": 6, "comment": "LlaveQr — la llave del residente, que no es una invitación" }
-      ]
+        {
+          "name": "SinQr",
+          "value": 1,
+          "comment": "SinQr"
+        },
+        {
+          "name": "QrIndividual",
+          "value": 2,
+          "comment": "QrIndividual"
+        },
+        {
+          "name": "QrGrupal",
+          "value": 3,
+          "comment": "QrGrupal"
+        },
+        {
+          "name": "QrFrecuente",
+          "value": 4,
+          "comment": "QrFrecuente"
+        },
+        {
+          "name": "Pedido",
+          "value": 5,
+          "comment": "Pedido"
+        },
+        {
+          "name": "LlaveQr",
+          "value": 6,
+          "comment": "LlaveQr — la llave del residente, que no es una invitación"
+        }
+      ],
+      "apiClass": "TipoDeAcceso",
+      "aliasesComment": "Los VALORES coinciden en los cuatro repos; los nombres de los cases no. El canónico es el del API y cada front declara el suyo. Medido el 2026-08-15: unificarlos por rename toca **507 call sites** (221 en el API, 286 en los tres fronts), y ninguno de los dos nombres está mal —sólo están en idiomas distintos—, así que no hay ninguna corrección que ganar. Se unifican cuando el módulo se migre a Mk2, que es cuando se tocan sus call sites igual.",
+      "aliasesByApp": {
+        "admin": {
+          "SinQr": "WITHOUT_QR",
+          "QrIndividual": "QR_INDIVIDUAL",
+          "QrGrupal": "QR_GROUP",
+          "QrFrecuente": "QR_FREQUENT",
+          "Pedido": "ORDER",
+          "LlaveQr": "QR_KEY"
+        },
+        "rnGuard": {
+          "SinQr": "WITHOUT_QR",
+          "QrIndividual": "QR_INDIVIDUAL",
+          "QrGrupal": "QR_GROUP",
+          "QrFrecuente": "QR_FREQUENT",
+          "Pedido": "ORDER",
+          "LlaveQr": "QR_KEY"
+        },
+        "rnOwner": {
+          "SinQr": "WITHOUT_QR",
+          "QrIndividual": "QR_INDIVIDUAL",
+          "QrGrupal": "QR_GROUP",
+          "QrFrecuente": "QR_FREQUENT",
+          "Pedido": "ORDER",
+          "LlaveQr": "QR_KEY"
+        }
+      }
     },
     "AccessStoredStatus": {
       "type": "int",
       "comment": "El estado GUARDADO de un acceso — `accesses.status`. En el API es `EstadoGuardado`.\n\n⚠️ No confundir con `EstadoDelAcceso` del API, que es el estado DERIVADO que ve el usuario (sin salida, completado, por salir…) y no es una columna: se calcula. Por eso no está en este SSoT.",
-      "apps": ["api", "admin", "rnGuard", "rnOwner"],
-      "aliasesByApp": {
-        "api": {
-          "WAITING": "Esperando",
-          "INSIDE": "Adentro",
-          "OUTSIDE": "Afuera",
-          "REJECTED": "Rechazado"
-        }
-      },
+      "apps": [
+        "api",
+        "admin",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "WAITING", "value": 1, "comment": "Esperando" },
-        { "name": "INSIDE", "value": 2, "comment": "Adentro" },
-        { "name": "OUTSIDE", "value": 3, "comment": "Afuera" },
-        { "name": "REJECTED", "value": 4, "comment": "Rechazado" }
-      ]
+        {
+          "name": "Esperando",
+          "value": 1,
+          "comment": "Esperando"
+        },
+        {
+          "name": "Adentro",
+          "value": 2,
+          "comment": "Adentro"
+        },
+        {
+          "name": "Afuera",
+          "value": 3,
+          "comment": "Afuera"
+        },
+        {
+          "name": "Rechazado",
+          "value": 4,
+          "comment": "Rechazado"
+        }
+      ],
+      "apiClass": "EstadoGuardado",
+      "aliasesComment": "Los VALORES coinciden en los cuatro repos; los nombres de los cases no. El canónico es el del API y cada front declara el suyo. Medido el 2026-08-15: unificarlos por rename toca **507 call sites** (221 en el API, 286 en los tres fronts), y ninguno de los dos nombres está mal —sólo están en idiomas distintos—, así que no hay ninguna corrección que ganar. Se unifican cuando el módulo se migre a Mk2, que es cuando se tocan sus call sites igual.",
+      "aliasesByApp": {
+        "admin": {
+          "Esperando": "WAITING",
+          "Adentro": "INSIDE",
+          "Afuera": "OUTSIDE",
+          "Rechazado": "REJECTED"
+        },
+        "rnGuard": {
+          "Esperando": "WAITING",
+          "Adentro": "INSIDE",
+          "Afuera": "OUTSIDE",
+          "Rechazado": "REJECTED"
+        },
+        "rnOwner": {
+          "Esperando": "WAITING",
+          "Adentro": "INSIDE",
+          "Afuera": "OUTSIDE",
+          "Rechazado": "REJECTED"
+        }
+      }
     },
     "AccessConfirmation": {
       "type": "int",
       "comment": "Si el residente confirmó el ingreso — `accesses.confirm`. En el API es `Confirmacion`. Era un char Y/N: un booleano disfrazado, de la misma familia que `invitations.is_advanced`.\n\n🔴 El flip de esta columna se corrió creyendo que afectaba 0 filas —la consulta preguntaba `where('confirm', 1)` contra una columna que todavía guardaba 'Y'— y en realidad eran 77.",
-      "apps": ["api", "admin", "rnGuard", "rnOwner"],
-      "aliasesByApp": {
-        "api": { "YES": "Si", "NO": "No" }
-      },
+      "apps": [
+        "api",
+        "admin",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "YES", "value": 1, "comment": "Si — era 'Y'" },
-        { "name": "NO", "value": 2, "comment": "No — era 'N'" }
-      ]
+        {
+          "name": "Si",
+          "value": 1,
+          "comment": "Si — era 'Y'"
+        },
+        {
+          "name": "No",
+          "value": 2,
+          "comment": "No — era 'N'"
+        }
+      ],
+      "apiClass": "Confirmacion",
+      "aliasesComment": "Los VALORES coinciden en los cuatro repos; los nombres de los cases no. El canónico es el del API y cada front declara el suyo. Medido el 2026-08-15: unificarlos por rename toca **507 call sites** (221 en el API, 286 en los tres fronts), y ninguno de los dos nombres está mal —sólo están en idiomas distintos—, así que no hay ninguna corrección que ganar. Se unifican cuando el módulo se migre a Mk2, que es cuando se tocan sus call sites igual.",
+      "aliasesByApp": {
+        "admin": {
+          "Si": "YES",
+          "No": "NO"
+        },
+        "rnGuard": {
+          "Si": "YES",
+          "No": "NO"
+        },
+        "rnOwner": {
+          "Si": "YES",
+          "No": "NO"
+        }
+      }
     },
     "AccessTaxiMark": {
       "type": "int",
       "comment": "Si el visitante llegó en taxi, y en qué rol — `accesses.taxi`. En el API es `MarcaDeTaxi`. Distingue al acompañante del taxista, que es lo que decide si se le registra la placa.",
-      "apps": ["api", "admin", "rnGuard", "rnOwner"],
-      "aliasesByApp": {
-        "api": {
-          "NO_TAXI": "SinTaxi",
-          "CAME_BY_TAXI": "LlegoEnTaxi",
-          "IS_THE_DRIVER": "EsElTaxista"
-        }
-      },
+      "apps": [
+        "api",
+        "admin",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "NO_TAXI", "value": 1, "comment": "SinTaxi" },
-        { "name": "CAME_BY_TAXI", "value": 2, "comment": "LlegoEnTaxi" },
-        { "name": "IS_THE_DRIVER", "value": 3, "comment": "EsElTaxista" }
-      ]
+        {
+          "name": "SinTaxi",
+          "value": 1,
+          "comment": "SinTaxi"
+        },
+        {
+          "name": "LlegoEnTaxi",
+          "value": 2,
+          "comment": "LlegoEnTaxi"
+        },
+        {
+          "name": "EsElTaxista",
+          "value": 3,
+          "comment": "EsElTaxista"
+        }
+      ],
+      "apiClass": "MarcaDeTaxi",
+      "aliasesComment": "Los VALORES coinciden en los cuatro repos; los nombres de los cases no. El canónico es el del API y cada front declara el suyo. Medido el 2026-08-15: unificarlos por rename toca **507 call sites** (221 en el API, 286 en los tres fronts), y ninguno de los dos nombres está mal —sólo están en idiomas distintos—, así que no hay ninguna corrección que ganar. Se unifican cuando el módulo se migre a Mk2, que es cuando se tocan sus call sites igual.",
+      "aliasesByApp": {
+        "admin": {
+          "SinTaxi": "NO_TAXI",
+          "LlegoEnTaxi": "CAME_BY_TAXI",
+          "EsElTaxista": "IS_THE_DRIVER"
+        },
+        "rnGuard": {
+          "SinTaxi": "NO_TAXI",
+          "LlegoEnTaxi": "CAME_BY_TAXI",
+          "EsElTaxista": "IS_THE_DRIVER"
+        },
+        "rnOwner": {
+          "SinTaxi": "NO_TAXI",
+          "LlegoEnTaxi": "CAME_BY_TAXI",
+          "EsElTaxista": "IS_THE_DRIVER"
+        }
+      }
     },
     "ReservationStatus": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Reservations\\Enums\\ReservationStatus (PHP). Char legacy mapeado en comments.",
-      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "AWAITING_APPROVAL", "value": 1, "comment": "W: Esperando confirmación" },
-        { "name": "PENDING_PAYMENT", "value": 2, "comment": "A: Pago pendiente" },
-        { "name": "PAYMENT_SUBMITTED", "value": 3, "comment": "Q: Por confirmar pago" },
-        { "name": "RESERVED_UNPAID", "value": 4, "comment": "N: Reservado (sin pago)" },
-        { "name": "RESERVED_PAID", "value": 5, "comment": "L: Reservado (pagado)" },
-        { "name": "REJECTED", "value": 6, "comment": "R: Reserva rechazada" },
-        { "name": "CANCELLED_MANUAL", "value": 7, "comment": "C: Cancelada manualmente" },
-        { "name": "CANCELLED_AUTO", "value": 8, "comment": "T: Cancelada automática" },
-        { "name": "COMPLETED", "value": 9, "comment": "F: Finalizada" },
-        { "name": "MAINTENANCE", "value": 10, "comment": "M: Mantenimiento" },
-        { "name": "LEGACY_REJECTED", "value": 11, "comment": "X: Rechazada (legacy)" }
-      ]
+        {
+          "name": "AWAITING_APPROVAL",
+          "value": 1,
+          "comment": "W: Esperando confirmación"
+        },
+        {
+          "name": "PENDING_PAYMENT",
+          "value": 2,
+          "comment": "A: Pago pendiente"
+        },
+        {
+          "name": "PAYMENT_SUBMITTED",
+          "value": 3,
+          "comment": "Q: Por confirmar pago"
+        },
+        {
+          "name": "RESERVED_UNPAID",
+          "value": 4,
+          "comment": "N: Reservado (sin pago)"
+        },
+        {
+          "name": "RESERVED_PAID",
+          "value": 5,
+          "comment": "L: Reservado (pagado)"
+        },
+        {
+          "name": "REJECTED",
+          "value": 6,
+          "comment": "R: Reserva rechazada"
+        },
+        {
+          "name": "CANCELLED_MANUAL",
+          "value": 7,
+          "comment": "C: Cancelada manualmente"
+        },
+        {
+          "name": "CANCELLED_AUTO",
+          "value": 8,
+          "comment": "T: Cancelada automática"
+        },
+        {
+          "name": "COMPLETED",
+          "value": 9,
+          "comment": "F: Finalizada"
+        },
+        {
+          "name": "MAINTENANCE",
+          "value": 10,
+          "comment": "M: Mantenimiento"
+        },
+        {
+          "name": "LEGACY_REJECTED",
+          "value": 11,
+          "comment": "X: Rechazada (legacy)"
+        }
+      ],
+      "apiClass": "ReservationStatus"
     },
     "PaymentStatus": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentStatus (PHP).",
-      "apps": ["api", "admin", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "SUBMITTED", "value": 1, "comment": "Por confirmar", "rnOwnerAlias": "PENDING" },
-        { "name": "PAID", "value": 2, "comment": "Confirmado/Pagado" },
-        { "name": "REJECTED", "value": 3, "comment": "Rechazado" },
-        { "name": "CANCELLED", "value": 4, "comment": "Anulado" }
-      ]
+        {
+          "name": "SUBMITTED",
+          "value": 1,
+          "comment": "Por confirmar",
+          "rnOwnerAlias": "PENDING"
+        },
+        {
+          "name": "PAID",
+          "value": 2,
+          "comment": "Confirmado/Pagado"
+        },
+        {
+          "name": "REJECTED",
+          "value": 3,
+          "comment": "Rechazado"
+        },
+        {
+          "name": "CANCELLED",
+          "value": 4,
+          "comment": "Anulado"
+        }
+      ],
+      "apiClass": "PaymentStatus",
+      "aliasesByApp": {
+        "rnOwner": {
+          "SUBMITTED": "PENDING"
+        }
+      },
+      "aliasesComment": "rnOwner llama `PENDING` a `SUBMITTED`. Estaba escrito a mano en dos lugares de su test de sincronía —un `if` con el nombre del enum adentro— y pasa acá para que sea dato y no código: un caso especial en el test se olvida cuando aparece el segundo."
     },
     "PaymentMethod": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentMethod (PHP).",
-      "apps": ["api", "admin", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "TRANSFER", "value": 1 },
-        { "name": "OFFICE", "value": 2 },
-        { "name": "QR", "value": 3 },
-        { "name": "CASH", "value": 4 },
-        { "name": "CHEQUE", "value": 5 }
-      ]
+        {
+          "name": "TRANSFER",
+          "value": 1
+        },
+        {
+          "name": "OFFICE",
+          "value": 2
+        },
+        {
+          "name": "QR",
+          "value": 3
+        },
+        {
+          "name": "CASH",
+          "value": 4
+        },
+        {
+          "name": "CHEQUE",
+          "value": 5
+        }
+      ],
+      "apiClass": "PaymentMethod"
     },
     "PaymentType": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentType (PHP). NO confundir con QrDinamico/types.ts PaymentType (string char, semántica distinta — son enums DIFERENTES, no se pueden unificar). SOLO consumido por admin — rnOwner usa `DebtType` (semántica diferente, no equivalente).",
-      "apps": ["api", "admin"],
+      "apps": [
+        "api",
+        "admin"
+      ],
       "values": [
-        { "name": "ALL_DEBTS", "value": 1 },
-        { "name": "EXPENSES", "value": 2 },
-        { "name": "RESERVATIONS", "value": 3 },
-        { "name": "CONDONATION", "value": 4 },
-        { "name": "PAYMENT_PLAN", "value": 5 },
-        { "name": "OTHER_DEBTS", "value": 6 },
-        { "name": "DIRECT_INCOME", "value": 7 }
-      ]
+        {
+          "name": "ALL_DEBTS",
+          "value": 1
+        },
+        {
+          "name": "EXPENSES",
+          "value": 2
+        },
+        {
+          "name": "RESERVATIONS",
+          "value": 3
+        },
+        {
+          "name": "CONDONATION",
+          "value": 4
+        },
+        {
+          "name": "PAYMENT_PLAN",
+          "value": 5
+        },
+        {
+          "name": "OTHER_DEBTS",
+          "value": 6
+        },
+        {
+          "name": "DIRECT_INCOME",
+          "value": 7
+        }
+      ],
+      "apiClass": "PaymentType"
     },
     "DebtStatus": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\DebtStatus (PHP).",
-      "apps": ["api", "admin", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "PENDING", "value": 1, "comment": "Por cobrar" },
-        { "name": "OVERDUE", "value": 2, "comment": "En mora" },
-        { "name": "PARTIAL", "value": 3, "comment": "En proceso parcial" },
-        { "name": "SUBMITTED", "value": 4, "comment": "Pago por confirmar" },
-        { "name": "PAID", "value": 5, "comment": "Saldada" },
-        { "name": "FORGIVEN", "value": 6, "comment": "Condonada" },
-        { "name": "WORKFLOW_PENDING", "value": 7, "comment": "Flujo externo pendiente" },
-        { "name": "CANCELLED", "value": 8, "comment": "Anulada" },
-        { "name": "AWAITING_VOUCHER", "value": 9, "comment": "Por subir comprobante" },
-        { "name": "REJECTED", "value": 10, "comment": "Rechazado" }
-      ]
+        {
+          "name": "PENDING",
+          "value": 1,
+          "comment": "Por cobrar"
+        },
+        {
+          "name": "OVERDUE",
+          "value": 2,
+          "comment": "En mora"
+        },
+        {
+          "name": "PARTIAL",
+          "value": 3,
+          "comment": "En proceso parcial"
+        },
+        {
+          "name": "SUBMITTED",
+          "value": 4,
+          "comment": "Pago por confirmar"
+        },
+        {
+          "name": "PAID",
+          "value": 5,
+          "comment": "Saldada"
+        },
+        {
+          "name": "FORGIVEN",
+          "value": 6,
+          "comment": "Condonada"
+        },
+        {
+          "name": "WORKFLOW_PENDING",
+          "value": 7,
+          "comment": "Flujo externo pendiente"
+        },
+        {
+          "name": "CANCELLED",
+          "value": 8,
+          "comment": "Anulada"
+        },
+        {
+          "name": "AWAITING_VOUCHER",
+          "value": 9,
+          "comment": "Por subir comprobante"
+        },
+        {
+          "name": "REJECTED",
+          "value": 10,
+          "comment": "Rechazado"
+        }
+      ],
+      "apiClass": "DebtStatus"
     },
     "DebtType": {
       "type": "int",
       "comment": "Solo rnOwner lo define. admin no tiene equivalente directo (mapea a PaymentType en su lugar). NO es el mismo enum que PaymentType — semántica y valores distintos.",
-      "apps": ["rnOwner"],
+      "apps": [
+        "rnOwner"
+      ],
       "values": [
-        { "name": "EXPENSE", "value": 1 },
-        { "name": "RESERVATION", "value": 2 },
-        { "name": "FINE", "value": 3 },
-        { "name": "FORGIVEN", "value": 5, "comment": "Salto 4 reservado (gap histórico del backend)" }
+        {
+          "name": "EXPENSE",
+          "value": 1
+        },
+        {
+          "name": "RESERVATION",
+          "value": 2
+        },
+        {
+          "name": "FINE",
+          "value": 3
+        },
+        {
+          "name": "FORGIVEN",
+          "value": 5,
+          "comment": "Salto 4 reservado (gap histórico del backend)"
+        }
       ]
     },
     "AssemblyStatus": {
       "type": "string",
       "comment": "Char-backed (string). Sincronizado con backend App\\Modules\\Assemblies\\Enums\\AssemblyStatus (PHP enum: string).",
-      "apps": ["api", "admin", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "Scheduled", "value": "S" },
-        { "name": "InProgress", "value": "P" },
-        { "name": "Completed", "value": "C" },
-        { "name": "Cancelled", "value": "X" }
-      ]
+        {
+          "name": "Scheduled",
+          "value": "S"
+        },
+        {
+          "name": "InProgress",
+          "value": "P"
+        },
+        {
+          "name": "Completed",
+          "value": "C"
+        },
+        {
+          "name": "Cancelled",
+          "value": "X"
+        }
+      ],
+      "apiClass": "AssemblyStatus"
     },
     "AssemblyType": {
       "type": "string",
       "comment": "Char-backed. Backend enums Assemblies son string, no int.",
-      "apps": ["api", "admin", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "Ordinary", "value": "O" },
-        { "name": "Extraordinary", "value": "E" },
-        { "name": "Informative", "value": "I" }
-      ]
+        {
+          "name": "Ordinary",
+          "value": "O"
+        },
+        {
+          "name": "Extraordinary",
+          "value": "E"
+        },
+        {
+          "name": "Informative",
+          "value": "I"
+        }
+      ],
+      "apiClass": "AssemblyType"
     },
     "AssemblyModality": {
       "type": "string",
       "comment": "Char-backed.",
-      "apps": ["api", "admin", "rnOwner"],
-      "aliasesByApp": {
-        "api": { "Presencial": "InPerson", "Hibrid": "Hybrid" }
-      },
-      "aliasesComment": "Los VALORES coinciden; los nombres de los cases no. El API dice `InPerson` y `Hybrid` donde los fronts dicen `Presencial` e `Hibrid`. Se declara el alias en vez de renombrar porque Assemblies todavía no se migró y el rename toca sus call sites. Nadie lo había visto porque hasta 1.1.0 el API no entraba a este contrato.",
+      "apps": [
+        "api",
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "Virtual", "value": "V" },
-        { "name": "Presencial", "value": "P" },
-        { "name": "Hibrid", "value": "H" }
-      ]
+        {
+          "name": "Virtual",
+          "value": "V"
+        },
+        {
+          "name": "InPerson",
+          "value": "P"
+        },
+        {
+          "name": "Hybrid",
+          "value": "H"
+        }
+      ],
+      "apiClass": "AssemblyModality",
+      "aliasesComment": "Los VALORES coinciden en los cuatro repos; los nombres de los cases no. El canónico es el del API y cada front declara el suyo. Medido el 2026-08-15: unificarlos por rename toca **507 call sites** (221 en el API, 286 en los tres fronts), y ninguno de los dos nombres está mal —sólo están en idiomas distintos—, así que no hay ninguna corrección que ganar. Se unifican cuando el módulo se migre a Mk2, que es cuando se tocan sus call sites igual.",
+      "aliasesByApp": {
+        "admin": {
+          "InPerson": "Presencial",
+          "Hybrid": "Hibrid"
+        },
+        "rnOwner": {
+          "InPerson": "Presencial",
+          "Hybrid": "Hibrid"
+        }
+      }
     },
     "TargetAudience": {
       "type": "string",
       "comment": "String-backed (no char).",
-      "apps": ["admin", "rnOwner"],
+      "apps": [
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "AllOwners", "value": "all_owners" },
-        { "name": "Residents", "value": "residents" },
-        { "name": "Dependents", "value": "dependents" }
+        {
+          "name": "AllOwners",
+          "value": "all_owners"
+        },
+        {
+          "name": "Residents",
+          "value": "residents"
+        },
+        {
+          "name": "Dependents",
+          "value": "dependents"
+        }
       ]
     },
     "InvitationStatus": {
       "type": "int",
       "comment": "En qué situación está una invitación — `invitations.status`. Era char(1) A/I/O/X hasta el 2026-08-15; migrado a enum numérico desde 1 sobre 5.420 filas. Lo escriben CINCO módulos del API (Invitation, Access, Visits, HomeOwner), y por eso el contrato importa más que de costumbre.\n\n⚠️ NO es el estado que ve el usuario en el listado del admin: ése es derivado (Anulada/Expirada/Activa) y se calcula cruzando esta columna con los accesos registrados.",
-      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "ACTIVE", "value": 1, "comment": "A — 2.090 filas al migrar" },
-        { "name": "INACTIVE", "value": 2, "comment": "I — 788" },
-        { "name": "USED", "value": 3, "comment": "O — 2.264" },
-        { "name": "CANCELLED", "value": 4, "comment": "X — 278" }
-      ]
+        {
+          "name": "ACTIVE",
+          "value": 1,
+          "comment": "A — 2.090 filas al migrar"
+        },
+        {
+          "name": "INACTIVE",
+          "value": 2,
+          "comment": "I — 788"
+        },
+        {
+          "name": "USED",
+          "value": 3,
+          "comment": "O — 2.264"
+        },
+        {
+          "name": "CANCELLED",
+          "value": 4,
+          "comment": "X — 278"
+        }
+      ],
+      "apiClass": "InvitationStatus"
     },
     "InvitationType": {
       "type": "int",
       "comment": "Qué clase de invitación es — `invitations.type`. Era char(1) I/G/F.\n\n🔴 La letra del QR FÍSICO usa el mismo alfabeto y NO es esta columna: el texto impreso dice `condaty|qr|G|<uuid>` y el lector del guardia manda `?qr=G`. Está en 5.432 filas de `qrs` y en los QR compartidos por WhatsApp, así que no se migró. Y sólo existen I (4.777) y G (655): ninguna F, porque los frecuentes se emitieron con I.",
-      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "INDIVIDUAL", "value": 1, "comment": "I — 3.725 filas al migrar" },
-        { "name": "GROUP", "value": 2, "comment": "G — 652" },
-        { "name": "FREQUENT", "value": 3, "comment": "F — 1.043" }
-      ]
+        {
+          "name": "INDIVIDUAL",
+          "value": 1,
+          "comment": "I — 3.725 filas al migrar"
+        },
+        {
+          "name": "GROUP",
+          "value": 2,
+          "comment": "G — 652"
+        },
+        {
+          "name": "FREQUENT",
+          "value": 3,
+          "comment": "F — 1.043"
+        }
+      ],
+      "apiClass": "InvitationType"
     },
     "InvitationSchedule": {
       "type": "int",
       "comment": "Si la invitación lleva días y horario — `invitations.is_advanced`. Era un char(1) N/Y, o sea un booleano disfrazado: entra al enum por la regla del proyecto y porque los tres fronts lo comparaban contra 'Y' a mano, cada uno en su archivo.\n\nEl admin no lo consume: no muestra ni edita la configuración horaria.",
-      "apps": ["api", "rnGuard", "rnOwner"],
+      "apps": [
+        "api",
+        "rnGuard",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "SIMPLE", "value": 1, "comment": "N — 5.099 filas al migrar" },
-        { "name": "ADVANCED", "value": 2, "comment": "Y — 321" }
-      ]
+        {
+          "name": "SIMPLE",
+          "value": 1,
+          "comment": "N — 5.099 filas al migrar"
+        },
+        {
+          "name": "ADVANCED",
+          "value": 2,
+          "comment": "Y — 321"
+        }
+      ],
+      "apiClass": "InvitationSchedule"
     },
     "InvitationGuestStatus": {
       "type": "int",
       "comment": "🔴 El estado de UN invitado de una grupal — `invitation_visits.status`. NO es InvitationStatus.\n\nComparte los tres valores a propósito: la columna guardaba las mismas letras, y hacer que un 1 signifique cosas distintas según la tabla convertiría cualquier consulta de diagnóstico en una trampa. No tiene CANCELLED: anular es una operación sobre la invitación entera.\n\nSon enums SEPARADOS —no un alias— para que confundirlos sea un error de tipo. Sólo rnOwner lo consume: es la pantalla que lista los invitados de un QR grupal.",
-      "apps": ["api", "rnOwner"],
+      "apps": [
+        "api",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "ACTIVE", "value": 1, "comment": "A — 3.846 de 5.262 filas al migrar" },
-        { "name": "INACTIVE", "value": 2, "comment": "I — 190" },
-        { "name": "USED", "value": 3, "comment": "O — 1.226" }
-      ]
+        {
+          "name": "ACTIVE",
+          "value": 1,
+          "comment": "A — 3.846 de 5.262 filas al migrar"
+        },
+        {
+          "name": "INACTIVE",
+          "value": 2,
+          "comment": "I — 190"
+        },
+        {
+          "name": "USED",
+          "value": 3,
+          "comment": "O — 1.226"
+        }
+      ],
+      "apiClass": "InvitationGuestStatus"
     },
     "SurveyStatus": {
       "type": "string",
       "comment": "Char-backed. Sincronizado con backend App\\Modules\\Surveys\\Enums\\SurveyStatus (PHP).\n\nEl API llamaba `Voting` a este case y significaba lo CONTRARIO: es el estado donde los participantes ven la encuesta pero NO pueden votar. El propio enum se contradecía —el case decía Voting y su label() devolvía 'Visible'— y los tres fronts siempre dijeron `Visible`. Se renombró en el API el 2026-08-15 en vez de dejarlo como alias: no tenía un solo call site fuera de su propio archivo, así que el rename costó dos líneas.",
-      "apps": ["api", "admin", "rnOwner"],
+      "apps": [
+        "api",
+        "admin",
+        "rnOwner"
+      ],
       "values": [
-        { "name": "Draft", "value": "D" },
-        { "name": "Visible", "value": "V", "comment": "Visible, participants can see but NOT vote" },
-        { "name": "Scheduled", "value": "S" },
-        { "name": "Active", "value": "A" },
-        { "name": "Paused", "value": "P" },
-        { "name": "Closed", "value": "C" },
-        { "name": "Disabled", "value": "X" }
-      ]
+        {
+          "name": "Draft",
+          "value": "D"
+        },
+        {
+          "name": "Visible",
+          "value": "V",
+          "comment": "Visible, participants can see but NOT vote"
+        },
+        {
+          "name": "Scheduled",
+          "value": "S"
+        },
+        {
+          "name": "Active",
+          "value": "A"
+        },
+        {
+          "name": "Paused",
+          "value": "P"
+        },
+        {
+          "name": "Closed",
+          "value": "C"
+        },
+        {
+          "name": "Disabled",
+          "value": "X"
+        }
+      ],
+      "apiClass": "SurveyStatus"
     }
   },
   "excluded": {

--- a/tests/__fixtures__/enums-ssot.json
+++ b/tests/__fixtures__/enums-ssot.json
@@ -1,14 +1,15 @@
 {
   "$schema": "./enums-ssot.schema.json",
   "version": "1.1.0",
-  "lastUpdated": "2026-08-09",
+  "lastUpdated": "2026-08-15",
   "maintainer": "Condaty cross-app team",
-  "source": "SSoT canónico de enums compartidos entre admin/rnGuard/rnOwner. Cada app mantiene su enum local sincronizado vía test de reflection contra esta fuente. NO es runtime: se usa solo en CI/tests para detectar drift.",
+  "source": "SSoT canónico de los enums compartidos entre condaty-api, admin, rnGuard y rnOwner. Cada repo mantiene su enum local sincronizado con un test de reflection contra esta fuente. NO es runtime: se usa sólo en CI/tests para detectar drift.\n\nDesde 1.1.0 el API entra al contrato con la app `api`, y ésa es la diferencia que importa: hasta 1.0.0 esto pineaba que los tres fronts coincidieran ENTRE ELLOS, no que coincidieran con las columnas. Tres fronts de acuerdo y los tres equivocados contra el API era exactamente el caso que no se podía detectar. El PHP es la fuente real: es lo que está guardado en la base.",
   "sync": {
     "strategy": "manual-copy",
-    "rationale": "Repos privados, sin registry npm compartido. El SSoT se versiona en humandistor y se copia a tests/fixtures/ de cada app cuando cambia. El test de reflection detecta drift si alguien modifica el enum local sin actualizar el SSoT.",
-    "copyCommand": "cp /Users/marioguzman/.mavis/projects/condaty/sprints/enums-ssot.json <app>/tests/fixtures/enums-ssot.json",
+    "rationale": "Repos privados, sin registry npm compartido. El SSoT se versiona en humandistor (Makromania) y se copia a cada repo cuando cambia. El test de reflection detecta drift si alguien modifica el enum local sin actualizar el SSoT.\n\n⚠️ La copia manual es el eslabón débil y no hay nada que la fuerce: si actualizás este archivo y no lo copiás, los repos siguen midiendo contra la versión vieja y NO se ponen rojos. Por eso `version` se sube en el mismo commit y cada test la afirma: una copia vieja tiene otra `version` y se nota.",
+    "copyCommand": "cp ~/Desktop/Makromania/.makromania/projects/condaty/sprints/enums-ssot.json <repo>/tests/__fixtures__/enums-ssot.json   # en condaty-api el destino es tests/Fixtures/enums-ssot.json",
     "apps": [
+      "condaty-api",
       "condaty-admin",
       "rnGuard",
       "rnOwner"
@@ -17,51 +18,80 @@
   "enums": {
     "AccessType": {
       "type": "int",
-      "comment": "accesses.type. Sincronizado con backend App\\Modules\\Access\\Enums\\TipoDeAcceso (PHP). Char legacy (pre 2026-08-09) en cada comment.",
-      "apps": ["admin", "rnGuard", "rnOwner"],
+      "comment": "Cómo entró un visitante — `accesses.type`. En el API se llama `TipoDeAcceso` y sus cases están en castellano: ver `aliasesByApp`.\n\n🔴 Estos cuatro enums de Access estaban importados en el `LOCAL_ENUMS` de los tres fronts desde el 2026-07-15 y el SSoT NUNCA los declaró, así que el test los saltaba en silencio: eran cuatro enums que nadie comparaba, en el módulo cuyo flip de chars ya mordió tres veces. Entran al contrato el 2026-08-15.",
+      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "aliasesByApp": {
+        "api": {
+          "WITHOUT_QR": "SinQr",
+          "QR_INDIVIDUAL": "QrIndividual",
+          "QR_GROUP": "QrGrupal",
+          "QR_FREQUENT": "QrFrecuente",
+          "ORDER": "Pedido",
+          "QR_KEY": "LlaveQr"
+        }
+      },
+      "aliasesComment": "Los VALORES coinciden en los cuatro repos; los nombres de los cases no. El API los tiene en castellano porque el módulo Access se escribió así, y los fronts en inglés. Se declara el alias en vez de renombrar: el rename toca los call sites de Access, que todavía no se migró a Mk2.",
       "values": [
-        { "name": "WITHOUT_QR", "value": 1, "comment": "C: Sin QR — 359.634 filas" },
-        { "name": "QR_INDIVIDUAL", "value": 2, "comment": "I: QR Individual — 2.397" },
-        { "name": "QR_GROUP", "value": 3, "comment": "G: QR Grupal — 1.422" },
-        { "name": "QR_FREQUENT", "value": 4, "comment": "F: QR frecuente — 17.200" },
-        { "name": "ORDER", "value": 5, "comment": "P: Pedido — 97" },
-        { "name": "QR_KEY", "value": 6, "comment": "O: Llave QR — 1.269" }
+        { "name": "WITHOUT_QR", "value": 1, "comment": "SinQr" },
+        { "name": "QR_INDIVIDUAL", "value": 2, "comment": "QrIndividual" },
+        { "name": "QR_GROUP", "value": 3, "comment": "QrGrupal" },
+        { "name": "QR_FREQUENT", "value": 4, "comment": "QrFrecuente" },
+        { "name": "ORDER", "value": 5, "comment": "Pedido" },
+        { "name": "QR_KEY", "value": 6, "comment": "LlaveQr — la llave del residente, que no es una invitación" }
       ]
     },
     "AccessStoredStatus": {
       "type": "int",
-      "comment": "accesses.status. Backend App\\Modules\\Access\\Enums\\EstadoGuardado. 🔴 NO es el estado que muestra la pantalla: ese se DERIVA de in_at/out_at/confirm_at (getAccessStatusInfo).",
-      "apps": ["admin", "rnGuard", "rnOwner"],
+      "comment": "El estado GUARDADO de un acceso — `accesses.status`. En el API es `EstadoGuardado`.\n\n⚠️ No confundir con `EstadoDelAcceso` del API, que es el estado DERIVADO que ve el usuario (sin salida, completado, por salir…) y no es una columna: se calcula. Por eso no está en este SSoT.",
+      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "aliasesByApp": {
+        "api": {
+          "WAITING": "Esperando",
+          "INSIDE": "Adentro",
+          "OUTSIDE": "Afuera",
+          "REJECTED": "Rechazado"
+        }
+      },
       "values": [
-        { "name": "WAITING", "value": 1, "comment": "A: Aprobado, esperando entrar — 824" },
-        { "name": "INSIDE", "value": 2, "comment": "I: Adentro — 10.004" },
-        { "name": "OUTSIDE", "value": 3, "comment": "O: Afuera — 367.900" },
-        { "name": "REJECTED", "value": 4, "comment": "N: Rechazado — 3.291" }
+        { "name": "WAITING", "value": 1, "comment": "Esperando" },
+        { "name": "INSIDE", "value": 2, "comment": "Adentro" },
+        { "name": "OUTSIDE", "value": 3, "comment": "Afuera" },
+        { "name": "REJECTED", "value": 4, "comment": "Rechazado" }
       ]
     },
     "AccessConfirmation": {
       "type": "int",
-      "comment": "accesses.confirm. Backend App\\Modules\\Access\\Enums\\Confirmacion. Es la RESPUESTA (¿lo dejo pasar?), no un estado.",
-      "apps": ["admin", "rnGuard", "rnOwner"],
+      "comment": "Si el residente confirmó el ingreso — `accesses.confirm`. En el API es `Confirmacion`. Era un char Y/N: un booleano disfrazado, de la misma familia que `invitations.is_advanced`.\n\n🔴 El flip de esta columna se corrió creyendo que afectaba 0 filas —la consulta preguntaba `where('confirm', 1)` contra una columna que todavía guardaba 'Y'— y en realidad eran 77.",
+      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "aliasesByApp": {
+        "api": { "YES": "Si", "NO": "No" }
+      },
       "values": [
-        { "name": "YES", "value": 1, "comment": "Y: Autorizado — 354.623" },
-        { "name": "NO", "value": 2, "comment": "N: No autorizado — 27.396" }
+        { "name": "YES", "value": 1, "comment": "Si — era 'Y'" },
+        { "name": "NO", "value": 2, "comment": "No — era 'N'" }
       ]
     },
     "AccessTaxiMark": {
       "type": "int",
-      "comment": "accesses.taxi. Backend App\\Modules\\Access\\Enums\\MarcaDeTaxi. 🔴 No es un booleano: IS_THE_DRIVER es lo unico que distingue al taxista de un acompanante.",
-      "apps": ["admin", "rnGuard", "rnOwner"],
+      "comment": "Si el visitante llegó en taxi, y en qué rol — `accesses.taxi`. En el API es `MarcaDeTaxi`. Distingue al acompañante del taxista, que es lo que decide si se le registra la placa.",
+      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "aliasesByApp": {
+        "api": {
+          "NO_TAXI": "SinTaxi",
+          "CAME_BY_TAXI": "LlegoEnTaxi",
+          "IS_THE_DRIVER": "EsElTaxista"
+        }
+      },
       "values": [
-        { "name": "NO_TAXI", "value": 1, "comment": "N: Sin taxi — 269.751" },
-        { "name": "CAME_BY_TAXI", "value": 2, "comment": "Y: Llego en taxi — 110.465" },
-        { "name": "IS_THE_DRIVER", "value": 3, "comment": "C: Es el taxista — 1.803" }
+        { "name": "NO_TAXI", "value": 1, "comment": "SinTaxi" },
+        { "name": "CAME_BY_TAXI", "value": 2, "comment": "LlegoEnTaxi" },
+        { "name": "IS_THE_DRIVER", "value": 3, "comment": "EsElTaxista" }
       ]
     },
     "ReservationStatus": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Reservations\\Enums\\ReservationStatus (PHP). Char legacy mapeado en comments.",
-      "apps": ["admin", "rnGuard", "rnOwner"],
+      "apps": ["api", "admin", "rnGuard", "rnOwner"],
       "values": [
         { "name": "AWAITING_APPROVAL", "value": 1, "comment": "W: Esperando confirmación" },
         { "name": "PENDING_PAYMENT", "value": 2, "comment": "A: Pago pendiente" },
@@ -79,7 +109,7 @@
     "PaymentStatus": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentStatus (PHP).",
-      "apps": ["admin", "rnOwner"],
+      "apps": ["api", "admin", "rnOwner"],
       "values": [
         { "name": "SUBMITTED", "value": 1, "comment": "Por confirmar", "rnOwnerAlias": "PENDING" },
         { "name": "PAID", "value": 2, "comment": "Confirmado/Pagado" },
@@ -90,7 +120,7 @@
     "PaymentMethod": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentMethod (PHP).",
-      "apps": ["admin", "rnOwner"],
+      "apps": ["api", "admin", "rnOwner"],
       "values": [
         { "name": "TRANSFER", "value": 1 },
         { "name": "OFFICE", "value": 2 },
@@ -102,7 +132,7 @@
     "PaymentType": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentType (PHP). NO confundir con QrDinamico/types.ts PaymentType (string char, semántica distinta — son enums DIFERENTES, no se pueden unificar). SOLO consumido por admin — rnOwner usa `DebtType` (semántica diferente, no equivalente).",
-      "apps": ["admin"],
+      "apps": ["api", "admin"],
       "values": [
         { "name": "ALL_DEBTS", "value": 1 },
         { "name": "EXPENSES", "value": 2 },
@@ -116,7 +146,7 @@
     "DebtStatus": {
       "type": "int",
       "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\DebtStatus (PHP).",
-      "apps": ["admin", "rnOwner"],
+      "apps": ["api", "admin", "rnOwner"],
       "values": [
         { "name": "PENDING", "value": 1, "comment": "Por cobrar" },
         { "name": "OVERDUE", "value": 2, "comment": "En mora" },
@@ -144,7 +174,7 @@
     "AssemblyStatus": {
       "type": "string",
       "comment": "Char-backed (string). Sincronizado con backend App\\Modules\\Assemblies\\Enums\\AssemblyStatus (PHP enum: string).",
-      "apps": ["admin", "rnOwner"],
+      "apps": ["api", "admin", "rnOwner"],
       "values": [
         { "name": "Scheduled", "value": "S" },
         { "name": "InProgress", "value": "P" },
@@ -155,7 +185,7 @@
     "AssemblyType": {
       "type": "string",
       "comment": "Char-backed. Backend enums Assemblies son string, no int.",
-      "apps": ["admin", "rnOwner"],
+      "apps": ["api", "admin", "rnOwner"],
       "values": [
         { "name": "Ordinary", "value": "O" },
         { "name": "Extraordinary", "value": "E" },
@@ -165,7 +195,11 @@
     "AssemblyModality": {
       "type": "string",
       "comment": "Char-backed.",
-      "apps": ["admin", "rnOwner"],
+      "apps": ["api", "admin", "rnOwner"],
+      "aliasesByApp": {
+        "api": { "Presencial": "InPerson", "Hibrid": "Hybrid" }
+      },
+      "aliasesComment": "Los VALORES coinciden; los nombres de los cases no. El API dice `InPerson` y `Hybrid` donde los fronts dicen `Presencial` e `Hibrid`. Se declara el alias en vez de renombrar porque Assemblies todavía no se migró y el rename toca sus call sites. Nadie lo había visto porque hasta 1.1.0 el API no entraba a este contrato.",
       "values": [
         { "name": "Virtual", "value": "V" },
         { "name": "Presencial", "value": "P" },
@@ -182,10 +216,54 @@
         { "name": "Dependents", "value": "dependents" }
       ]
     },
+    "InvitationStatus": {
+      "type": "int",
+      "comment": "En qué situación está una invitación — `invitations.status`. Era char(1) A/I/O/X hasta el 2026-08-15; migrado a enum numérico desde 1 sobre 5.420 filas. Lo escriben CINCO módulos del API (Invitation, Access, Visits, HomeOwner), y por eso el contrato importa más que de costumbre.\n\n⚠️ NO es el estado que ve el usuario en el listado del admin: ése es derivado (Anulada/Expirada/Activa) y se calcula cruzando esta columna con los accesos registrados.",
+      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "values": [
+        { "name": "ACTIVE", "value": 1, "comment": "A — 2.090 filas al migrar" },
+        { "name": "INACTIVE", "value": 2, "comment": "I — 788" },
+        { "name": "USED", "value": 3, "comment": "O — 2.264" },
+        { "name": "CANCELLED", "value": 4, "comment": "X — 278" }
+      ]
+    },
+    "InvitationType": {
+      "type": "int",
+      "comment": "Qué clase de invitación es — `invitations.type`. Era char(1) I/G/F.\n\n🔴 La letra del QR FÍSICO usa el mismo alfabeto y NO es esta columna: el texto impreso dice `condaty|qr|G|<uuid>` y el lector del guardia manda `?qr=G`. Está en 5.432 filas de `qrs` y en los QR compartidos por WhatsApp, así que no se migró. Y sólo existen I (4.777) y G (655): ninguna F, porque los frecuentes se emitieron con I.",
+      "apps": ["api", "admin", "rnGuard", "rnOwner"],
+      "values": [
+        { "name": "INDIVIDUAL", "value": 1, "comment": "I — 3.725 filas al migrar" },
+        { "name": "GROUP", "value": 2, "comment": "G — 652" },
+        { "name": "FREQUENT", "value": 3, "comment": "F — 1.043" }
+      ]
+    },
+    "InvitationSchedule": {
+      "type": "int",
+      "comment": "Si la invitación lleva días y horario — `invitations.is_advanced`. Era un char(1) N/Y, o sea un booleano disfrazado: entra al enum por la regla del proyecto y porque los tres fronts lo comparaban contra 'Y' a mano, cada uno en su archivo.\n\nEl admin no lo consume: no muestra ni edita la configuración horaria.",
+      "apps": ["api", "rnGuard", "rnOwner"],
+      "values": [
+        { "name": "SIMPLE", "value": 1, "comment": "N — 5.099 filas al migrar" },
+        { "name": "ADVANCED", "value": 2, "comment": "Y — 321" }
+      ]
+    },
+    "InvitationGuestStatus": {
+      "type": "int",
+      "comment": "🔴 El estado de UN invitado de una grupal — `invitation_visits.status`. NO es InvitationStatus.\n\nComparte los tres valores a propósito: la columna guardaba las mismas letras, y hacer que un 1 signifique cosas distintas según la tabla convertiría cualquier consulta de diagnóstico en una trampa. No tiene CANCELLED: anular es una operación sobre la invitación entera.\n\nSon enums SEPARADOS —no un alias— para que confundirlos sea un error de tipo. Sólo rnOwner lo consume: es la pantalla que lista los invitados de un QR grupal.",
+      "apps": ["api", "rnOwner"],
+      "values": [
+        { "name": "ACTIVE", "value": 1, "comment": "A — 3.846 de 5.262 filas al migrar" },
+        { "name": "INACTIVE", "value": 2, "comment": "I — 190" },
+        { "name": "USED", "value": 3, "comment": "O — 1.226" }
+      ]
+    },
     "SurveyStatus": {
       "type": "string",
       "comment": "Char-backed. Sincronizado con backend App\\Modules\\Surveys\\Enums\\SurveyStatus (PHP).",
-      "apps": ["admin", "rnOwner"],
+      "apps": ["api", "admin", "rnOwner"],
+      "aliasesByApp": {
+        "api": { "Visible": "Voting" }
+      },
+      "aliasesComment": "🔴 El valor coincide ('V') y el nombre no, y acá el nombre del API está MAL: `Voting` es el estado en el que los participantes ven la encuesta pero NO pueden votar — lo dice su propio comentario en el PHP, 'Visible - participantes ven PERO no votan'. Renombrarlo toca los call sites de Surveys, que no está migrado: anotado en HALLAZGOS_CRUZADOS.md.",
       "values": [
         { "name": "Draft", "value": "D" },
         { "name": "Visible", "value": "V", "comment": "Visible, participants can see but NOT vote" },

--- a/tests/__fixtures__/enums-ssot.json
+++ b/tests/__fixtures__/enums-ssot.json
@@ -258,12 +258,8 @@
     },
     "SurveyStatus": {
       "type": "string",
-      "comment": "Char-backed. Sincronizado con backend App\\Modules\\Surveys\\Enums\\SurveyStatus (PHP).",
+      "comment": "Char-backed. Sincronizado con backend App\\Modules\\Surveys\\Enums\\SurveyStatus (PHP).\n\nEl API llamaba `Voting` a este case y significaba lo CONTRARIO: es el estado donde los participantes ven la encuesta pero NO pueden votar. El propio enum se contradecía —el case decía Voting y su label() devolvía 'Visible'— y los tres fronts siempre dijeron `Visible`. Se renombró en el API el 2026-08-15 en vez de dejarlo como alias: no tenía un solo call site fuera de su propio archivo, así que el rename costó dos líneas.",
       "apps": ["api", "admin", "rnOwner"],
-      "aliasesByApp": {
-        "api": { "Visible": "Voting" }
-      },
-      "aliasesComment": "🔴 El valor coincide ('V') y el nombre no, y acá el nombre del API está MAL: `Voting` es el estado en el que los participantes ven la encuesta pero NO pueden votar — lo dice su propio comentario en el PHP, 'Visible - participantes ven PERO no votan'. Renombrarlo toca los call sites de Surveys, que no está migrado: anotado en HALLAZGOS_CRUZADOS.md.",
       "values": [
         { "name": "Draft", "value": "D" },
         { "name": "Visible", "value": "V", "comment": "Visible, participants can see but NOT vote" },


### PR DESCRIPTION
Espejo del admin para la migración de Invitaciones a enums numéricos.

🔴 **Es UN SOLO RELEASE.** No mergear suelto: el API es [condaty2025-api#262](https://github.com/mariogfos/condaty2025-api/pull/262), y van también `rnOwner` y `rnGuard`. Runbook: `Makromania/plans/runbook-release-invitation.md`.

## Qué cambia

`invitations.status` y `invitations.type` eran `char(1)` y ahora son enteros desde 1. Antes había `=== "G"` suelto en dos componentes y una tabla de etiquetas por char en un tercero; ahora la comparación está escrita **una vez** en `invitationEnums.ts`.

Los códigos de período pasan a los **cortos** (`w`/`lw`/`m`/`lm`). El admin mandaba los largos (`lmonth`) y el módulo del API los traducía con una tabla propia — esa traducción era la **décima copia** del switch de fechas del proyecto. Se borró de los dos lados.

## Los predicados con nombre, y por qué

Este archivo era el único de los cuatro espejos del enum **sin un solo test**, y el que tenía el agujero más grande: `esTipo` y `esEstado` reciben un `number` pelado, así que `esEstado(x, InvitationType.GROUP)` compila —compara un estado contra un tipo— y `tsc` no dice nada. En rnOwner y rnGuard eso al menos es un error de tipo.

Se agregan `esGrupal`/`esIndividual`/`esFrecuente`/`esAnulada` y los 8 call sites de `QrTab` y `RenderView` pasan a usarlos: el enum se nombra una vez, y el test lo fija contra **todos** los cases —no sólo contra el suyo, porque afirmar sólo `esGrupal(2) === true` sigue pasando si alguien lo reescribe como `>= 2`—.

⚠️ Ningún case vale 0, y no es casualidad: `0 == ""` es `true` en JavaScript y el `Select` compartido auto-elige la opción con id 0 como si el usuario la hubiera tocado (CDT-30).

## Verificación

- **Reinyección**: cambiando `GROUP` por `FREQUENT` en `esGrupal`, **3 tests en rojo**. Antes de este PR, el mismo cambio daba **0**.
- Suite del admin: **756 verdes**, 110 archivos. `tsc` limpio en lo tocado.
- **Abriendo la pantalla**: la pestaña de Invitaciones dibuja Grupal/Individual con su ícono, el chip **Anulada** en rojo, Activa y Expirada, y el detalle expandido lista los 5 invitados de la grupal. Sin errores nuevos en consola.
