### PR TITLE
fix(morosos): volver del detalle de una unidad regresa a Morosos (CDT-56)

### DIFF
--- a/src/components/ProfileModal/__tests__/elLinkDeUnidadLlevaSuOrigen.test.tsx
+++ b/src/components/ProfileModal/__tests__/elLinkDeUnidadLlevaSuOrigen.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * CDT-56 — el tercer origen del detalle de unidad. Este modal ya mandaba
+ * `returnTo=owners`; el test lo pinea para que el arreglo de Morosos no se lo
+ * lleve puesto. 🔴 Acá `router.back()` sería incorrecto: volvería a la pantalla
+ * de atrás con el modal ya cerrado.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/owners",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+// El Avatar arrastra el Image compartido, que exige ImageModalProvider.
+vi.mock("@/mk/components/ui/Avatar/Avatar", () => ({
+  Avatar: () => <div />,
+}));
+
+// ⚠️ La respuesta tiene que conservar su IDENTIDAD entre renders: el modal la
+// tiene en las deps de un useEffect que hace setState. Un objeto nuevo por
+// render lo mete en un bucle infinito y el worker de vitest muere por memoria.
+const { axiosStub } = vi.hoisted(() => ({
+  axiosStub: {
+    data: {
+      data: [
+        {
+          id: 9,
+          name: "Ana",
+          last_name: "Perez",
+          unidades: [{ id: 42, nro: "A-101", type: { name: "Unidad" } }],
+        },
+      ],
+    },
+    reLoad: () => {},
+    execute: () => {},
+    loaded: true,
+  },
+}));
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => axiosStub,
+}));
+
+import ProfileModal from "../ProfileModal";
+
+describe("CDT-56 · ProfileModal sigue mandando su origen", () => {
+  beforeEach(() => mockPush.mockClear());
+
+  it("abre el detalle con returnTo=owners", () => {
+    const { container } = render(
+      <ProfileModal
+        open
+        onClose={vi.fn()}
+        dataID={9}
+        type="owner"
+        title="Ana"
+      />,
+    );
+
+    // El nro de la unidad también sale en "Domicilio": el que navega es el
+    // span de la lista "Propietario de".
+    const link = container.querySelector('[class*="unitLink"]');
+    expect(link).toHaveTextContent("Unidad A-101");
+    fireEvent.click(link!);
+
+    expect(mockPush).toHaveBeenCalledWith(
+      "/units/42?returnTo=owners&userType=owner",
+    );
+  });
+});

--- a/src/modulos/DashDptos/DashDptos.tsx
+++ b/src/modulos/DashDptos/DashDptos.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/mk/components/ui/Skeleton/Skeleton";
 import OwnersRenderForm from "../Owners/RenderForm/RenderForm";
 import UnitFinanceHistory from "./UnitFinanceHistory/UnitFinanceHistory";
+import { getBackTarget } from "./backTarget";
 
 interface DashDptosProps {
   id: string | number;
@@ -258,24 +259,15 @@ const DashDptos = ({ id }: DashDptosProps) => {
     }
   };
 
-  const handleBackNavigation = () => {
-    if (returnTo === "owners") {
-      router.push("/owners");
-    } else {
-      router.push("/units");
-    }
-  };
+  const backTarget = getBackTarget(returnTo);
 
