### PR TITLE
feat(deudas)!: se edita y elimina la deuda individual; el grupo solo se crea (CDT-50)

### DIFF
--- a/context/condaty_admin_context.md
+++ b/context/condaty_admin_context.md
@@ -322,6 +322,11 @@ Modulo/
 - Reportes de morosidad
 - Condonación selectiva
 
+**SharedDebts** sigue la misma regla que las expensas (ver *14. Expenses →
+Qué se puede editar y qué no*): el grupo sólo se crea, y el reparto por unidad
+(`DetalleDeudaCompartida`) es donde se edita el monto y se elimina la deuda de
+UNA unidad, contra `/v3/debt-dptos/{id}` con `type: 4`.
+
 ### 10. Defaulters (Morosos)
 **Ubicación**: `src/modulos/Defaulters/`
 **Funcionalidad**: Gestión de usuarios morosos
@@ -366,19 +371,40 @@ Modulo/
 - Control de asistencia
 - Integración con calendario
 
-### 14. Expenses (Gastos)
+### 14. Expenses (Expensas)
 **Ubicación**: `src/modulos/Expenses/`
-**Funcionalidad**: Gestión de gastos
+**Funcionalidad**: Expensas de las unidades, agrupadas por periodo
 
 #### Submódulos:
-- **ExpensesDetails**: Detalles de gastos
-- **RenderForm**: Formulario de gastos
+- **ExpensesDetails**: el periodo abierto, una fila por unidad
+- **RenderForm**: crear el periodo (año + mes + descripción)
 
 **Características**:
-- Categorización de gastos
-- Aprobación de gastos
-- Reportes detallados
-- Integración con presupuestos
+- Listado por periodo con totales cobrados, en mora y por cobrar
+- Detalle por unidad con su estado, multa y mantenimiento de valor
+- Exportación por el motor async (`debt-groups-expenses` / `expenses-periodo`)
+
+#### 🔴 Qué se puede editar y qué no (CDT-50, decisión del CTO)
+
+Un **grupo** —el periodo de expensas o una deuda compartida— **sólo se crea**.
+No se edita ni se elimina: `PUT` y `DELETE` de `/debt-groups/{id}` no existen
+(404 en `/api/v3`, 405 en el alias legacy `/api`). Un grupo es una agrupación
+que ya repartió su cometido; editarlo o borrarlo entero significaba borrar duro
+las N deudas de las unidades y regenerarlas, arrastrando a las que no tenían
+nada que ver.
+
+Lo que se edita y se elimina es la **deuda individual**, con el lápiz y el
+tacho de su fila en el detalle por unidad → `PUT`/`DELETE /v3/debt-dptos/{id}`.
+Condiciones del back (`DebtDptoController`):
+
+- No se puede si la deuda tiene **cualquier pago vivo**, ni parcial ni sin
+  confirmar (CDT-45). El rechazo vuelve con el motivo en `message` y ese texto
+  es el que se le muestra al usuario: las pantallas no lo tapan con un texto
+  fijo propio.
+- El `PUT` **exige `type`**: sin él el back rutea a NORMAL y pide otras cinco
+  claves. Para EXPENSE exige además `penalty_amount` (`required|numeric|min:0`).
+- El `PUT` **ignora** `dpto_id`, `year`, `month`, `debt_id` y `shared_id`:
+  editar corrige la plata, nunca muda la deuda de unidad ni de grupo.
 
 ### 15. Guards (Guardias)
 **Ubicación**: `src/modulos/Guards/`

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.module.css
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.module.css
@@ -118,30 +118,6 @@
   flex: 1;
 }
 
