### PR TITLE
fix(listados): el scroll infinito ya no salta al inicio al traer más filas (CDT-53)

### DIFF
--- a/src/mk/components/ui/Table/Table.tsx
+++ b/src/mk/components/ui/Table/Table.tsx
@@ -18,7 +18,6 @@ import styles from "./styles.module.css";
 import { shouldIgnoreValueTranslationContext } from "@/i18n/translationGuards";
 import { formatNumber } from "@/mk/utils/numbers";
 import useScrollbarWidth from "@/mk/hooks/useScrollbarWidth";
-import { useAuth } from "@/mk/contexts/AuthProvider";
 import ContextMenu, {
   ContextMenuActionParams,
   ContextMenuItem,
@@ -62,7 +61,6 @@ type PropsType = {
     sortabled?: boolean;
     onHide?: () => boolean;
   }[];
-  id?: string;
   data: any;
   footer?: any;
   sumarize?: boolean;
@@ -463,7 +461,6 @@ const Row = memo(function Row({
 
 const Table = ({
   header = [],
-  id = "0",
   data,
   footer,
   sumarize = false,
@@ -666,7 +663,6 @@ const Table = ({
               setScrollbarWidth={setScrollbarWidth}
               onRenderBody={onRenderBody}
               extraData={extraData}
-              id={id}
               manualWidths={manualWidths}
               measuredWidths={measuredWidths}
               fillColumnIndex={fillColumnIndex}
@@ -942,7 +938,6 @@ const Body = ({
   onRenderBody,
   extraData,
   onRenderCard,
-  id,
   manualWidths,
   measuredWidths,
   fillColumnIndex,
@@ -968,7 +963,6 @@ const Body = ({
   onRenderBody?: null | ((row: any, i: number, onClick: Function) => any);
   extraData?: any;
   onRenderCard?: any;
-  id?: string;
   manualWidths: Record<number, number>;
   measuredWidths?: Record<number, string>;
   fillColumnIndex: number;
@@ -982,7 +976,6 @@ const Body = ({
   skeletonRowCount?: number;
   rowContextMenu?: TableRowContextMenuConfig;
 }) => {
-  const { store, setStore } = useAuth();
   const isMobile = false;
   const divRef: any = useRef(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -1062,26 +1055,12 @@ const Body = ({
   useEffect(() => {
     if (setScrollbarWidth) setScrollbarWidth(scrollWidth);
   }, [scrollWidth]);
-  useLayoutEffect(() => {
-    if (store && id) {
-      const scrollTop = store["scrollTop" + id];
-
-      if (scrollTop && divRef.current) divRef.current.scrollTop = scrollTop;
-    }
-  }, []);
-
   // Memoizada porque baja como prop a cada fila: como función suelta, su
   // identidad nueva por render invalidaba el memo de TODAS las filas y la
   // extracción del componente `Row` no servía de nada.
   const _onRowClick = useCallback((e: any) => {
     closeContextMenu();
-    if (onRowClick) {
-      // const scrollTop = divRef?.current?.scrollTop;
-      // if (scrollTop !== undefined && store && id) {
-      //   setStore({ ["scrollTop" + id]: scrollTop });
-      // }
-      onRowClick(e);
-    }
+    if (onRowClick) onRowClick(e);
   }, [closeContextMenu, onRowClick]);
 
   const resolveScrollContainer = useCallback(() => {

--- a/src/mk/hooks/useCrud/README.md
+++ b/src/mk/hooks/useCrud/README.md
@@ -435,6 +435,30 @@ if (userCan('USER', 'D')) { // D = Delete
 - Implement proper loading states
 - Use pagination for large datasets
 
+### 2.1 Scroll infinito dentro de un `<LoadingScreen>` (CDT-53)
+
+Con `paramsInitial.perPage > 0` el hook usa scroll infinito y pide las páginas
+solo. Ese pedido decide por sí mismo si mueve el contador global `waiting` del
+`AxiosInstanceProvider` —el que `LoadingScreen` usa para tapar a sus hijos con
+un esqueleto—, y el criterio es la PÁGINA:
+
+| situación                                | `page` | esqueleto |
+|------------------------------------------|--------|-----------|
+| carga inicial                            | 1      | **sí**    |
+| reset por filtro, búsqueda u orden        | 1      | **sí**    |
+| append del scroll infinito                | > 1    | **no**    |
+
+🔴 Un append que moviera `waiting` desmontaría el contenedor scrolleable y lo
+remontaría con `scrollTop = 0`: la lista salta al inicio sola y con muchas filas
+nunca se llega al final. Y al revés, apagarlo también en los resets dejaría al
+usuario mirando las filas del filtro anterior como si fueran el resultado del
+nuevo.
+
+⚠️ El "cargando más" del pie de la lista NO sale de acá: lo dibuja
+`isAppendingList`, que es del hook. Un módulo no necesita declarar `noWaiting`
+para arreglar el salto de scroll — ya está resuelto en el hook, y declararlo
+apagaría también el esqueleto de la carga inicial y el de los filtros.
+
 ### 3. User Experience
 - Provide meaningful labels and messages
 - Use custom renderers for complex UI requirements

--- a/src/mk/hooks/useCrud/__tests__/useCrudScrollInfinitoNoDesmontaLaLista.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrudScrollInfinitoNoDesmontaLaLista.test.tsx
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, act, waitFor, screen } from "@testing-library/react";
+import React from "react";
+
+/**
+ * CDT-53 — el scroll de la lista no puede volver al inicio solo.
+ *
+ * ## 🔴 Qué se rompió (medido el 2026-08-15, detalle de un período de Expensas)
+ *
+ * El detalle usa scroll infinito (`perPage: 20`) y envuelve la lista en un
+ * `<LoadingScreen>`. `LoadingScreen` no mira el estado del listado: mira el
+ * contador GLOBAL `waiting` del `AxiosInstanceProvider`, y con `waiting > 0`
+ * reemplaza a sus hijos por un esqueleto.
+ *
+ * Cada página del scroll infinito salía por `execute(..., noWaiting)` con el
+ * `noWaiting` del módulo, que en esta pantalla no está declarado. O sea que la
+ * página 2 incrementaba `waiting`, `LoadingScreen` tapaba la lista con el
+ * esqueleto, el contenedor scrolleable se DESMONTABA, y al volver la respuesta
+ * se remontaba con `scrollTop = 0`. Con muchas unidades nunca se llegaba al
+ * final: cada intento de bajar rebotaba al principio.
+ *
+ * ## Las tres situaciones que este test separa
+ *
+ * El corte del arreglo es por PÁGINA, y por eso hay tres casos y no dos:
+ *
+ * | situación                                   | página | esqueleto |
+ * |---------------------------------------------|--------|-----------|
+ * | carga inicial                               | 1      | **sí**    |
+ * | reset por filtro / búsqueda / orden         | 1      | **sí**    |
+ * | append del scroll infinito                  | > 1    | **no**    |
+ *
+ * 🔴 El segundo caso es el que hace que el arreglo se pueda pasar de rosca. Si
+ * se apaga el indicador de más, el usuario filtra con la lista scrolleada y se
+ * queda mirando las filas VIEJAS como si fueran el resultado del filtro nuevo:
+ * un bug de scroll cambiado por uno de datos mentirosos, que es peor.
+ *
+ * ## Por qué este test monta la cadena entera
+ *
+ * Se usan el `AxiosInstanceProvider`, el `useAxios` y el `LoadingScreen` de
+ * verdad, y sólo se falsea el `axios` de abajo de todo. Afirmar que `useCrud`
+ * pasa cierta bandera sería afirmar la implementación; lo que rompía era el
+ * DOM. Acá se mide el DOM: que el nodo de la lista siga siendo **el mismo
+ * nodo** —no uno remontado, que es lo que pierde el `scrollTop`.
+ */
+
+const request = vi.fn();
+
+vi.mock("axios", () => {
+  const instance: any = {
+    request: (...args: any[]) => request(...args),
+    defaults: {},
+  };
+  const fake: any = { create: () => instance, request: instance.request };
+  return { default: fake, ...fake };
+});
+
+vi.mock("@/mk/components/ui/Table/Table", () => ({
+  default: () => <div data-testid="table-mock" />,
+}));
+vi.mock("@/mk/components/ui/Pagination/Pagination", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/hooks/useCrud/FormElement", () => ({ default: () => null }));
+vi.mock("@/mk/components/forms/DataSearch/DataSearch", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/data/ImportDataModal/ImportDataModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/DetailModal/DetailModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/NewModal/NewModal", () => ({ default: () => null }));
+vi.mock("@/mk/components/forms/FloatButton/FloatButton", () => ({
+  default: () => null,
+}));
+vi.mock("@/components/NoData/EmptyData", () => ({ default: () => null }));
+vi.mock("@/mk/hooks/useMediaQuery", () => ({ default: () => false }));
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) mocked[key] = () => null;
+  return mocked;
+});
+
+import useCrud, { ModCrudType } from "../useCrud";
+import AxiosInstanceProvider from "@/mk/contexts/AxiosInstanceProvider";
+import LoadingScreen from "@/mk/components/ui/LoadingScreen/LoadingScreen";
+
+/** `useCrud` normaliza el `perPage: 20` del módulo a su lote mínimo. */
+const LOTE = 40;
+const TOTAL = 500;
+
+const filas = (desde: number, cuantas: number) =>
+  Array.from({ length: cuantas }, (_, i) => ({
+    id: `u-${desde + i}`,
+    name: `Unidad ${desde + i}`,
+  }));
+
+const mod: ModCrudType = {
+  modulo: "debt-dptos",
+  singular: "unidad",
+  plural: "unidades",
+  permiso: "debts",
+} as ModCrudType;
+
+const fields = {
+  id: { rules: [], api: "e" },
+  name: { rules: [], api: "ae", label: "Nombre", list: {} },
+};
+
+/** Los requests quedan EN VUELO hasta que el test los suelta a mano. */
+type EnVuelo = { page: number; resolver: (rows?: any[]) => void };
+let enVuelo: EnVuelo[] = [];
+
+const soltarUltimo = async (rows?: any[]) => {
+  const pendiente = enVuelo.pop();
+  if (!pendiente) throw new Error("No hay ningún request en vuelo que soltar.");
+  await act(async () => {
+    pendiente.resolver(rows);
+    await Promise.resolve();
+  });
+};
+
+/**
+ * La pantalla del ticket, en miniatura: scroll infinito adentro de un
+ * `LoadingScreen` sin `loaded` — igual que `ExpensesDetailsView`.
+ */
+const montar = () => {
+  const runtime: { current: any } = { current: null };
+
+  const Pantalla = () => {
+    const crud = useCrud({
+      paramsInitial: { page: 1, perPage: 20, fullType: "L", searchBy: "" },
+      mod,
+      fields,
+    });
+    runtime.current = crud;
+    return (
+      <LoadingScreen>
+        <div data-testid="lista">{crud.data?.data?.length ?? 0}</div>
+      </LoadingScreen>
+    );
+  };
+
+  render(
+    <AxiosInstanceProvider>
+      <Pantalla />
+    </AxiosInstanceProvider>,
+  );
+
+  return runtime;
+};
+
+describe("CDT-53: el scroll infinito no desmonta la lista al traer más filas", () => {
+  beforeEach(() => {
+    enVuelo = [];
+    request.mockReset();
+    request.mockImplementation((config: any) => {
+      const page = Number(
+        new URLSearchParams(String(config?.url).split("?")[1] || "").get(
+          "page",
+        ) || 1,
+      );
+      return new Promise((resolve) => {
+        enVuelo.push({
+          page,
+          resolver: (rows?: any[]) =>
+            resolve({
+              data: {
+                data: rows ?? filas((page - 1) * LOTE + 1, LOTE),
+                message: { total: TOTAL },
+              },
+            }),
+        });
+      });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("la carga inicial SÍ muestra el esqueleto, y el append NO desmonta la lista", async () => {
+    const runtime = montar();
+
+    // 1) Carga inicial (`page: 1`): todavía no hay nada que mostrar, así que
+    //    el esqueleto tiene que tapar a los hijos.
+    await waitFor(() => expect(enVuelo).toHaveLength(1));
+    expect(
+      screen.queryByTestId("lista"),
+      "La carga inicial dejó de mostrar el esqueleto: la pantalla arranca " +
+        "vacía y sin ninguna señal de que está cargando.",
+    ).toBeNull();
+
+    await soltarUltimo();
+    await waitFor(() => expect(screen.queryByTestId("lista")).not.toBeNull());
+
+    const nodoAntes = screen.getByTestId("lista");
+    expect(nodoAntes.textContent).toBe(String(LOTE));
+
+    // 2) Append (`page: 2`): el usuario llegó al fondo y se pide más.
+    await act(async () => {
+      runtime.current.onLoadMore();
+    });
+    await waitFor(() => expect(enVuelo).toHaveLength(1));
+    expect(enVuelo[0].page).toBe(2);
+
+    // 🔴 Acá estaba el bug: con el request de la página 2 EN VUELO, el
+    // contador global subía y `LoadingScreen` reemplazaba la lista por el
+    // esqueleto.
+    const nodoDurante = screen.queryByTestId("lista");
+    expect(
+      nodoDurante,
+      "Mientras se pedía la página 2, la lista se reemplazó por el esqueleto: " +
+        "el contenedor scrolleable se desmonta y al volver se remonta con " +
+        "scrollTop = 0. Es el salto al inicio del ticket.",
+    ).not.toBeNull();
+
+    // Y no alcanza con que HAYA una lista: tiene que ser LA MISMA. Un nodo
+    // nuevo es un remonte, y un remonte es el scroll perdido.
+    expect(
+      nodoDurante,
+      "La lista se remontó durante el append: es un nodo del DOM distinto, " +
+        "así que perdió el scrollTop aunque en pantalla se vea igual.",
+    ).toBe(nodoAntes);
+
+    await soltarUltimo();
+    await waitFor(() =>
+      expect(screen.getByTestId("lista").textContent).toBe(String(LOTE * 2)),
+    );
+    expect(screen.getByTestId("lista")).toBe(nodoAntes);
+  });
+
+  it("el reset por filtro SÍ vuelve a mostrar el esqueleto", async () => {
+    const runtime = montar();
+
+    await waitFor(() => expect(enVuelo).toHaveLength(1));
+    await soltarUltimo();
+    await waitFor(() => expect(screen.queryByTestId("lista")).not.toBeNull());
+
+    // Se scrollea: ya hay dos páginas cargadas.
+    await act(async () => {
+      runtime.current.onLoadMore();
+    });
+    await waitFor(() => expect(enVuelo).toHaveLength(1));
+    await soltarUltimo();
+    await waitFor(() =>
+      expect(screen.getByTestId("lista").textContent).toBe(String(LOTE * 2)),
+    );
+
+    // 3) Reset por filtro: `page` vuelve a 1 y las 80 filas de pantalla ya no
+    //    corresponden a lo que el usuario pidió.
+    await act(async () => {
+      runtime.current.onFilter("status", "1");
+    });
+
+    await waitFor(() => expect(enVuelo).toHaveLength(1));
+    expect(enVuelo[0].page).toBe(1);
+
+    // 🔴 Esto es lo que protege de que el arreglo se pase de rosca. Sin el
+    // esqueleto, el usuario ve las filas del filtro VIEJO como si fueran el
+    // resultado del nuevo, sin un solo aviso.
+    expect(
+      screen.queryByTestId("lista"),
+      "El filtro dejó de mostrar el esqueleto: la lista sigue en pantalla con " +
+        "las filas del filtro anterior mientras llega la respuesta nueva. " +
+        "Datos mentirosos, que es peor que el salto de scroll.",
+    ).toBeNull();
+
+    await soltarUltimo(filas(1, 3));
+    await waitFor(() => expect(screen.getByTestId("lista").textContent).toBe("3"));
+  });
+
+  it("el reset por búsqueda y el reset por orden también muestran el esqueleto", async () => {
+    const runtime = montar();
+
+    await waitFor(() => expect(enVuelo).toHaveLength(1));
+    await soltarUltimo();
+    await waitFor(() => expect(screen.queryByTestId("lista")).not.toBeNull());
+
+    for (const [nombre, disparar] of [
+      ["búsqueda", () => runtime.current.onSearch("torre b")],
+      ["orden", () => runtime.current.onSort("name", true)],
+    ] as const) {
+      await act(async () => {
+        disparar();
+      });
+
+      await waitFor(() => expect(enVuelo).toHaveLength(1));
+      expect(enVuelo[0].page, `El reset por ${nombre} no volvió a la página 1.`)
+        .toBe(1);
+      expect(
+        screen.queryByTestId("lista"),
+        `El reset por ${nombre} dejó de mostrar el esqueleto: quedan las filas ` +
+          `viejas en pantalla mientras llega la respuesta nueva.`,
+      ).toBeNull();
+
+      await soltarUltimo();
+      await waitFor(() => expect(screen.queryByTestId("lista")).not.toBeNull());
+    }
+  });
+});

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -627,12 +627,39 @@ const useCrud = ({
       setManualError("");
       setManualLoaded(false);
 
+      /**
+       * 🔴 CDT-53: un APPEND del scroll infinito no es una carga de pantalla.
+       *
+       * El contador global `waiting` del `AxiosInstanceProvider` es lo que mira
+       * `LoadingScreen`: con `waiting > 0` reemplaza a sus hijos por un
+       * esqueleto. Si la página N+1 lo incrementa, el contenedor scrolleable se
+       * DESMONTA mientras el request vuela y se remonta con `scrollTop = 0`:
+       * la lista salta al inicio sola y, con muchas filas, nunca se llega al
+       * final. Medido en el detalle de un período de Expensas
+       * (`ExpensesDetailsView`, `perPage: 20` dentro de un `<LoadingScreen>`).
+       *
+       * ⚠️ El corte es por PÁGINA, no por módulo, y esa es toda la gracia:
+       *
+       * - carga inicial  → `page === 1` → sí mueve `waiting` → esqueleto.
+       * - reset por filtro, búsqueda u orden → `beginListReset` vuelve a
+       *   `page = 1` → sí mueve `waiting` → esqueleto. 🔴 Sin esto el usuario
+       *   filtra con la lista scrolleada y se queda mirando las filas VIEJAS
+       *   como si fueran el resultado del filtro nuevo: un bug de scroll
+       *   cambiado por uno de datos mentirosos, que es peor.
+       * - append (`page > 1`) → NO lo mueve → la lista no se desmonta.
+       *
+       * El "cargando más" del pie de la lista no depende de esto: lo dibuja
+       * `isAppendingList`, que es del hook y no del contador global.
+       */
+      const requestedPage = Number(nextRequestParams?.page || 1);
+      const esAppend = requestedPage > 1;
+
       const result = await execute(
         "/" + mod.modulo,
         "GET",
         nextRequestParams,
         false,
-        noWaiting,
+        noWaiting || esAppend,
       );
 
       if (requestId !== latestRequestIdRef.current) {
@@ -647,7 +674,6 @@ const useCrud = ({
       // viejos apenas `loadMoreRows` cambia la página — antes de que el
       // request responda —, así que cualquier flag que se mire o se escriba
       // ahí llega tarde o confirma páginas que nunca respondieron.
-      const requestedPage = Number(nextRequestParams?.page || 1);
       if (result.error) {
         // Sólo `loadMoreRows` pide páginas > 1 (el inicio y los resets van
         // siempre a la 1): un fallo con página > 1 es un "cargar más" perdido.
@@ -2627,7 +2653,6 @@ const useCrud = ({
                     extraData={runtime.extraData}
                     onSort={hasSortableColumns ? runtime.onSort : undefined}
                     sortCol={runtime.sortCol}
-                    id={runtime.mod?.modulo}
                     useInfiniteScroll={runtime.useInfiniteList}
                     hasMore={runtime.useInfiniteList && runtime.listHasMore}
                     isLoadingMore={runtime.isAppendingList}


### PR DESCRIPTION
Cierra **CDT-53**: en el detalle de un período de Expensas, el scroll de la lista de unidades volvía al inicio solo, y con muchas unidades nunca se llegaba al final.

## Qué pasaba

La lista usa scroll infinito con `perPage: 20`. Cada pedido de página nueva pasaba por `execute(..., mod?.noWaiting)` y, como esta pantalla no declara `noWaiting`, **incrementaba el contador global `waiting`** del `AxiosInstanceProvider`.

Y la lista está envuelta en `<LoadingScreen>`, que con `waiting > 0` **reemplaza a sus hijos por un esqueleto**. O sea: mientras la página N+1 estaba en vuelo, el contenedor scrolleable **se desmontaba**, y al volver la respuesta se remontaba con `scrollTop = 0`.

Eso es exactamente lo que reportó el tester: "recarga la vista y la barra vuelve arriba". Con 400+ unidades no se llega nunca al final, porque cada intento de traer más te devuelve al principio.

## El arreglo

Una línea, en la raíz (`useCrud`): **un pedido con `page > 1` es un append, no una carga de pantalla**, y no mueve el indicador global.

🔴 **El corte es por PÁGINA, no por módulo, y ahí está toda la gracia:**

| situación | ¿esqueleto? | por qué |
|---|---|---|
| carga inicial (`page === 1`) | **sí** | la pantalla arranca vacía; sin esqueleto no hay señal de que está cargando |
| reset por filtro, búsqueda u orden | **sí** | `beginListReset` vuelve a `page = 1` |
| append del scroll (`page > 1`) | **no** | la lista no se desmonta |

El segundo caso es el que importa: **sin él, el usuario filtra con la lista scrolleada y se queda mirando las filas viejas** como si fueran el resultado del filtro nuevo. Sería cambiar un bug de scroll por uno de datos mentirosos, que es peor. Por eso tiene su propio test.

El "cargando más" del pie no depende de esto: lo dibuja `isAppendingList`, que es del hook y no del contador global.

## El test, y por qué es un archivo nuevo

No se sumó a `useCrudScrollInfinitoNoPierdePaginas` ni a `useCrudScrollInfinitoNoSeCuelga` **a propósito**: esos dos mockean `@/mk/hooks/useAxios`, y con `execute` falso el contador global no existe — **no podrían ver este bug**. El nuevo monta la cadena real (`AxiosInstanceProvider` + `useAxios` + `LoadingScreen`) y falsea sólo `axios`.

Y no afirma una bandera: afirma que **el nodo de la lista sigue siendo el mismo objeto del DOM**, porque un nodo nuevo es un remonte, y un remonte es el scroll perdido.

Verificado reinyectando **las dos direcciones**:

```
× volver el append a noWaiting:
Mientras se pedía la página 2, la lista se reemplazó por el esqueleto: el
contenedor scrolleable se desmonta y al volver se remonta con scrollTop = 0.

× apagar el indicador para TODAS las páginas (pasarse de rosca):
El filtro dejó de mostrar el esqueleto: la lista sigue en pantalla con las filas
del filtro anterior mientras llega la respuesta nueva. Datos mentirosos, que es
peor que el salto de scroll.
```

## De paso: código muerto borrado

El rescate de posición del scroll (`store["scrollTop"+id]`) estaba **muerto**: el `useLayoutEffect` que lo lee existía, pero la escritura estaba comentada. `rg scrollTop src/` da **cero escritores** en todo el repo. Con el arreglo de raíz ya no hace falta —la lista no se desmonta, así que no hay posición que restaurar—, así que se fue, y con él el prop `id` de `Table` y un `useAuth()` que sólo existían para alimentarlo.

## Alcance verificado

`ExpensesDetailsView` es **la única** pantalla afectada. El criterio no es "importa `LoadingScreen`" sino **`perPage > 0` + envolver la lista**: `Defaulters` (Morosos) declara `perPage: -1`, trae todo en un pedido y **nunca pide página 2**, así que no está afectado y **no se tocó**.

## Verificación

- Suite completa: **116 archivos, 788 tests, todos verdes**.
- ⚠️ El `Errors: 1` es **preexistente y ajeno**: `Surveys.test.tsx` levanta InstantDB con un `appId` que no es uuid en el entorno de test. Sale en `dev` igual y no está en este diff.

## Qué mirar al probarlo

**Expensas → detalle de un período → lista de unidades**, en un condominio con más de 40 unidades:

1. Bajar hasta el fondo trae más filas **sin que la lista parpadee ni salte al inicio**, y se llega hasta la última.
2. El contraste, en la misma pantalla: **aplicar un filtro o buscar sí tiene que mostrar el esqueleto**, no las filas viejas.
3. Por el borrado en `Table` (que es compartido): en cualquier listado con click en fila, que el click siga navegando igual.