-  const getBackLabel = () => {
-    if (returnTo === "owners") {
-      return "Volver a residentes";
-    }
-    return "Volver a lista de unidades";
+  const handleBackNavigation = () => {
+    router.push(backTarget.href);
   };
 
   return (
     <div className={styles.container}>
-      <HeaderBack label={getBackLabel()} onClick={handleBackNavigation} />
+      <HeaderBack label={backTarget.label} onClick={handleBackNavigation} />
       <section>
         <div className={styles.firtsPanel}>
           {!loaded ? (

--- a/src/modulos/DashDptos/__tests__/volverDelDetalleDeUnidad.test.tsx
+++ b/src/modulos/DashDptos/__tests__/volverDelDetalleDeUnidad.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * CDT-56 — el botón "atrás" del detalle de una unidad.
+ *
+ * 🔴 Lo que mide de verdad este archivo es que la ETIQUETA y el DESTINO no se
+ * puedan desincronizar: el bug original venía anunciado en la etiqueta ("Volver
+ * a lista de unidades" viniendo de Morosos) y nadie lo leyó. Cada caso lee el
+ * rótulo del botón, lo aprieta, y afirma la ruta a la que se fue.
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const mockPush = vi.fn();
+let currentSearch = "";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/units/7",
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}));
+
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: 1, name: "Test User" },
+    userCan: () => true,
+    store: {},
+    setStore: vi.fn(),
+    showToast: vi.fn(),
+  }),
+}));
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({
+    data: { data: { id: 7, nro: "A-101" }, extraData: {} },
+    reLoad: vi.fn(),
+    execute: vi.fn(),
+    loaded: true,
+  }),
+}));
+
+// Los hijos del detalle no participan del camino de vuelta: se apagan para que
+// el test mida el header y nada más.
+vi.mock("../UnitInfo/UnitInfo", () => ({ default: () => <div /> }));
+vi.mock("../AccessTable/AccessTable", () => ({ default: () => <div /> }));
+vi.mock("../ReservationsTable/ReservationsTable", () => ({
+  default: () => <div />,
+}));
+vi.mock("../TitleRender/TitleRender", () => ({ default: () => <div /> }));
+vi.mock("../UnitFinanceHistory/UnitFinanceHistory", () => ({
+  default: () => <div />,
+}));
+vi.mock("../HistoryOwnership/HistoryOwnership", () => ({
+  default: () => <div />,
+}));
+vi.mock("../../Owners/RenderView/RenderView", () => ({
+  default: () => <div />,
+}));
+vi.mock("../../Owners/RenderForm/RenderForm", () => ({
+  default: () => <div />,
+}));
+vi.mock("../../Dptos/RenderForm", () => ({ default: () => <div /> }));
+vi.mock("@/components/ProfileModal/ProfileModal", () => ({
+  default: () => <div />,
+}));
+
+import DashDptos from "../DashDptos";
+
+const casos = [
+  {
+    origen: "Morosos (CDT-56)",
+    search: "returnTo=defaulters",
+    label: "Volver a morosos",
+    href: "/defaulters",
+  },
+  {
+    origen: "ProfileModal / Residentes",
+    search: "returnTo=owners&userType=owner",
+    label: "Volver a residentes",
+    href: "/owners",
+  },
+  {
+    origen: "Unidades (sin returnTo)",
+    search: "",
+    label: "Volver a lista de unidades",
+    href: "/units",
+  },
+  {
+    origen: "un returnTo desconocido cae al default",
+    search: "returnTo=marte",
+    label: "Volver a lista de unidades",
+    href: "/units",
+  },
+];
+
+describe("CDT-56 · vuelta del detalle de unidad", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it.each(casos)(
+    "desde $origen: la etiqueta dice '$label' y el botón lleva a $href",
+    ({ search, label, href }) => {
+      currentSearch = search;
+      render(<DashDptos id={7} />);
+
+      const boton = screen.getByText(label);
+      fireEvent.click(boton);
+
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith(href);
+    },
+  );
+});

--- a/src/modulos/DashDptos/backTarget.ts
+++ b/src/modulos/DashDptos/backTarget.ts
@@ -1,0 +1,29 @@
+/**
+ * CDT-56: a dónde vuelve el botón "atrás" del detalle de una unidad.
+ *
+ * El detalle de una unidad (`/units/[id]`) se abre desde TRES orígenes y no
+ * tiene historial propio: `HeaderBack` es un `onClick` plano, así que
+ * `router.back()` no es opción (rompería el caso de `ProfileModal`, que lo
+ * abre desde un modal y volvería a la pantalla con el modal cerrado).
+ * El origen viaja en el query string `?returnTo=`.
+ *
+ * 🔴 El destino y la etiqueta viven en la MISMA entrada a propósito. El bug
+ * original (Morosos volvía a `/units`) ya estaba anunciado en la etiqueta —
+ * decía "Volver a lista de unidades" antes de que nadie lo apretara — porque
+ * eran dos `if` separados que se podían desincronizar. Un origen nuevo agrega
+ * su clave acá y nada más.
+ */
+export type BackTarget = { href: string; label: string };
+
+export const BACK_TARGETS: Record<string, BackTarget> = {
+  owners: { href: "/owners", label: "Volver a residentes" },
+  defaulters: { href: "/defaulters", label: "Volver a morosos" },
+};
+
+export const DEFAULT_BACK_TARGET: BackTarget = {
+  href: "/units",
+  label: "Volver a lista de unidades",
+};
+
+export const getBackTarget = (returnTo?: string | null): BackTarget =>
+  (returnTo && BACK_TARGETS[returnTo]) || DEFAULT_BACK_TARGET;

--- a/src/modulos/Defaulters/Defaulters.tsx
+++ b/src/modulos/Defaulters/Defaulters.tsx
@@ -261,8 +261,11 @@ const Defaulters = () => {
       calculatedTotals.porCobrarMv,
     ],
   );