-.actionButtons {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spS);
-  min-width: 120px;
-}
-
-.actionButton {
-  display: flex;
-  align-items: center;
-  gap: var(--spXS);
-  justify-content: center;
-  padding: var(--spS) var(--spM);
-  border-radius: var(--bRadiusM);
-  font-size: var(--sM);
-  font-weight: var(--bMedium);
-  transition: all 0.2s ease;
-}
-
-.actionButton:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
 /* Modal de confirmación */
 .modalOverlay {
   position: fixed;
@@ -188,16 +164,6 @@
 @media (max-width: 768px) {
   .summarySection {
     flex-direction: column;
-  }
-
-  .actionButtons {
-    flex-direction: row;
-    min-width: auto;
-    width: 100%;
-  }
-
-  .actionButton {
-    flex: 1;
   }
 }
 

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
@@ -1,21 +1,16 @@
 "use client";
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import useCrud, { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
 import {
   IconCategories,
   IconArrowLeft,
-  IconEdit,
-  IconTrash,
 } from "@/components/layout/icons/IconsBiblioteca";
 import FormatBsAlign from "@/mk/utils/FormatBsAlign";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
 import Button from "@/mk/components/forms/Button/Button";
-import RenderForm from "../RenderForm/RenderForm";
 import RenderView from "../../AllDebts/RenderView/RenderView";
 import { useAuth } from "@/mk/contexts/AuthProvider";
-import DataModal from "@/mk/components/ui/DataModal/DataModal";
-import { capitalize } from "@/mk/utils/string";
 import styles from "./DetailSharedDebts.module.css";
 import { getDateStrMes } from "@/mk/utils/date";
 import UnifiedCard from "../../../UnifiedCard/UnifiedCard";
@@ -31,37 +26,13 @@ interface DetailSharedDebtsProps {
   debtId: string;
   debtTitle?: string;
 }
-interface DebtData {
-  id?: string | number;
-  begin_at?: string;
-  due_at?: string;
-  type?: number;
-  description?: string;
-  category_id?: string | number;
-  subcategory_id?: string | number;
-  asignar?: string;
-  dpto_id?: any[];
-  amount_type?: string;
-  amount?: string | number;
-  is_advance?: string;
-  interest?: number;
-  show_advanced?: boolean;
-  has_mv?: boolean;
-  is_forgivable?: boolean;
-  has_pp?: boolean;
-  is_blocking?: boolean;
-}
 
 const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
   debtId,
   debtTitle = "Deuda Compartida",
 }) => {
   const router = useRouter();
-  const { user, showToast } = useAuth();
-
-  const [showEditForm, setShowEditForm] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [debtData, setDebtData] = useState<DebtData | undefined>(undefined);
+  const { user } = useAuth();
 
   const getSegmentationText = (segmentation: string) => {
     const segmentationMap: { [key: string]: string } = {
@@ -273,6 +244,11 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
     permiso: "expense",
     extraData: true,
     sumarize: false,
+    // 🔴 CDT-50: esta pantalla tenía los botones "Editar" y "Eliminar" del
+    // GRUPO —`PUT`/`DELETE /v3/debt-groups/{id}` con `type: 4`—, que borraban
+    // duro las N deudas de todas las unidades. El grupo ya no se edita ni se
+    // borra (esos endpoints devuelven 404). Lo que se edita y se elimina es la
+    // deuda de UNA unidad.
     hideActions: {
       add: true,
       view: false,
@@ -311,7 +287,7 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
     </Button>,
   ];
 
-  const { List, extraData, execute, reLoad, onSave } = useCrud({
+  const { List, extraData } = useCrud({
     paramsInitial,
     mod,
     fields,
@@ -353,100 +329,6 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
 
   const handleVolver = () => {
     router.back();
-  };
-
-  const fetchDebtData = async () => {
-    try {
-      const response = await execute(`/v3/debt-groups/${debtId}`, "GET", {
-        id: debtId,
-      });
-      if (response?.data?.success) {
-        return response.data.data;
-      }
-    } catch (error) {}
-    return null;
-  };
-
-  const handleEdit = async () => {
-    const fullDebtData = await fetchDebtData();
-    if (fullDebtData) {
-      setDebtData(fullDebtData);
-    } else {
-      setDebtData({ id: debtId });
-    }
-    setShowEditForm(true);
-  };
-
-  const handleDelete = () => {
-    setShowDeleteConfirm(true);
-  };
-
-  const confirmDelete = async () => {
-    try {
-      const response = await execute(`/v3/debt-groups/${debtId}`, "DELETE", {
-        id: debtId,
-        type: 4,
-      });
-      if (response?.data?.success) {
-        showToast("Deuda eliminada exitosamente", "success");
-        router.back();
-      } else {
-        showToast("Error al eliminar la deuda", "error");
-      }
-    } catch (error) {
-      showToast("Error al eliminar la deuda", "error");
-    }
-    setShowDeleteConfirm(false);
-  };
-
-  const handleFormSave = async (data: any) => {
-    try {
-      const response = await execute(`/v3/debt-groups/${debtId}`, "PUT", data);
-
-      if (response?.data?.success) {
-        setShowEditForm(false);
-        reLoad();
-        showToast("Deuda actualizada exitosamente", "success");
-      } else {
-        showToast(
-          response?.data?.message || "Error al actualizar la deuda",
-          "error",
-        );
-      }
-    } catch (error) {
-      showToast("Error al actualizar la deuda", "error");
-    }
-  };
-
-  const FormDelete = ({
-    open,
-    onClose,
-    item,
-    onConfirm,
-    message = "",
-  }: any) => {
-    return (
-      <DataModal
-        id="Eliminar"
-        title={capitalize("eliminar") + " deuda compartida"}
-        buttonText={capitalize("eliminar")}
-        buttonCancel="Cancelar"
-        onSave={(e) => (onConfirm ? onConfirm(item) : confirmDelete())}
-        onClose={onClose}
-        open={open}
-        variant="mini"
-      >
-        {message ? (
-          message
-        ) : (
-          <p>
-            ¿Estás seguro de eliminar esta información?
-            <br />
-            Recuerda que, al momento de eliminar, ya no podrás recuperarla.
-          </p>
-        )}
-      </DataModal>
-    );
   };
 
   return (
@@ -510,27 +392,6 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
               current={summaryData.enMora.count}
             />
           </div>
-
-          <div className={styles.actionButtons}>
-            <>
-              <Button
-                onClick={handleEdit}
-                variant="primary"
-                className={styles.actionButton}
-              >
-                <IconEdit size={16} />
-                Editar
-              </Button>
-              <Button
-                onClick={handleDelete}
-                variant="secondary"
-                className={styles.actionButton}
-              >
-                <IconTrash size={16} />
-                Eliminar
-              </Button>
-            </>
-          </div>
         </div>
 
         <div className={styles.listContainer}>
@@ -544,41 +405,6 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
           />
         </div>
       </div>
-
-      {showEditForm && debtData && (
-        <RenderForm
-          open={showEditForm}
-          onClose={() => setShowEditForm(false)}
-          item={debtData}
-          onSave={handleFormSave}
-          extraData={extraData}
-          execute={
-            execute as (
-              url: string,
-              method: string,
-              params: any,
-            ) => Promise<any>
-          }
-          showToast={
-            showToast as (
-              msg: string,
-              type?: "info" | "success" | "error" | "warning",
-            ) => void
-          }
-          reLoad={reLoad as () => void}
-          user={user}
-        />
-      )}
-
-      {showDeleteConfirm && (
-        <FormDelete
-          open={showDeleteConfirm}
-          onClose={() => setShowDeleteConfirm(false)}
-          item={{ id: debtId }}
-          onConfirm={confirmDelete}
-          message=""
-        />
-      )}
     </>
   );
 };

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/DetailSharedDebts.tsx
@@ -106,6 +106,28 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
   const fields = useMemo(() => {
     return {
       id: { rules: [], api: "e" },
+      /**
+       * 🔴 Va en el `PUT` aunque no se vea ni se edite.
+       *
+       * `DebtDptoController::beforeUpdate` rutea por `type`: sin él,
+       * `(int) null` es 0 —NORMAL— y entonces exige `begin_at`, `due_at`,
+       * `subcategory_id`, `amount` y `dpto_id`, que esta pantalla no tiene.
+       * El valor sale de la fila (`debt_dptos.type`); todas son SHARED porque
+       * la lista se pide con `type: 4`.
+       *
+       * Sin `form` a propósito: `useCrud` sólo dibuja los campos que lo
+       * declaran, así que no ocupa una celda del grid del formulario.
+       */
+      type: { rules: [], api: "e" },
+      obs: {
+        rules: ["required"],
+        api: "e",
+        label: "Motivo del cambio",
+        form: {
+          type: "text",
+          label: "Motivo del cambio",
+        },
+      },
       unit: {
         rules: [""],
         api: "",
@@ -141,9 +163,17 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
           order: 3,
         },
       },
+      /**
+       * El monto de ESTA unidad. El back congela `dpto_id`, `debt_id`,
+       * `shared_id`, `year` y `month`, así que editar corrige la plata y nunca
+       * muda la deuda de unidad ni de grupo.
+       *
+       * La multa NO se edita acá: `beforeUpdate` no la pide para SHARED (sí
+       * para EXPENSE) y la aplica el proceso de mora.
+       */
       amount: {
-        rules: [""],
-        api: "",
+        rules: ["required", "number", "positive"],
+        api: "e",
         label: (
           <label
             style={{ display: "block", textAlign: "right", width: "100%" }}
@@ -155,6 +185,10 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
           onRender: renderDebtAmountCell,
           order: 4,
           sumarize: true,
+        },
+        form: {
+          type: "number",
+          label: "Monto",
         },
       },
       penalty_amount: {
@@ -224,7 +258,8 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
     // leen `extraData.debt`, que arma `DebtDptoController` buscando por
     // `shared_id` — justo el que no se estaba llamando.
     modulo: "v3/debt-dptos",
-    singular: "Detalle",
+    // Titula los modales de editar y eliminar ("Editar deuda de la unidad").
+    singular: "deuda de la unidad",
     plural: "Detalles",
     // Motor nuevo (Fase 6): lo atiende `DetalleDeCompartidaExportConfig`.
     //
@@ -248,12 +283,15 @@ const DetailSharedDebts: React.FC<DetailSharedDebtsProps> = ({
     // GRUPO —`PUT`/`DELETE /v3/debt-groups/{id}` con `type: 4`—, que borraban
     // duro las N deudas de todas las unidades. El grupo ya no se edita ni se
     // borra (esos endpoints devuelven 404). Lo que se edita y se elimina es la
-    // deuda de UNA unidad.
+    // deuda de UNA unidad, con el lápiz y el tacho de su fila, que `useCrud`
+    // manda a `PUT`/`DELETE /v3/debt-dptos/{id}`.
+    //
+    // Como en el detalle de expensas, no hay `onHideActions` que adivine si la
+    // deuda tiene pagos: esa regla vive en `beforeUpdate`/`beforeDelete` y su
+    // rechazo llega con el texto del back.
     hideActions: {
       add: true,
       view: false,
-      edit: true,
-      del: true,
     },
     renderView: (props: any) => (
       <RenderView

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/__tests__/CDT50CompartidaIndividual.test.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/DetalleDeudaCompartida/__tests__/CDT50CompartidaIndividual.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * CDT-50 — el reparto de una compartida se edita y se elimina POR UNIDAD.
+ *
+ * ## 🔴 Qué se rompía
+ *
+ * Esta pantalla tenía dos botones de GRUPO, "Editar" y "Eliminar", que pegaban
+ * a `PUT`/`DELETE /v3/debt-groups/{id}` con `type: 4` y borraban duro las N
+ * deudas de todas las unidades. La API de CDT-50 sacó esos dos endpoints (404
+ * en `v3`, 405 en la ruta legacy): los botones quedaron rotos desde el mismo
+ * release. Y la lista por unidad —la única que muestra la deuda de cada
+ * `dpto`— venía con `hideActions {edit, del}`, así que no había ninguna forma
+ * de tocar UNA sola.
+ *
+ * Encima el `confirmDelete` viejo tapaba la respuesta del back con textos
+ * fijos: `showToast("Deuda eliminada exitosamente")` cuando `success` venía en
+ * true, y `"Error al eliminar la deuda"` si no. Un rechazo por pagos vivos
+ * viaja con `success: true` y el motivo adentro de `message` (CDT-49), así que
+ * el admin leía "eliminada exitosamente" sobre una deuda que seguía ahí.
+ *
+ * ## Qué mide este archivo
+ *
+ * El request que sale, con `useCrud` de verdad. El transporte, la sesión y el
+ * dibujo de los íconos están mockeados; el cuerpo del `PUT` lo arma
+ * `getParamFields` con los `fields` reales de la pantalla.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
+
+const showToast = vi.fn();
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u-1",
+      client_id: "c-1",
+      role: { abilities: "**c-1**" },
+      clients: [{ id: "c-1" }],
+    },
+    userCan: () => true,
+    showToast,
+    store: {},
+    setStore: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) {
+    mocked[key] = (props: any) =>
+      React.createElement("span", {
+        "data-testid": key,
+        onClick: props?.onClick,
+      });
+  }
+  return mocked;
+});
+
+import DetailSharedDebts from "../DetailSharedDebts";
+
+const request = vi.fn();
+
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as any;
+
+/** Una fila del reparto, tal como la trae la rama SHARED de `getModelByList`. */
+const FILA = {
+  id: "dd-shared-1",
+  type: 4,
+  dpto_id: "dpto-9",
+  dpto: { nro: "B-202", description: "Bloque B" },
+  amount: "500.00",
+  penalty_amount: "0.00",
+  maintenance_amount: "0.00",
+  obs: null,
+  status: 1,
+  due_at: "2026-08-30",
+};
+
+const listaOk = {
+  data: {
+    success: true,
+    data: [FILA],
+    message: { total: 1 },
+    extraData: { debt: { description: "Portón nuevo" } },
+  },
+};
+
+const montar = () => {
+  render(
+    <AxiosContext.Provider
+      value={
+        {
+          contextInstance: { request },
+          waiting: 0,
+          setWaiting: vi.fn(),
+        } as any
+      }
+    >
+      <DetailSharedDebts debtId="grupo-1" />
+    </AxiosContext.Provider>,
+  );
+};
+
+const mutacion = () =>
+  request.mock.calls
+    .map((c) => c[0])
+    .find((c: any) => c.method === "PUT" || c.method === "DELETE");
+
+describe("CDT-50 · la compartida se edita y se elimina por unidad", () => {
+  beforeEach(() => {
+    request.mockReset();
+    showToast.mockReset();
+    request.mockResolvedValue(listaOk);
+  });
+
+  afterEach(() => cleanup());
+
+  it("ya no están los botones de grupo, que pegaban a un endpoint muerto", async () => {
+    montar();
+    await screen.findByText("B-202");
+
+    // Los del grupo eran botones con texto; los de la fila son íconos.
+    expect(screen.queryByRole("button", { name: "Editar" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Eliminar" })).toBeNull();
+  });
+
+  it("la fila por unidad trae lápiz y tacho", async () => {
+    montar();
+    await screen.findByText("B-202");
+
+    expect(screen.getAllByTestId("IconEdit")).toHaveLength(1);
+    expect(screen.getAllByTestId("IconTrash")).toHaveLength(1);
+  });
+
+  it("editar manda PUT a /v3/debt-dptos/{id} con type 4, no al grupo", async () => {
+    montar();
+    await screen.findByText("B-202");
+
+    fireEvent.click(screen.getByTestId("IconEdit"));
+
+    const monto = await screen.findByDisplayValue("500.00");
+    fireEvent.change(monto, { target: { name: "amount", value: "640.00" } });
+    fireEvent.change(screen.getByLabelText(/Motivo del cambio/i), {
+      target: { name: "obs", value: "Reparto corregido" },
+    });
+
+    fireEvent.click(screen.getByText("Actualizar"));
+
+    await waitFor(() => expect(mutacion()).toBeTruthy());
+
+    expect(mutacion()).toMatchObject({
+      url: "/v3/debt-dptos/dd-shared-1",
+      method: "PUT",
+    });
+    expect(mutacion().url).not.toContain("debt-groups");
+    // 🔴 Sin `type`, `beforeUpdate` cae en NORMAL y pide otras cinco claves.
+    expect(mutacion().data).toMatchObject({
+      id: "dd-shared-1",
+      type: 4,
+      amount: "640.00",
+      obs: "Reparto corregido",
+    });
+    // El back congela las llaves que mudarían la deuda; la pantalla ni las manda.
+    expect(mutacion().data).not.toHaveProperty("dpto_id");
+    expect(mutacion().data).not.toHaveProperty("shared_id");
+  });
+
+  it("eliminar manda DELETE a /v3/debt-dptos/{id}, no al grupo", async () => {
+    montar();
+    await screen.findByText("B-202");
+
+    fireEvent.click(screen.getByTestId("IconTrash"));
+    fireEvent.click(await screen.findByText("Eliminar"));
+
+    await waitFor(() => expect(mutacion()).toBeTruthy());
+
+    expect(mutacion()).toMatchObject({
+      url: "/v3/debt-dptos/dd-shared-1",
+      method: "DELETE",
+    });
+    expect(mutacion().url).not.toContain("debt-groups");
+  });
+
+  /**
+   * 🔴 Éste es el texto que el `confirmDelete` viejo tapaba con "Deuda
+   * eliminada exitosamente". El `success: true` mentiroso es CDT-49 y se
+   * arregla en el kernel; lo que se pinea acá es que el motivo del back llegue
+   * al usuario en vez de morir tapado por un texto fijo de la pantalla.
+   */
+  it("el rechazo por pagos registrados le llega al usuario con el texto del back", async () => {
+    const RECHAZO =
+      "No se puede eliminar esta deuda porque tiene pagos registrados. " +
+      "Primero anule o elimine los pagos.";
+
+    montar();
+    await screen.findByText("B-202");
+
+    request.mockResolvedValueOnce({
+      data: { success: true, data: true, message: RECHAZO },
+    });
+
+    fireEvent.click(screen.getByTestId("IconTrash"));
+    fireEvent.click(await screen.findByText("Eliminar"));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(RECHAZO, expect.anything()),
+    );
+  });
+});

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/RenderForm/RenderForm.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/RenderForm/RenderForm.tsx
@@ -391,16 +391,19 @@ const RenderForm: React.FC<RenderFormProps> = ({
     setLdpto(lista);
   }, [client?.type_dpto, extraData?.dptos]);
 
+  // 🔴 CDT-50: este formulario SÓLO crea. El título y el botón tenían dos
+  // variantes ("Editar deuda compartida" / "Actualizar") para el botón Editar
+  // del detalle, que pegaba a `PUT /v3/debt-groups/{id}`. Ese endpoint ya no
+  // existe y un grupo dejó de editarse: lo que se edita es la deuda de UNA
+  // unidad, desde el detalle del reparto.
   return (
     <DataModal
       open={open}
       onClose={onCloseModal}
       onSave={handleSave}
       buttonCancel="Cancelar"
-      buttonText={_formState.id ? "Actualizar" : "Crear deuda compartida"}
-      title={
-        _formState.id ? "Editar deuda compartida" : "Crear deuda compartida"
-      }
+      buttonText="Crear deuda compartida"
+      title="Crear deuda compartida"
       variant={"mini"}
     >
       <div className={styles.formContainer}>

--- a/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
+++ b/src/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts.tsx
@@ -1,14 +1,11 @@
 "use client";
 import React, { useMemo, useEffect, useState } from "react";
 import useCrud, { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
-import useCrudUtils from "../../../shared/useCrudUtils";
-import { getDateStrMesShort, getNow } from "@/mk/utils/date";
+import { getDateStrMesShort } from "@/mk/utils/date";
 import RenderForm from "./RenderForm/RenderForm";
 import { IconCategories } from "@/components/layout/icons/IconsBiblioteca";
 import FormatBsAlign from "@/mk/utils/FormatBsAlign";
 import { StatusBadge } from "@/components/StatusBadge/StatusBadge";
-import ItemList from "@/mk/components/ui/ItemList/ItemList";
-import RenderItem from "../../../shared/RenderItem";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import Button from "@/mk/components/forms/Button/Button";
 import DateRangeFilterModal from "@/components/DateRangeFilterModal/DateRangeFilterModal";
@@ -33,7 +30,7 @@ interface SharedDebtsProps {
 }
 
 const SharedDebts: React.FC<SharedDebtsProps> = ({ onExtraDataChange }) => {
-  const { user, setStore, store } = useAuth();
+  const { user } = useAuth();
   const router = useRouter();
   const [openCustomFilter, setOpenCustomFilter] = useState(false);
   const [customDateErrors, setCustomDateErrors] = useState<{
@@ -484,6 +481,11 @@ const SharedDebts: React.FC<SharedDebtsProps> = ({ onExtraDataChange }) => {
     permiso: "expense",
     extraData: true,
     sumarize: false,
+    // 🔴 CDT-50 (decisión del CTO): una deuda compartida es una agrupación que
+    // ya repartió su cometido. Sólo se crea; `PUT` y `DELETE` de
+    // `/debt-groups/{id}` ya no existen en el back. Lo que se edita y se
+    // elimina es la deuda de UNA unidad, desde el detalle del reparto
+    // (`DetalleDeudaCompartida`).
     hideActions: {
       view: true,
       edit: true,
@@ -518,71 +520,20 @@ const SharedDebts: React.FC<SharedDebtsProps> = ({ onExtraDataChange }) => {
     </Button>,
   ];
 
-  const {
-    userCan,
-    List,
-    onEdit,
-    onDel,
-    extraData,
-    onFilter,
-    execute,
-    reLoad,
-    showToast,
-  } = useCrud({
-    paramsInitial,
-    mod,
-    fields,
-    extraButtons,
-    getFilter: handleGetFilter,
-  });
+  const { userCan, List, extraData, onFilter, execute, reLoad, showToast } =
+    useCrud({
+      paramsInitial,
+      mod,
+      fields,
+      extraButtons,
+      getFilter: handleGetFilter,
+    });
 
   useEffect(() => {
     if (extraData && onExtraDataChange) {
       onExtraDataChange(extraData);
     }
   }, [extraData, onExtraDataChange]);
-
-  const { onLongPress, selItem } = useCrudUtils({
-    onSearch: () => {},
-    searchs: {},
-    setStore,
-    mod,
-    onEdit,
-    onDel,
-  });
-
-  const renderItem = (item: Record<string, any>) => {
-    const rawStatus = Number(item?.status);
-    const numericStatus = Number.isFinite(rawStatus) && rawStatus > 0 ? rawStatus : DebtStatus.PENDING;
-    const dueAtString = item?.due_at;
-    const todayString = getNow();
-    const displayStatus = dueAtString && dueAtString < todayString && numericStatus === DebtStatus.PENDING
-      ? DebtStatus.OVERDUE
-      : numericStatus;
-
-    const debtAmount = montoDelGrupo(item);
-    const totalPenalty =
-      item?.asignados?.reduce((sum: number, asignado: any) => {
-        return sum + (parseFloat(asignado?.penalty_amount) || 0);
-      }, 0) || 0;
-    const totalBalance =
-      debtAmount + totalPenalty + maintenanceAmountFor(user, item);
-
-    return (
-      <RenderItem item={item} onClick={() => {}} onLongPress={onLongPress}>
-        <ItemList
-          title={`${item?.description || "Sin concepto"} - ${getStatusText(displayStatus)}`}
-          subtitle={`Deuda: Bs ${debtAmount.toFixed(
-            2,
-          )} | Multa: Bs ${totalPenalty.toFixed(
-            2,
-          )} | Total: Bs ${totalBalance.toFixed(2)}`}
-          variant="V1"
-          active={selItem && selItem.id == item.id}
-        />
-      </RenderItem>
-    );
-  };
 
   const onClickDetail = (row: any) => {
     if (row?.id) {
@@ -594,7 +545,6 @@ const SharedDebts: React.FC<SharedDebtsProps> = ({ onExtraDataChange }) => {
     <>
       <List
         height={"100%"}
-        onTabletRow={renderItem}
         onRowClick={onClickDetail}
         emptyMsg="Lista de deudas grupales vacía. Una vez generes las cuotas"
         emptyLine2="grupales las verás aquí."

--- a/src/modulos/Expenses/Expenses.tsx
+++ b/src/modulos/Expenses/Expenses.tsx
@@ -1,13 +1,10 @@
 'use client';
 import useCrud, { ModCrudType } from '@/mk/hooks/useCrud/useCrud';
 import NotAccess from '@/components/auth/NotAccess/NotAccess';
-import ItemList from '@/mk/components/ui/ItemList/ItemList';
-import useCrudUtils from '../shared/useCrudUtils';
 import { useEffect, useMemo, useState } from 'react';
-import RenderItem from '../shared/RenderItem';
 import { MONTHS } from '@/mk/utils/date';
 import RenderForm from './RenderForm/RenderForm';
-import { isUnitInDefault, paidUnits } from '@/mk/utils/utils';
+import { isUnitInDefault } from '@/mk/utils/utils';
 import ExpensesDetails from './ExpensesDetails/ExpensesDetailsView';
 import { IconCategories } from '@/components/layout/icons/IconsBiblioteca';
 import FormatBsAlign from '@/mk/utils/FormatBsAlign';
@@ -100,16 +97,22 @@ const mod: ModCrudType = {
   permiso: 'expense',
   extraData: true,
   search: { hide: true },
+  // 🔴 CDT-50 (decisión del CTO): un periodo de expensas SÓLO se crea. Editarlo
+  // o borrarlo entero significaba borrar duro las N deudas de las unidades y
+  // regenerarlas, arrastrando a las que no tenían nada que ver — y `PUT` y
+  // `DELETE` de `/debt-groups/{id}` ya no existen en el back (404 en `v3`, 405
+  // en la ruta legacy). Lo que se edita y se elimina es la deuda INDIVIDUAL,
+  // desde el detalle por unidad del periodo (`ExpensesDetails`).
+  //
+  // Acá vivía además un `onHideActions` que escondía lápiz y tacho según
+  // `paidUnits(asignados)`: era código muerto —su único consumidor es el
+  // `onButtonActions` de `useCrud`, que no se monta cuando `edit` y `del`
+  // están ocultas— y la regla de "no si tiene pagos" ahora la aplica el back
+  // sobre la deuda individual, que es donde se puede medir.
   hideActions: {
     view: true,
     edit: true,
     del: true,
-  },
-  onHideActions: (item: any) => {
-    return {
-      hideEdit: paidUnits(item?.asignados) > 0,
-      hideDel: paidUnits(item?.asignados) > 0,
-    };
   },
   renderForm: (props: {
     item: any;
@@ -288,33 +291,12 @@ const Expenses = () => {
     };
   }, []);
 
-  const { userCan, List, setStore, onEdit, onDel } = useCrud({
+  const { userCan, List, setStore } = useCrud({
     paramsInitial,
     mod,
     fields,
   });
 
-  const { onLongPress, selItem } = useCrudUtils({
-    onSearch: () => {},
-    searchs: {},
-    setStore,
-    mod,
-    onEdit,
-    onDel,
-  });
-
-  const renderItem = (item: Record<string, any>) => {
-    return (
-      <RenderItem item={item} onClick={onClickDetail} onLongPress={onLongPress}>
-        <ItemList
-          title={item?.name}
-          subtitle={item?.description}
-          variant="V1"
-          active={selItem && selItem.id == item.id}
-        />
-      </RenderItem>
-    );
-  };
   const onClickDetail = (row: any) => {
     setDetailItem(row);
     setOpenDetail(true);
@@ -337,7 +319,6 @@ const Expenses = () => {
       <>
         <List
           height={"100%"}
-          onTabletRow={renderItem}
           onRowClick={onClickDetail}
           emptyMsg="Lista de expensas vacía. Una vez generes las cuotas"
           emptyLine2="de los residentes las verás aquí."

--- a/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
+++ b/src/modulos/Expenses/ExpensesDetails/ExpensesDetailsView.tsx
@@ -152,7 +152,8 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
 
   const mod: ModCrudType = {
     modulo: "v3/debt-dptos",
-    singular: "",
+    // Titula los modales de editar y eliminar ("Editar expensa de la unidad").
+    singular: "expensa de la unidad",
     plural: "",
     filter: true,
     export: false,
@@ -171,10 +172,23 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
       endpoint: "/v3/debt-dptos",
     },
     permiso: "expenses",
+    // 🔴 CDT-50: acá se editaba y se borraba el PERIODO ENTERO desde la
+    // pantalla anterior, y esta —la única que muestra la deuda de CADA
+    // unidad— no tenía ninguna acción. La única forma de sacar la expensa de
+    // UNA unidad era borrar el mes completo.
+    //
+    // Ahora el lápiz y el tacho de la fila van a `PUT`/`DELETE
+    // /v3/debt-dptos/{id}`, que es lo que `useCrud` arma con `mod.modulo`.
+    // `add` sigue oculto: las expensas de un periodo las genera el back al
+    // crear el grupo, no se agregan de a una desde acá.
+    //
+    // No hay `onHideActions` que adivine si la deuda tiene pagos: la regla es
+    // "ningún pago vivo, ni parcial ni sin confirmar" y vive en
+    // `DebtDptoController::beforeUpdate`/`beforeDelete` (CDT-45). Copiarla acá
+    // la dejaría en dos lenguajes esperando a separarse; el back rechaza con
+    // su texto y ese texto es el que ve el usuario.
     hideActions: {
       add: true,
-      edit: true,
-      del: true,
     },
     loadView: {},
     renderView: (props: {
@@ -210,6 +224,19 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
   const fields = useMemo(() => {
     return {
       id: { rules: [], api: "e" },
+      /**
+       * 🔴 Va en el `PUT` aunque no se vea ni se edite.
+       *
+       * `DebtDptoController::beforeUpdate` rutea por `type`: sin él,
+       * `(int) null` es 0 —NORMAL— y entonces exige `begin_at`, `due_at`,
+       * `subcategory_id`, `amount` y `dpto_id`, que esta pantalla no tiene.
+       * El valor sale de la fila (`debt_dptos.type`); todas son EXPENSE
+       * porque la lista se pide con `type: 1`.
+       *
+       * Sin `form` a propósito: `useCrud` sólo dibuja los campos que lo
+       * declaran, así que no ocupa una celda del grid del formulario.
+       */
+      type: { rules: [], api: "e" },
       unit: {
         rules: [""],
         api: "",
@@ -248,7 +275,7 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
         },
       },
       amount: {
-        rules: ["required"],
+        rules: ["required", "number", "positive"],
         api: "e",
         label: (
           <span style={{ display: "block", textAlign: "right", width: "100%" }}>
@@ -259,7 +286,7 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
           onRender: renderAmountCell,
         },
         form: {
-          type: "text",
+          type: "number",
           label: "Monto",
         },
       },
@@ -272,9 +299,19 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
           label: "Motivo del cambio",
         },
       },
+      /**
+       * 🔴 `required` de este lado no es cosmético: el back valida
+       * `penalty_amount => required|numeric|min:0` para EXPENSE y responde
+       * **422**. Un 422 hace que axios tire, así que `execute` vuelve con
+       * `data: null` y el toast de error de `useCrud` saldría VACÍO — el
+       * usuario no vería nada. Con la regla acá el formulario ni sale.
+       *
+       * Cero es un valor válido (la regla `required` de `mk` acepta 0 y "0"):
+       * una expensa sin multa se guarda con 0, no se deja vacía.
+       */
       penalty_amount: {
-        rules: [""],
-        api: "",
+        rules: ["required", "number", "positive"],
+        api: "e",
         label: (
           <span style={{ display: "block", textAlign: "right", width: "100%" }}>
             Multa
@@ -282,6 +319,10 @@ const ExpensesDetails = ({ data, setOpenDetail }: any) => {
         ),
         list: {
           onRender: renderPenaltyAmountCell,
+        },
+        form: {
+          type: "number",
+          label: "Multa",
         },
       },
       maintenance_amount: {

--- a/src/modulos/Expenses/ExpensesDetails/__tests__/CDT50DeudaIndividualDeExpensa.test.tsx
+++ b/src/modulos/Expenses/ExpensesDetails/__tests__/CDT50DeudaIndividualDeExpensa.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * CDT-50 — la expensa de UNA unidad se edita y se elimina desde su detalle.
+ *
+ * ## 🔴 Qué se rompía
+ *
+ * El único editar/eliminar de expensas vivía sobre el GRUPO: el periodo entero,
+ * contra `PUT`/`DELETE /debt-groups/{id}`. Borrar la expensa de una sola unidad
+ * obligaba a borrar el mes completo y regenerarlo, arrastrando a las unidades
+ * que no tenían nada que ver. El detalle por unidad —la única pantalla que
+ * muestra la deuda de cada `dpto`— venía con `hideActions {add, edit, del}` y
+ * `useCrud` ni siquiera montaba la columna de acciones (`useCrud.tsx:2617`,
+ * `onButtonActions: undefined` cuando `edit` y `del` están ocultas).
+ *
+ * La API de CDT-50 sacó los dos endpoints de grupo (404 en `v3`, 405 en la
+ * ruta legacy) y abrió `PUT`/`DELETE /v3/debt-dptos/{id}` para la deuda
+ * individual.
+ *
+ * ## Qué mide este archivo
+ *
+ * El request que sale, con `useCrud` de verdad: URL, método y cuerpo. Lo que se
+ * mockea es el transporte (`AxiosContext`), la sesión (`AuthContext`) y el
+ * dibujo de los íconos —los íconos mockeados conservan su `onClick`, que es lo
+ * que hace falta para apretarlos—. Nada de eso fabrica lo que se afirma: el
+ * cuerpo del `PUT` lo arma `getParamFields` a partir de los `fields` reales de
+ * la pantalla.
+ *
+ * 🔴 Las dos claves que muerden si faltan, y por eso están afirmadas una por
+ * una:
+ *
+ *  - `type`: `DebtDptoController::beforeUpdate` rutea por él. Sin `type`,
+ *    `(int) null` es 0 —NORMAL— y el back pide `begin_at`, `due_at`,
+ *    `subcategory_id` y `dpto_id`, que esta pantalla no tiene.
+ *  - `penalty_amount`: para EXPENSE el back valida `required|numeric|min:0` y
+ *    responde 422. Un 422 hace tirar a axios, así que `execute` vuelve con
+ *    `data: null` y el toast de error de `useCrud` saldría VACÍO.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
+
+const showToast = vi.fn();
+
+/**
+ * `src/test/setup.ts` mockea `useAuth` global, pero su `user` no trae
+ * `showToast` ni permisos de escritura. Acá hace falta el toast —es donde
+ * aterriza el mensaje del back— y un rol que pueda editar y borrar.
+ */
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u-1",
+      client_id: "c-1",
+      role: { abilities: "**c-1**" },
+      clients: [{ id: "c-1" }],
+    },
+    userCan: () => true,
+    showToast,
+    store: {},
+    setStore: vi.fn(),
+  }),
+}));
+
+/**
+ * Los íconos se dibujan como botones con testid, PERO conservan su `onClick`:
+ * el test aprieta el lápiz y el tacho de verdad, y quien decide qué hacen
+ * sigue siendo `useCrud.onButtonActions`.
+ */
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) {
+    // `span` y no `button`: varios íconos viven adentro de un `<button>` real
+    // de la pantalla, y anidar botones es HTML inválido.
+    mocked[key] = (props: any) =>
+      React.createElement("span", {
+        "data-testid": key,
+        onClick: props?.onClick,
+      });
+  }
+  return mocked;
+});
+
+import ExpensesDetails from "../ExpensesDetailsView";
+
+const request = vi.fn();
+
+// jsdom no trae `matchMedia`, y el filtro responsive de `useCrud` lo usa.
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as any;
+
+/**
+ * Una fila tal como la devuelve `DebtDptoController::getModelByList` en la rama
+ * EXPENSE: la consulta no proyecta columnas, así que la fila trae la tabla
+ * entera de `debt_dptos` — `type` incluido.
+ */
+const FILA = {
+  id: "dd-uuid-1",
+  type: 1,
+  dpto_id: "dpto-1",
+  dpto: { nro: "A-101", description: "Bloque A" },
+  amount: "350.00",
+  penalty_amount: "0.00",
+  maintenance_amount: "0.00",
+  obs: null,
+  status: 1,
+  due_at: "2026-07-28",
+  paid_at: null,
+  year: 2026,
+  month: 7,
+};
+
+const listaOk = {
+  data: {
+    success: true,
+    data: [FILA],
+    message: { total: 1 },
+    extraData: {},
+  },
+};
+
+const montar = () => {
+  render(
+    <AxiosContext.Provider
+      value={
+        {
+          contextInstance: { request },
+          waiting: 0,
+          setWaiting: vi.fn(),
+        } as any
+      }
+    >
+      <ExpensesDetails data={{ year: 2026, month: 7 }} setOpenDetail={vi.fn()} />
+    </AxiosContext.Provider>,
+  );
+};
+
+/** El request de mutación: el primero que no es el GET del listado. */
+const mutacion = () =>
+  request.mock.calls
+    .map((c) => c[0])
+    .find((c: any) => c.method === "PUT" || c.method === "DELETE");
+
+describe("CDT-50 · la expensa de una unidad se edita y se elimina", () => {
+  beforeEach(() => {
+    request.mockReset();
+    showToast.mockReset();
+    request.mockResolvedValue(listaOk);
+  });
+
+  afterEach(() => cleanup());
+
+  it("la fila trae lápiz y tacho (antes no se montaba la columna de acciones)", async () => {
+    montar();
+
+    expect(await screen.findByText("A-101")).toBeInTheDocument();
+    expect(screen.getAllByTestId("IconEdit")).toHaveLength(1);
+    expect(screen.getAllByTestId("IconTrash")).toHaveLength(1);
+  });
+
+  it("editar manda PUT a /v3/debt-dptos/{id} con type y penalty_amount", async () => {
+    montar();
+    await screen.findByText("A-101");
+
+    fireEvent.click(screen.getByTestId("IconEdit"));
+
+    const monto = await screen.findByDisplayValue("350.00");
+    fireEvent.change(monto, { target: { name: "amount", value: "222.50" } });
+    const motivo = screen.getByLabelText(/Motivo del cambio/i);
+    fireEvent.change(motivo, {
+      target: { name: "obs", value: "Corrección de lectura" },
+    });
+
+    fireEvent.click(screen.getByText("Actualizar"));
+
+    await waitFor(() => expect(mutacion()).toBeTruthy());
+
+    expect(mutacion()).toMatchObject({
+      url: "/v3/debt-dptos/dd-uuid-1",
+      method: "PUT",
+    });
+    // 🔴 `type` y `penalty_amount`, uno por uno: sin el primero el back cae en
+    // NORMAL, sin el segundo responde 422 y el toast sale vacío.
+    expect(mutacion().data).toMatchObject({
+      id: "dd-uuid-1",
+      type: 1,
+      amount: "222.50",
+      penalty_amount: "0.00",
+      obs: "Corrección de lectura",
+    });
+    // Las llaves congeladas no se mandan: el back las descarta igual, pero
+    // mandarlas dice que la pantalla cree que puede mudar la deuda de lugar.
+    expect(mutacion().data).not.toHaveProperty("dpto_id");
+    expect(mutacion().data).not.toHaveProperty("year");
+    expect(mutacion().data).not.toHaveProperty("month");
+  });
+
+  it("eliminar manda DELETE a /v3/debt-dptos/{id}, no al grupo", async () => {
+    montar();
+    await screen.findByText("A-101");
+
+    fireEvent.click(screen.getByTestId("IconTrash"));
+    fireEvent.click(await screen.findByText("Eliminar"));
+
+    await waitFor(() => expect(mutacion()).toBeTruthy());
+
+    expect(mutacion()).toMatchObject({
+      url: "/v3/debt-dptos/dd-uuid-1",
+      method: "DELETE",
+    });
+    expect(mutacion().url).not.toContain("debt-groups");
+  });
+
+  /**
+   * 🔴 El rechazo por pagos vivos llega con HTTP 200 y `success: true`, con el
+   * texto del error adentro de `message`: `Mk/Controller::handleDeleteMessage`
+   * hace `isset($msg['status'])`, que es verdadero también cuando el status es
+   * `false`. Ese `success` mentiroso es CDT-49 y se arregla en el kernel, no
+   * acá. Lo que sí es de esta pantalla es que el texto del back NO se pierda:
+   * antes el detalle de compartidas lo tapaba con un "Deuda eliminada
+   * exitosamente" fijo, y el usuario leía lo contrario de lo que había pasado.
+   */
+  it("el rechazo del back por pagos registrados le llega al usuario con su texto", async () => {
+    const RECHAZO =
+      "No se puede eliminar esta deuda porque tiene pagos registrados. " +
+      "Primero anule o elimine los pagos.";
+
+    montar();
+    await screen.findByText("A-101");
+
+    request.mockResolvedValueOnce({
+      data: { success: true, data: true, message: RECHAZO },
+    });
+
+    fireEvent.click(screen.getByTestId("IconTrash"));
+    fireEvent.click(await screen.findByText("Eliminar"));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith(RECHAZO, expect.anything()),
+    );
+  });
+});

--- a/src/modulos/Expenses/RenderForm/RenderForm.tsx
+++ b/src/modulos/Expenses/RenderForm/RenderForm.tsx
@@ -47,14 +47,19 @@ const RenderForm = ({
     return errs;
   };
   const onSave = async () => {
-    let method = formState.id ? "PUT" : "POST";
     if (hasErrors(validate())) return;
     // TODO(advance-payments): selective expense creation moved to the payment form.
     // EXPENSE create now generates for the whole condominio (period-only);
     // the backend derives due_at/begin_at from the period and generates for all active units.
+    //
+    // 🔴 CDT-50: este formulario SÓLO crea. Antes armaba `PUT /debt-groups/{id}`
+    // cuando el item traía `id`; ese endpoint ya no existe (404 en `v3`, 405 en
+    // la ruta legacy) y el único camino que lo abría —el long press del listado
+    // de periodos— se sacó. Editar un periodo entero no es una operación: se
+    // edita la deuda de UNA unidad, desde el detalle del periodo.
     const { data: response } = await execute(
-      "/debt-groups" + (formState.id ? "/" + formState.id : ""),
-      method,
+      "/debt-groups",
+      "POST",
       {
         year: formState.year,
         month: formState.month,

--- a/src/modulos/Expenses/__tests__/CDT50NingunaAccionDeGrupo.test.tsx
+++ b/src/modulos/Expenses/__tests__/CDT50NingunaAccionDeGrupo.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * CDT-50 — ni el listado de periodos ni el de compartidas ofrecen editar o
+ * eliminar el GRUPO.
+ *
+ * ## 🔴 Qué se rompía
+ *
+ * Las dos pantallas escondían lápiz y tacho en escritorio (`hideActions`) pero
+ * le pasaban `onTabletRow` a la lista: en tablet/móvil ese render abre el long
+ * press de `useCrudUtils`, que pone lápiz y tacho en la barra y llama a
+ * `onEdit`/`onDel` de `useCrud` sobre `modulo: v3/debt-groups`. O sea
+ * `PUT`/`DELETE /v3/debt-groups/{id}` — los dos endpoints que la API de CDT-50
+ * eliminó (404 en `v3`, 405 en la ruta legacy).
+ *
+ * ## Qué mide este archivo
+ *
+ * Los dos props con los que `useCrud` puede llegar a una mutación desde la
+ * tabla, capturados de la `Table` real:
+ *
+ *  - `onButtonActions`: la columna de lápiz y tacho. `useCrud.tsx:2617` la
+ *    manda `undefined` sólo si `edit` **y** `del` están ocultas.
+ *  - `onTabletRow`: el render de tarjeta con long press.
+ *
+ * El mock de `Table` GUARDA los props, no los reenvía: acá se mide qué pasa la
+ * pantalla, no lo que la tabla hace con eso.
+ *
+ * ⚠️ Medido al escribir este archivo: `Table.tsx` tiene `const isMobile =
+ * false` fijo desde el commit 94338bc7 (2025-05-21, "remove useScreenSize
+ * hook"), así que `onTabletRow` HOY no se dibuja en ningún lado. El long press
+ * está muerto en los 12 archivos que lo pasan. Igual se saca de estas dos
+ * pantallas: si alguien devuelve el `isMobile` de verdad, éstas no pueden
+ * volver a ofrecer una acción que el back ya no atiende.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { AxiosContext } from "@/mk/contexts/AxiosInstanceProvider";
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: {
+      id: "u-1",
+      client_id: "c-1",
+      role: { abilities: "**c-1**" },
+      clients: [{ id: "c-1" }],
+    },
+    userCan: () => true,
+    showToast: vi.fn(),
+    store: {},
+    setStore: vi.fn(),
+  }),
+}));
+
+const tableProps: { current: any } = { current: undefined };
+vi.mock("@/mk/components/ui/Table/Table", () => ({
+  default: (props: any) => {
+    tableProps.current = props;
+    return <div data-testid="table-mock" />;
+  },
+}));
+
+import Expenses from "../Expenses";
+import SharedDebts from "@/modulos/DebtsManager/TabComponents/SharedDebts/SharedDebts";
+
+const request = vi.fn();
+
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as any;
+
+const respuesta = (fila: Record<string, any>) => ({
+  data: {
+    success: true,
+    data: [fila],
+    message: { total: 1 },
+    extraData: {},
+  },
+});
+
+const montar = (children: React.ReactNode) =>
+  render(
+    <AxiosContext.Provider
+      value={
+        {
+          contextInstance: { request },
+          waiting: 0,
+          setWaiting: vi.fn(),
+        } as any
+      }
+    >
+      {children}
+    </AxiosContext.Provider>,
+  );
+
+describe("CDT-50 · los listados de grupo no ofrecen editar ni eliminar", () => {
+  beforeEach(() => {
+    request.mockReset();
+    tableProps.current = undefined;
+  });
+
+  afterEach(() => cleanup());
+
+  it("periodos de expensas: sin columna de acciones y sin long press", async () => {
+    request.mockResolvedValue(
+      respuesta({ id: "2026-7", year: 2026, month: 7, asignados: [] }),
+    );
+
+    montar(<Expenses />);
+
+    await waitFor(() => expect(tableProps.current).toBeTruthy());
+    expect(tableProps.current.onButtonActions).toBeUndefined();
+    expect(tableProps.current.onTabletRow).toBeUndefined();
+  });
+
+  it("listado de compartidas: sin columna de acciones y sin long press", async () => {
+    request.mockResolvedValue(
+      respuesta({ id: "grupo-1", description: "Portón", asignados: [] }),
+    );
+
+    montar(
+      <SharedDebts
+        openView={false}
+        setOpenView={vi.fn()}
+        viewItem={null}
+        setViewItem={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(tableProps.current).toBeTruthy());
+    expect(tableProps.current.onButtonActions).toBeUndefined();
+    expect(tableProps.current.onTabletRow).toBeUndefined();
+  });
+
+  it("ninguna de las dos dispara una mutación contra /debt-groups", async () => {
+    request.mockResolvedValue(
+      respuesta({ id: "2026-7", year: 2026, month: 7, asignados: [] }),
+    );
+
+    montar(<Expenses />);
+    await waitFor(() => expect(tableProps.current).toBeTruthy());
+
+    const mutaciones = request.mock.calls
+      .map((c) => c[0])
+      .filter((c: any) => c.method === "PUT" || c.method === "DELETE");
+    expect(mutaciones).toEqual([]);
+  });
+});


### PR DESCRIPTION
Cierra el lado **admin** de **CDT-50**. 🔴 **Va junto con `condaty2025-api#263`**: esa rama saca los endpoints de grupo, así que este PR es el que evita que queden botones apuntando a un 404.

## El contrato nuevo (decisión del CTO)

Un grupo de deudas —**expensas y compartidas**— **sólo se crea**. Lo que se edita y se elimina es la **deuda individual**, y sólo si no tiene **ningún pago, ni parcial**.

## Qué se saca

- **Detalle de compartidas**: los botones "Editar" y "Eliminar" del grupo con todos sus handlers. **Eran los dos únicos vivos en escritorio.**
- **Listados de Expensas y de Compartidas**: el long press (`onTabletRow` + `useCrudUtils`) que abría lápiz y tacho de grupo en tablet/móvil. El de Compartidas no estaba en el alcance original: apareció al medir.
- La rama `PUT` de los dos `RenderForm` de grupo — el formulario sólo crea.
- El `onHideActions` de `Expenses.tsx`, que ya era código muerto (su único consumidor era un `onButtonActions` que nunca se montaba).

## Qué se agrega

Lápiz y tacho **por fila**, en la columna que `useCrud` monta cuando `edit`/`del` dejan de estar ocultas:

- **Expensas → periodo → detalle por unidad**
- **Deudas → Compartidas → detalle del reparto**

Van contra `PUT`/`DELETE` de `/v3/debt-dptos/{id}` con el `type` de la deuda. Para expensas se agrega `penalty_amount` al formulario, que el back exige (`required|numeric|min:0`); el `PUT` ignora `dpto_id`, `year`, `month`, `debt_id` y `shared_id`, que son llaves congeladas.

⚠️ **El formulario del detalle de expensas nunca fue alcanzable**: su `fields.form` se estrena con este cambio. Es lo primero a mirar en pantalla.

## 🔴 Hallazgo: el modo móvil de las tablas está apagado hace más de un año

`Table.tsx:495` y `:986` tienen **`const isMobile = false`** escrito a mano (desde `94338bc7`, 2025-05-21, *"remove useScreenSize hook"*), y es lo que gobierna `onTabletRow` (`:1299`) y `onRenderCard` (`:632`).

O sea: **el long press ya estaba muerto en los 12 archivos / 10 módulos que lo declaran**, y con él el render de tarjetas en móvil. Se sacó igual de las dos pantallas de este ticket — si alguien devuelve el `isMobile` de verdad, que no vuelvan a ofrecer lo que el back ya no atiende. **El `isMobile` fijo va en ticket propio.**

⚠️ Efecto visible de sacar `useCrudUtils`: desaparece la **lupa del header** en esos dos listados. Estaba cableada a `onSearch: () => {}` —no hacía nada— y las dos pantallas tienen la búsqueda oculta.

⚠️ Anotado y **no tocado**: `AllDebts` e `IndividualDebts` tienen un `PUT` a `debt-groups` hoy inalcanzable (esconden las acciones, el long press está muerto, y su `onClickDetail` es un no-op que pisa el `onView` de `useCrud`, así que el detalle no se abre nunca). **Son dos pestañas sin ninguna acción alcanzable**: ticket propio.

## Tests

**114 archivos / 755 tests** en la suite (baseline 111/743), **78 verdes** en los módulos tocados. `tsc`: **23 = 23**. Tres archivos nuevos, y los tres corren `useCrud` de verdad y miden **el request que sale** — ninguno afirma sobre texto de código.

Verificados por reinyección; cada una en rojo con su mensaje literal:

| reinyección | rojos |
|---|---|
| volver a ocultar `edit`/`del` en el detalle de expensas | 4 — `Unable to find an element by: [data-testid="IconEdit"]` |
| sacar `type` del `PUT` | 1 — `to match object { id: 'dd-uuid-1', type: 1, … }` |
| sacar `penalty_amount` del `PUT` | 1 |
| reponer los botones de grupo | 1 + 2 colaterales |
| reponer `onTabletRow` | 1 por pantalla |

## Review

`gentle-ai` **aprobado** — recibo `review-5c3e7399b480c557`, riesgo medio, cero blockers, sin ciclo de corrección.

Su único WARNING decía que la regla `positive` sobre la multa podía rechazar el 0 y trabar el caso común. **Refutado con evidencia**: `Rules.tsx:183` es `value < 0` (el cero pasa) y `required` trata el `0` como válido explícitamente. El test verde manda `penalty_amount: "0.00"` y afirma que viaja en el `PUT`.

## Verificación en pantalla, pendiente

1. **Expensas → detalle de un periodo**: que aparezca la columna de acciones y que el modal muestre Monto, Multa y Motivo; que guardar no tire 422.
2. **Compartidas → detalle**: que ya no estén los botones de arriba a la derecha y que el bloque de tarjetas del resumen no quede descolocado (se sacó la segunda columna de un flex).
3. Borrar una deuda **con pago**: el mensaje del back se ve, pero el toast sale **verde** — es el `success: true` de CDT-49, no se arregla acá.
