### PR TITLE
La pantalla de permisos operativos por vínculo

### DIFF
--- a/src/modulos/Config/DptoConfig/DptoConfig.module.css
+++ b/src/modulos/Config/DptoConfig/DptoConfig.module.css
@@ -635,6 +635,36 @@
 }
 
 @media (max-width: 860px) {
+  /* La matriz colapsa a una fila por vínculo: la cabecera desaparece y cada
+     acción muestra su propia etiqueta. Sin esto, cinco columnas de 112px
+     fuerzan scroll horizontal en el celular del administrador. */
+  .permissionMatrix {
+    overflow-x: visible;
+  }
+
+  .permissionMatrixHeader {
+    display: none;
+  }
+
+  .permissionMatrixRow {
+    grid-template-columns: 1fr;
+    min-width: 0;
+  }
+
+  .permissionRoleCell {
+    padding-bottom: 8px;
+  }
+
+  .permissionActionCell {
+    justify-content: space-between;
+    border-top: 1px solid var(--cModalBorder);
+    padding-block: 10px;
+  }
+
+  .permissionMobileLabel {
+    display: inline;
+  }
+
   .profilePreviewRow {
     margin-top: 36px;
     padding-inline: 12px;
@@ -681,4 +711,74 @@
   .printLogoActions {
     align-items: flex-start;
   }
+}
+
+/* Matriz de permisos operativos: 6 vínculos x 4 acciones. */
+.permissionMatrix {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--cModalBorder);
+  border-radius: 14px;
+  background-color: color-mix(
+    in srgb,
+    var(--cModalSurfaceRaised) 64%,
+    transparent
+  );
+}
+.permissionMatrixRow {
+  display: grid;
+  grid-template-columns: minmax(210px, 1.2fr) repeat(4, minmax(112px, 0.7fr));
+  min-width: 660px;
+  border-bottom: 1px solid var(--cModalBorder);
+}
+.permissionMatrixRow:last-child {
+  border-bottom: 0;
+}
+.permissionMatrixHeader {
+  color: var(--cWhiteV1);
+  font-size: var(--body-xs-size);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+}
+.permissionMatrixHeader > div,
+.permissionRoleCell,
+.permissionActionCell {
+  padding: 12px;
+}
+.permissionMatrixHeader > div {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.permissionMatrixHeader > div:first-child {
+  justify-content: flex-start;
+}
+.permissionRoleCell {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  min-width: 0;
+}
+.permissionRoleName {
+  color: var(--cWhite);
+  font-size: var(--body-sm-size);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.25;
+}
+.permissionRoleDescription {
+  color: var(--cWhiteV1);
+  font-size: var(--body-xs-size);
+  line-height: 1.35;
+}
+.permissionActionCell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+.permissionMobileLabel {
+  display: none;
+  color: var(--cWhiteV1);
+  font-size: var(--body-sm-size);
 }

--- a/src/modulos/Config/DptoConfig/DptoConfig.tsx
+++ b/src/modulos/Config/DptoConfig/DptoConfig.tsx
@@ -40,6 +40,14 @@ const paymentMethodOptions = [
 type PaymentDebtType = (typeof paymentDebtTypes)[number]["id"];
 type PaymentMethod = (typeof paymentMethodOptions)[number]["id"];
 
+import {
+  normalizeOperationalPermissionsConfig,
+  operationalActionOptions,
+  operationalRoleOptions,
+  type OperationalAction,
+  type OperationalRole,
+} from "./operationalPermissions";
+
 const normalizePaymentMethodsConfig = (value: any) => {
   const parsed =
     typeof value === "string"
@@ -128,6 +136,10 @@ export const createFormState = (client_config: Record<string, any>) => ({
   payment_methods_config: normalizePaymentMethodsConfig(
     client_config?.payment_methods_config,
   ),
+  operational_permissions_config: normalizeOperationalPermissionsConfig(
+    client_config?.operational_permissions_config,
+    client_config,
+  ),
   payment_whatsapp_phone: client_config?.payment_whatsapp_phone || "",
   /**
    * 🔴 `?? 0` y no `|| 0`: son distintos y acá importa.
@@ -149,6 +161,9 @@ export const getComparableState = (formState: Record<string, any>) => ({
   url_banner: getSingleUrl(formState.url_banner),
   payment_methods_config: normalizePaymentMethodsConfig(
     formState.payment_methods_config,
+  ),
+  operational_permissions_config: normalizeOperationalPermissionsConfig(
+    formState.operational_permissions_config,
   ),
   payment_time_limit: formState.bookingRequiresPayment
     ? formState.payment_time_limit || ""
@@ -245,6 +260,30 @@ const DptoConfig = ({
       [name]: value,
     }));
   };
+
+  /**
+   * Un switch de la matriz. Se guarda como booleano en el JSON, que es como
+   * está escrito en los condominios que ya lo tienen cargado.
+   */
+  const handleOperationalPermissionSwitch =
+    (role: OperationalRole, action: OperationalAction) =>
+    ({ target: { value } }: any) => {
+      const isEnabled = value === "Y";
+
+      setFormState((prev: any) => {
+        const currentConfig = normalizeOperationalPermissionsConfig(
+          prev.operational_permissions_config,
+        );
+
+        return {
+          ...prev,
+          operational_permissions_config: {
+            ...currentConfig,
+            [role]: { ...currentConfig[role], [action]: isEnabled },
+          },
+        };
+      });
+    };
 
   const handleSwitchChange = ({ target: { name, value } }: any) => {
     if (name === "bookingRequiresPayment") {
@@ -583,6 +622,9 @@ const DptoConfig = ({
   const condoTypeLabel =
     condoTypeOptions.find((option) => option.id === formState.type)?.name ||
     "Condominio";
+  const operationalPermissionsConfig = normalizeOperationalPermissionsConfig(
+    formState.operational_permissions_config,
+  );
   const paymentMethodsConfig = normalizePaymentMethodsConfig(
     formState.payment_methods_config,
   );
@@ -1085,6 +1127,71 @@ const DptoConfig = ({
                   disabled={!editMode}
                 />
               </div>
+
+                <div className={styles.sectionDivider} />
+
+                <div className={styles.cardHeader}>
+                  <p className={styles.textTitle}>
+                    Permisos operativos por vínculo
+                  </p>
+                  <p className={styles.textSubtitle}>
+                    Controla qué puede hacer cada perfil y sus dependientes en
+                    la app y en guardia.
+                  </p>
+                </div>
+
+                <div className={styles.permissionMatrix}>
+                  <div
+                    className={`${styles.permissionMatrixRow} ${styles.permissionMatrixHeader}`}
+                  >
+                    <div>Vínculo</div>
+                    {operationalActionOptions.map((action) => (
+                      <div key={action.id}>{action.name}</div>
+                    ))}
+                  </div>
+
+                  {operationalRoleOptions.map((role) => (
+                    <div className={styles.permissionMatrixRow} key={role.id}>
+                      <div className={styles.permissionRoleCell}>
+                        <span className={styles.permissionRoleName}>
+                          {role.name}
+                        </span>
+                        <span className={styles.permissionRoleDescription}>
+                          {role.description}
+                        </span>
+                      </div>
+
+                      {operationalActionOptions.map((action) => (
+                        <div
+                          className={styles.permissionActionCell}
+                          key={`${role.id}-${action.id}`}
+                        >
+                          <span className={styles.permissionMobileLabel}>
+                            {action.name}
+                          </span>
+                          <Switch
+                            name={`${role.id}_${action.id}`}
+                            label=""
+                            value={
+                              operationalPermissionsConfig[role.id]?.[action.id]
+                                ? "Y"
+                                : "N"
+                            }
+                            onChange={handleOperationalPermissionSwitch(
+                              role.id,
+                              action.id,
+                            )}
+                            optionValue={["Y", "N"]}
+                            checked={Boolean(
+                              operationalPermissionsConfig[role.id]?.[action.id],
+                            )}
+                            disabled={!editMode}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </section>

--- a/src/modulos/Config/DptoConfig/__tests__/operationalPermissions.test.ts
+++ b/src/modulos/Config/DptoConfig/__tests__/operationalPermissions.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultOperationalPermissionsConfig,
+  isPermisoOtorgado,
+  normalizeOperationalPermissionsConfig,
+} from "../operationalPermissions";
+
+describe("isPermisoOtorgado", () => {
+  // 🔴 Las cuatro columnas `owner_can_*_without_residence` son enums numéricos
+  // desde 1: 1 = DENIED, 2 = GRANTED. La versión de producción de esta pantalla
+  // las lee con `Number(value) === 1`, que con esta numeración es el caso
+  // DENEGADO — mostraría habilitado justo lo que el condominio niega.
+  it("lee 2 como otorgado y 1 como denegado", () => {
+    expect(isPermisoOtorgado(2)).toBe(true);
+    expect(isPermisoOtorgado("2")).toBe(true);
+    expect(isPermisoOtorgado(1)).toBe(false);
+    expect(isPermisoOtorgado("1")).toBe(false);
+  });
+
+  it("sigue aceptando las formas viejas que puede traer una respuesta anterior", () => {
+    expect(isPermisoOtorgado(true)).toBe(true);
+    expect(isPermisoOtorgado("Y")).toBe(true);
+  });
+
+  it("un dato ausente o basura no otorga", () => {
+    expect(isPermisoOtorgado(undefined)).toBe(false);
+    expect(isPermisoOtorgado(null)).toBe(false);
+    expect(isPermisoOtorgado(0)).toBe(false);
+    expect(isPermisoOtorgado("cualquier cosa")).toBe(false);
+  });
+});
+
+describe("buildDefaultOperationalPermissionsConfig", () => {
+  it("quien reside puede todo", () => {
+    const config = buildDefaultOperationalPermissionsConfig({});
+
+    expect(config.homeowner_resident.invitation).toBe(true);
+    expect(config.tenant.alert).toBe(true);
+    expect(config.tenant_dependent.reservation).toBe(true);
+  });
+
+  // Un permiso falla cerrado, igual que en el API: un condominio sin
+  // configuración le niega al propietario no residente.
+  it("sin configuración, el no residente no puede nada", () => {
+    const config = buildDefaultOperationalPermissionsConfig({});
+
+    expect(config.homeowner_non_resident.invitation).toBe(false);
+    expect(config.homeowner_non_resident_dependent.alert).toBe(false);
+  });
+
+  it("y con las columnas cargadas toma su valor", () => {
+    const config = buildDefaultOperationalPermissionsConfig({
+      owner_can_invite_without_residence: 2, // GRANTED
+      owner_can_alert_without_residence: 1, // DENIED
+    });
+
+    expect(config.homeowner_non_resident.invitation).toBe(true);
+    expect(config.homeowner_non_resident.alert).toBe(false);
+  });
+});
+
+describe("normalizeOperationalPermissionsConfig", () => {
+  // ⚠️ Si la ausencia contara como false, un condominio con la matriz guardada
+  // a medias apagaría permisos que nadie tocó.
+  it("el JSON pisa sólo las claves que nombra", () => {
+    const config = normalizeOperationalPermissionsConfig({
+      tenant: { alert: false },
+    });
+
+    expect(config.tenant.alert).toBe(false);
+    expect(config.tenant.invitation).toBe(true);
+    expect(config.tenant.reservation).toBe(true);
+  });
+
+  it("acepta el JSON como string, que es como puede venir del API", () => {
+    const config = normalizeOperationalPermissionsConfig(
+      JSON.stringify({ tenant: { alert: false } }),
+    );
+
+    expect(config.tenant.alert).toBe(false);
+  });
+
+  it("un JSON roto no rompe la pantalla: cae a los defaults", () => {
+    const config = normalizeOperationalPermissionsConfig("{no es json");
+
+    expect(config.tenant.alert).toBe(true);
+    expect(config.homeowner_non_resident.alert).toBe(false);
+  });
+
+  it("una clave que no es de la matriz se ignora", () => {
+    const config = normalizeOperationalPermissionsConfig({
+      rol_inventado: { invitation: true },
+      tenant: { visitApproval: false },
+    } as any);
+
+    expect(config).not.toHaveProperty("rol_inventado");
+    expect(config.tenant.visit_approval).toBe(true);
+  });
+});

--- a/src/modulos/Config/DptoConfig/operationalPermissions.ts
+++ b/src/modulos/Config/DptoConfig/operationalPermissions.ts
@@ -1,0 +1,139 @@
+/**
+ * La matriz de permisos operativos: 6 vínculos x 4 acciones.
+ *
+ * Los ids SON las claves del JSON `operational_permissions_config` y de las
+ * cuatro columnas legacy. No se traducen.
+ */
+export const operationalActionOptions = [
+  { id: "invitation", name: "QR" },
+  { id: "visit_approval", name: "Visitas" },
+  { id: "reservation", name: "Reservas" },
+  { id: "alert", name: "Alertas" },
+] as const;
+
+export const operationalRoleOptions = [
+  {
+    id: "homeowner_resident",
+    name: "Propietario residente",
+    description: "Propietario que también vive en la unidad.",
+  },
+  {
+    id: "homeowner_resident_dependent",
+    name: "Dep. prop. residente",
+    description: "Dependiente de propietario residente.",
+  },
+  {
+    id: "homeowner_non_resident",
+    name: "Propietario no residente",
+    description: "Propietario que no vive en la unidad.",
+  },
+  {
+    id: "homeowner_non_resident_dependent",
+    name: "Dep. prop. no residente",
+    description: "Dependiente de propietario no residente.",
+  },
+  { id: "tenant", name: "Inquilino", description: "Residente asignado como inquilino." },
+  {
+    id: "tenant_dependent",
+    name: "Dep. inquilino",
+    description: "Dependiente de inquilino.",
+  },
+] as const;
+
+export type OperationalAction = (typeof operationalActionOptions)[number]["id"];
+export type OperationalRole = (typeof operationalRoleOptions)[number]["id"];
+export type OperationalPermissionsConfig = Record<
+  OperationalRole,
+  Record<OperationalAction, boolean>
+>;
+
+const legacyOperationalActionFieldNames: Record<OperationalAction, string> = {
+  invitation: "owner_can_invite_without_residence",
+  visit_approval: "owner_can_approve_visits_without_residence",
+  reservation: "owner_can_reserve_without_residence",
+  alert: "owner_can_alert_without_residence",
+};
+
+/**
+ * Las cuatro columnas `owner_can_*_without_residence` son ENUMS NUMÉRICOS
+ * desde 1: 1 = DENIED, 2 = GRANTED.
+ *
+ * 🔴 La versión de producción de esta pantalla las lee con
+ * `Number(value) === 1`, que con esta numeración es exactamente el caso
+ * DENEGADO. Copiarla habría mostrado habilitado justo lo que el condominio
+ * niega — el mismo `is_main == 1` que ya mordió en el formulario de pagos.
+ *
+ * Se aceptan `true` y `"Y"` porque una respuesta vieja del API todavía puede
+ * traerlos, pero el 1 pelado ya no significa "sí".
+ */
+const OWNER_PERMISSION_GRANTED = 2;
+
+export const isPermisoOtorgado = (value: unknown) =>
+  Number(value) === OWNER_PERMISSION_GRANTED || value === true || value === "Y";
+
+/**
+ * Los defaults: quien reside puede todo; quien no reside, lo que digan sus
+ * cuatro columnas. Un condominio sin configuración le niega al no residente —
+ * un permiso falla cerrado, igual que en el API.
+ */
+export const buildDefaultOperationalPermissionsConfig = (
+  client_config: Record<string, any> = {},
+): OperationalPermissionsConfig => {
+  const residentDefaults = operationalActionOptions.reduce(
+    (acc, action) => ({ ...acc, [action.id]: true }),
+    {} as Record<OperationalAction, boolean>,
+  );
+  const nonResidentOwnerDefaults = operationalActionOptions.reduce(
+    (acc, action) => ({
+      ...acc,
+      [action.id]: isPermisoOtorgado(
+        client_config?.[legacyOperationalActionFieldNames[action.id]],
+      ),
+    }),
+    {} as Record<OperationalAction, boolean>,
+  );
+
+  return {
+    homeowner_resident: { ...residentDefaults },
+    homeowner_resident_dependent: { ...residentDefaults },
+    homeowner_non_resident: { ...nonResidentOwnerDefaults },
+    homeowner_non_resident_dependent: { ...nonResidentOwnerDefaults },
+    tenant: { ...residentDefaults },
+    tenant_dependent: { ...residentDefaults },
+  };
+};
+
+/**
+ * El JSON guardado sobre los defaults, clave por clave.
+ *
+ * ⚠️ Sólo pisa lo que el JSON NOMBRA. Si la ausencia contara como `false`, un
+ * condominio con la matriz guardada a medias apagaría permisos que nadie tocó.
+ */
+export const normalizeOperationalPermissionsConfig = (
+  value: any,
+  client_config: Record<string, any> = {},
+): OperationalPermissionsConfig => {
+  const parsed =
+    typeof value === "string"
+      ? (() => {
+          try {
+            return JSON.parse(value);
+          } catch {
+            return {};
+          }
+        })()
+      : value || {};
+  const config = buildDefaultOperationalPermissionsConfig(client_config);
+
+  operationalRoleOptions.forEach((role) => {
+    operationalActionOptions.forEach((action) => {
+      if (
+        Object.prototype.hasOwnProperty.call(parsed?.[role.id] || {}, action.id)
+      ) {
+        config[role.id][action.id] = Boolean(parsed[role.id][action.id]);
+      }
+    });
+  });
+
+  return config;
+};


### PR DESCRIPTION
La matriz de **6 vínculos × 4 acciones** en `Config → Unidades`. Sin ella el condominio no puede cambiar lo que el API ya aplica.

⚠️ Va en lockstep con [condaty2025-api#268](https://github.com/mariogfos/condaty2025-api/pull/268).

## 🔴 Por qué no es una copia de producción

Su `isEnabledConfigValue` acepta `Number(value) === 1`, y las cuatro columnas `owner_can_*_without_residence` son **enums numéricos desde 1, donde 1 es `DENIED`**. Copiarla habría mostrado **habilitado justo lo que el condominio niega**.

Es el mismo `is_main == 1` que ya mordió en el formulario de pagos — y el tercer repo donde aparece el patrón, después de rnOwner.

Acá el otorgado es `2`, y **está fijado por test: con el predicado de producción puesto, 2 de 10 en rojo**.

## Lo que además se corrige del lado del API

El admin **no podía guardar la matriz**: las cinco columnas no estaban en el `$fillable` de `ClientConfig` y `ClientConfigController` tampoco las nombra. El request llegaba, el `update()` las descartaba en silencio y la pantalla decía que guardó.

## Decisiones

- Las funciones puras salen del componente de 1.500 líneas a `operationalPermissions.ts` — es lo que hace testeable el predicado.
- ⚠️ **Ausente no es `false`**: el JSON pisa sólo las claves que nombra, porque el servicio conserva el default de lo que no se nombra. Completar con `false` apagaría permisos que el administrador no tocó.
- El responsive colapsa la matriz a una fila por vínculo: cinco columnas de 112px fuerzan scroll horizontal en el celular del admin.

## Verificación

- **116 archivos, 795 tests verdes.**
- `tsc`: 23 errores, **los mismos 23 que ya tenía `dev`** en `useAsyncExport` y `Payments` — verificado corriendo `tsc` contra `dev` limpio. **Cero en `DptoConfig`.**