+  // CDT-56: Morosos no tiene detalle propio, manda al de Unidades. Sin el
+  // origen en el query string, el botón "atrás" de ese detalle caía al default
+  // (`/units`) y encima lo anunciaba con la etiqueta equivocada.
   const handleRowClick = (item: any) => {
-    router.push(`/units/${item.dpto_id}`);
+    router.push(`/units/${item.dpto_id}?returnTo=defaulters`);
   };
 
   const renderRightPanel = useCallback(() => {

--- a/src/modulos/Defaulters/__tests__/laFilaLlevaSuOrigen.test.tsx
+++ b/src/modulos/Defaulters/__tests__/laFilaLlevaSuOrigen.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * CDT-56 — Morosos no tiene detalle propio: abre el de Unidades. Si la fila no
+ * manda su origen, el botón "atrás" de ese detalle no tiene con qué volver acá.
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/defaulters",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Sin AxiosContext, `waiting` es undefined y LoadingScreen se queda en el
+// skeleton para siempre.
+vi.mock("@/mk/components/ui/LoadingScreen/LoadingScreen", () => ({
+  default: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock("@/mk/hooks/useCrud/useCrud", () => ({
+  default: () => ({
+    userCan: () => true,
+    data: { data: [{ dpto_id: 42 }] },
+    extraData: {},
+    List: ({ onRowClick }: any) => (
+      <button data-testid="fila" onClick={() => onRowClick({ dpto_id: 42 })}>
+        A-101
+      </button>
+    ),
+  }),
+}));
+
+import Defaulters from "../Defaulters";
+
+describe("CDT-56 · la fila de Morosos abre el detalle con su origen", () => {
+  beforeEach(() => mockPush.mockClear());
+
+  it("manda returnTo=defaulters en el query string", () => {
+    render(<Defaulters />);
+
+    fireEvent.click(screen.getByTestId("fila"));
+
+    expect(mockPush).toHaveBeenCalledWith("/units/42?returnTo=defaulters");
+  });
+});


### PR DESCRIPTION
Cierra **CDT-56**: volver desde el detalle de una unidad morosa llevaba a `/units` en vez de a Morosos.

## La raíz no era el push sin parámetro

Morosos abría `/units/:id` sin mandar origen, sí. Pero el problema de fondo es que `DashDptos` tenía **dos `if/else` gemelos**: uno decidía el destino, otro el rótulo del botón.

Por eso este bug **venía anunciado**: el botón decía "Volver a lista de unidades" **antes** de que nadie lo apretara. La pantalla te avisaba adónde te iba a mandar, y nadie lo leyó como defecto. Dos decisiones separadas para una sola cosa siempre terminan así.

## El arreglo

Un mapa donde `href` y `label` viven en la **misma entrada**, y las dos funciones leen de ahí:

```ts
export const BACK_TARGETS: Record<string, BackTarget> = {
  owners:     { href: "/owners",     label: "Volver a residentes" },
  defaulters: { href: "/defaulters", label: "Volver a morosos" },
};
export const DEFAULT_BACK_TARGET = { href: "/units", label: "Volver a lista de unidades" };
```

Un origen nuevo agrega su clave y listo. **Y la etiqueta ya no se puede desincronizar del destino**, porque son el mismo objeto.

🔴 **No se usó `router.back()` a propósito.** `HeaderBack` es un `onClick` plano, sin historial, y `back()` rompería el caso de `ProfileModal`, que abre el detalle desde arriba de un modal: volvería a la pantalla con el modal cerrado, o a una ruta intermedia.

## Los tres orígenes

| origen | antes | después |
|---|---|---|
| **Morosos** | mandaba a `/units` ❌ | `?returnTo=defaulters` → `/defaulters` ✅ |
| Unidades (`Dptos`) | sin `returnTo` → `/units` ✅ | igual: cae al default, que **es** su origen |
| Perfil (`ProfileModal`) | `returnTo=owners` → `/owners` ✅ | igual, ahora por la clave del mapa |

Los otros dos **no cambian de comportamiento**. `ProfileModal` no se tocó: sólo se pineó con un test.

## Verificado reinyectando

El test lee el rótulo del botón, **lo aprieta, y afirma la ruta** — etiqueta y destino en la misma aserción, así que un desincronizado no pasa:

```
× Morosos sin mandar el origen:
expected "vi.fn()" to be called with [ '/units/42?returnTo=defaulters' ]
+   "/units/42",

× el if/else original de vuelta:
Unable to find an element with the text: Volver a morosos.

× desincronizar etiqueta y destino a mano (label intacto, href a /units):
expected "vi.fn()" to be called with [ '/defaulters' ]
+   "/units",

× ProfileModal sin su returnTo:
+   "/units/42?userType=owner",
```

La tercera es la que importa: prueba que el chequeo del rótulo **muerde**, que es lo que evita que este bug vuelva por donde vino.

## Verificación

- Suite completa: **119 archivos, 794 tests, todos verdes**. `eslint` sobre lo tocado: 0 errores. `tsc` no suma errores nuevos.
- ⚠️ El contador de `Errors` de vitest baila entre 1 y 5 según la corrida: es `Surveys.test.tsx` levantando InstantDB con un `appId` que no es uuid. **Preexistente y ajeno**, sale en `dev` igual, no está en este diff.
- Sin migraciones: es query string del front, no viaja nada al back.

## Qué mirar al probarlo

1. Finanzas → **Morosos** → clic en una fila → cae en el detalle de la unidad.
2. El rótulo del header tiene que decir **"Volver a morosos"**, y al apretarlo volver a Morosos.
3. No-regresión: Residentes → perfil → su unidad → dice **"Volver a residentes"** y vuelve ahí. Y desde Unidades directo, **"Volver a lista de unidades"**.
