### PR TITLE
fix(deudas): el alta individual manda booleanos y ningún error queda mudo (CDT-60)

### DIFF
--- a/src/mk/components/ui/Toast/Toast.tsx
+++ b/src/mk/components/ui/Toast/Toast.tsx
@@ -31,9 +31,13 @@ const Toast = ({
     setLegacyToasts([normalizedToast]);
   }, [normalizedToast]);
 
+  // El descarte es local: saca ESTE toast de la lista de este componente.
+  // Antes llamaba además a `showToast("")`, que vaciaba la cola global entera
+  // —se llevaba puestos los avisos de otras pantallas— y desde CDT-60 un
+  // mensaje vacío ya no toca la cola. `showToast` sigue en las props porque es
+  // parte del contrato con `Payments`/`Outlays`.
   const dismissToast = (id: string) => {
     setLegacyToasts((prev) => prev.filter((item) => item.id !== id));
-    showToast("");
   };
 
   return <ToastViewport toasts={legacyToasts} onDismiss={dismissToast} />;

--- a/src/mk/hooks/__tests__/useToastMensajeVacioNoBorraLaCola.test.tsx
+++ b/src/mk/hooks/__tests__/useToastMensajeVacioNoBorraLaCola.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useState } from "react";
+
+import useToast, { ToastItem } from "../useToast";
+
+/**
+ * Un pedido de toast SIN mensaje no borra los que ya están en pantalla.
+ *
+ * ## 🔴 Qué se rompía (CDT-60)
+ *
+ * `showToast` con mensaje vacío hacía `setToastQueue([]); return;`. Eso lo
+ * convertía en el arma perfecta para tapar un error: cuando un request muere no
+ * llega sobre de respuesta, `showToast(response?.message, "error")` viaja sin
+ * texto, y en vez de avisar algo el hook BARRÍA la cola. Dos daños en la misma
+ * línea: el error del guardado no se ve, y el aviso que el usuario ya tenía en
+ * pantalla —de otra pantalla, de otro flujo— desaparece sin que nadie lo pida.
+ *
+ * Pedir un toast sin texto no es una orden de limpiar: es una llamada que se
+ * quedó sin mensaje. Se ignora. Para SACAR un toast está el `onDismiss` del
+ * `ToastViewport`, que lo quita por `id` y no toca los demás.
+ *
+ * ## Reinyección, medida el 2026-08-16
+ *
+ * Con `setToastQueue([])` de vuelta: **2/4 rojos**.
+ */
+
+const montarCola = () =>
+  renderHook(() => {
+    const [cola, setCola] = useState<ToastItem[]>([]);
+    const { showToast } = useToast(setCola);
+    return { cola, showToast };
+  });
+
+describe("useToast: el mensaje vacío", () => {
+  it("no se lleva puesto un toast que ya estaba en pantalla", () => {
+    const { result } = montarCola();
+
+    act(() => result.current.showToast("Reserva creada", "success"));
+    expect(result.current.cola).toHaveLength(1);
+
+    // El caso real: un `showToast(response?.message, "error")` con el request
+    // caído. Llega sin texto.
+    act(() => result.current.showToast(undefined as any, "error"));
+
+    // 🔴 Acá la cola quedaba en [] y el "Reserva creada" desaparecía.
+    expect(
+      result.current.cola,
+      "un pedido sin mensaje no borra los avisos que ya están",
+    ).toHaveLength(1);
+    expect(result.current.cola[0].msg).toBe("Reserva creada");
+  });
+
+  it("el string vacío tampoco borra la cola", () => {
+    const { result } = montarCola();
+
+    act(() => result.current.showToast("Egreso guardado", "success"));
+    act(() => result.current.showToast(""));
+
+    expect(result.current.cola).toHaveLength(1);
+    expect(result.current.cola[0].msg).toBe("Egreso guardado");
+  });
+
+  it("tampoco encola un toast en blanco", () => {
+    const { result } = montarCola();
+
+    act(() => result.current.showToast("", "error"));
+
+    // Ni borra ni inventa: un toast sin texto es una caja vacía en pantalla.
+    expect(result.current.cola).toHaveLength(0);
+  });
+
+  it("un mensaje con texto sigue encolando normal", () => {
+    const { result } = montarCola();
+
+    act(() => result.current.showToast("No se pudo guardar", "error"));
+
+    expect(result.current.cola).toHaveLength(1);
+    expect(result.current.cola[0].msg).toBe("No se pudo guardar");
+    expect(result.current.cola[0].type).toBe("error");
+  });
+
+  it("sin `setToastQueue` no revienta", () => {
+    const { result } = renderHook(() => useToast());
+    expect(() => result.current.showToast("")).not.toThrow();
+    expect(vi.isMockFunction(result.current.showToast)).toBe(false);
+  });
+});

--- a/src/mk/hooks/useCrud/README.md
+++ b/src/mk/hooks/useCrud/README.md
@@ -493,6 +493,39 @@ apagaría también el esqueleto de la carga inicial y el de los filtros.
    - Check validation function implementations
    - Verify form data structure
 
+## 🔴 `onSave` nunca es mudo
+
+Un guardado que no llega a buen puerto **siempre** dice algo. Son tres salidas y
+las tres avisan:
+
+| salida | qué se ve |
+|---|---|
+| `checkRulesFields` rechaza | toast de error `"Revisa los datos del formulario"`, y los mensajes por campo quedan en `errors` / el `setErrors` que le hayas pasado. **No se despacha request.** |
+| el request responde `success: false` | el `message` del API |
+| el request **muere** (500, red, un `1366` de MySQL) | `"No se pudo guardar. Intenta nuevamente."` — no hay sobre, así que no hay `message` |
+
+⚠️ Que el rechazo de validación tenga toast **no exime al formulario de pintar
+los errores por campo**. Si tu `renderForm` arma su propia validación local,
+mezclá los dos juegos de errores; quedarte sólo con los locales tapa lo que
+rechazó el kernel:
+
+```tsx
+// ❌ `{}` es truthy: este `||` se queda SIEMPRE con el del kernel
+const errores = externalErrors || _errors;
+// ✅
+const errores = { ..._errors, ...(externalErrors || {}) };
+```
+
+Y `showToast("")` **no limpia la cola de toasts**: un pedido sin mensaje se
+ignora. Para sacar un toast de la pantalla está el `onDismiss` del
+`ToastViewport`, que lo quita por `id`.
+
+Contexto: CDT-60. El alta de Deudas Individuales mandaba cuatro banderas como
+`'Y'`/`'N'` a columnas `tinyint(1)`, el INSERT moría con
+`ERROR 1366: Incorrect integer value: 'N' for column has_mv`, el toast salía sin
+mensaje y `useToast` con mensaje vacío vaciaba la cola. Se apretaba Crear y la
+pantalla no se movía.
+
 ## API Reference
 
 ### Types

--- a/src/mk/hooks/useCrud/__tests__/useCrudGuardadoFallidoNoEsMudo.test.tsx
+++ b/src/mk/hooks/useCrud/__tests__/useCrudGuardadoFallidoNoEsMudo.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, act, waitFor } from "@testing-library/react";
+import React from "react";
+
+/**
+ * Un guardado que falla SIEMPRE dice algo.
+ *
+ * ## 🔴 Qué se rompía (CDT-60)
+ *
+ * "El botón Crear de Deudas Individuales no hace nada, ningún mensaje."
+ *
+ * El alta mandaba las cuatro banderas como `'Y'`/`'N'` a columnas `tinyint(1)`,
+ * MySQL en modo estricto tiraba
+ * `ERROR 1366: Incorrect integer value: 'N' for column has_mv` y el request
+ * moría. Sin sobre de respuesta, `response` queda `undefined`, así que
+ * `showToast(response?.message, "error")` pedía un toast SIN MENSAJE — y
+ * `useToast` con mensaje vacío vaciaba la cola y no mostraba nada.
+ *
+ * El bug de origen es de un formulario; el ENCUBRIMIENTO es del kernel y lo
+ * consumen ~40 pantallas: cualquier módulo cuyo POST reviente se veía igual de
+ * mudo. Por eso la red va acá.
+ *
+ * La otra puerta muda era el `return` de la validación: `setErrors` deja los
+ * mensajes en el estado, pero un formulario que pinta sólo sus errores locales
+ * no muestra ni uno y el click se pierde en el vacío.
+ *
+ * ## Reinyección, medida el 2026-08-16
+ *
+ * Con `showToast(response?.message, "error")` (sin genérico) y con el `return`
+ * mudo de la validación: **2/3 rojos**.
+ */
+
+const execute = vi.fn();
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({
+    data: null,
+    reLoad: vi.fn(),
+    execute,
+    loaded: true,
+    error: null,
+    cancel: vi.fn(),
+    waiting: 0,
+    setWaiting: vi.fn(),
+  }),
+}));
+
+const showToast = vi.fn();
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: 1 },
+    userCan: () => true,
+    store: {},
+    setStore: vi.fn(),
+    showToast,
+  }),
+}));
+
+vi.mock("@/mk/components/ui/Table/Table", () => ({
+  default: () => <div data-testid="table-mock" />,
+}));
+vi.mock("@/mk/components/ui/Pagination/Pagination", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/hooks/useCrud/FormElement", () => ({ default: () => null }));
+vi.mock("@/mk/components/forms/DataSearch/DataSearch", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/data/ImportDataModal/ImportDataModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/DetailModal/DetailModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/DataModal/DataModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/ui/NewModal/NewModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/forms/FloatButton/FloatButton", () => ({
+  default: () => null,
+}));
+vi.mock("@/components/NoData/EmptyData", () => ({ default: () => null }));
+vi.mock("@/mk/hooks/useMediaQuery", () => ({ default: () => false }));
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) mocked[key] = () => null;
+  return mocked;
+});
+
+import useCrud, { ModCrudType } from "../useCrud";
+
+const mod: ModCrudType = {
+  modulo: "v3/debt-dptos",
+  singular: "Deuda",
+  plural: "",
+  permiso: "expense",
+} as ModCrudType;
+
+const fields = {
+  id: { rules: [], api: "e" },
+  dpto_id: { rules: ["required"], api: "ae", label: "Unidad" },
+  amount: { rules: [], api: "ae", label: "Monto", list: {} },
+};
+
+const listaOk = () => ({
+  data: { data: [], message: { total: 0 } },
+  error: null,
+});
+
+const montar = () => {
+  const runtime: { current: any } = { current: null };
+
+  const Comp = () => {
+    runtime.current = useCrud({
+      paramsInitial: { page: 1, perPage: 20, fullType: "L", searchBy: "" },
+      mod,
+      fields,
+    });
+    return null;
+  };
+
+  render(<Comp />);
+  return runtime;
+};
+
+/** Los toast que el usuario VE: con texto. Un toast sin mensaje no existe. */
+const toastsVisibles = () =>
+  showToast.mock.calls.filter(([msg]) => !!msg && String(msg).trim() !== "");
+
+describe("useCrud: un guardado fallido no puede ser mudo", () => {
+  beforeEach(() => {
+    execute.mockReset();
+    showToast.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("el request que revienta —sin sobre de respuesta— saca un mensaje visible", async () => {
+    execute.mockImplementation(async (_url: string, method: string) => {
+      if (method === "POST") {
+        // Es LITERALMENTE lo que devuelve `useAxios` cuando el request muere:
+        // no hay sobre, `data` es null. Es el caso del 1366 de MySQL.
+        return { data: null, error: { data: {} } };
+      }
+      return listaOk();
+    });
+
+    const runtime = montar();
+    await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      void runtime.current.onSave({ dpto_id: 7, amount: 150 });
+      await new Promise((resolve) => setTimeout(resolve, 80));
+    });
+
+    // 🔴 Acá no salía NADA: el usuario apretaba Crear y la pantalla se quedaba
+    // igual. Ni éxito, ni error, ni el modal cerrándose.
+    expect(
+      toastsVisibles(),
+      "un guardado que falla tiene que decir algo",
+    ).toHaveLength(1);
+    expect(toastsVisibles()[0][1]).toBe("error");
+  });
+
+  it("si el API sí manda mensaje, gana el del API sobre el genérico", async () => {
+    execute.mockImplementation(async (_url: string, method: string) => {
+      if (method === "POST") {
+        return {
+          data: { success: false, message: "La unidad ya tiene esa deuda" },
+          error: null,
+        };
+      }
+      return listaOk();
+    });
+
+    const runtime = montar();
+    await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      void runtime.current.onSave({ dpto_id: 7, amount: 150 });
+      await new Promise((resolve) => setTimeout(resolve, 80));
+    });
+
+    expect(toastsVisibles()).toHaveLength(1);
+    expect(toastsVisibles()[0][0]).toBe("La unidad ya tiene esa deuda");
+  });
+
+  it("el rechazo de la validación del kernel se avisa, no se traga", async () => {
+    execute.mockImplementation(async () => listaOk());
+
+    const runtime = montar();
+    await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      // `dpto_id` es `required`: `checkRulesFields` lo rechaza y el POST ni sale.
+      void runtime.current.onSave({ amount: 150 });
+      await new Promise((resolve) => setTimeout(resolve, 80));
+    });
+
+    const posts = execute.mock.calls.filter((c) => c[1] === "POST");
+    expect(posts, "con la validación rota no se despacha nada").toHaveLength(0);
+
+    // 🔴 Acá el `return` era mudo: el click se perdía en el vacío.
+    expect(
+      toastsVisibles(),
+      "un rechazo de validación tiene que verse",
+    ).toHaveLength(1);
+    expect(toastsVisibles()[0][1]).toBe("error");
+  });
+});

--- a/src/mk/hooks/useCrud/useCrud.tsx
+++ b/src/mk/hooks/useCrud/useCrud.tsx
@@ -1056,7 +1056,18 @@ const useCrud = ({
         } else {
           setErrors(errors);
         }
-        if (hasErrors(errors)) return;
+        // 🔴 El rechazo de la validación del kernel tiene que DECIRSE (CDT-60).
+        //
+        // Este `return` era mudo: `setErrors` deja los mensajes en el estado,
+        // pero un formulario que pinta sólo sus errores locales —el de Deudas
+        // Individuales pintaba `_errors` y usaba `errors` nada más que para una
+        // clase CSS— no muestra ni uno. Se apretaba Guardar y no pasaba nada.
+        // El aviso va acá, en el kernel, porque es el único punto por el que
+        // pasan las ~40 pantallas.
+        if (hasErrors(errors)) {
+          showToast("Revisa los datos del formulario", "error");
+          return;
+        }
       }
 
       const url = "/" + mod.modulo + (data.id ? "/" + data.id : "");
@@ -1135,7 +1146,16 @@ const useCrud = ({
         }
         showToast(mod.saveMsg?.[action] || response?.message, "success");
       } else {
-        showToast(response?.message, "error");
+        // 🔴 Un guardado fallido NUNCA puede ser mudo (CDT-60).
+        //
+        // Cuando el request revienta —un 500, un 1366 de MySQL, la red— el
+        // sobre no llega y `response` es `undefined`, así que `response.message`
+        // era `undefined` y no se veía nada. El genérico es la red de abajo: el
+        // mensaje del API sigue teniendo prioridad cuando existe.
+        showToast(
+          response?.message || "No se pudo guardar. Intenta nuevamente.",
+          "error",
+        );
         logError("Error onSave:", err);
       }
     } finally {

--- a/src/mk/hooks/useToast.tsx
+++ b/src/mk/hooks/useToast.tsx
@@ -109,8 +109,18 @@ const useToast = (setToastQueue?: Function) => {
 
     const normalized = normalizeToastArgs(message, type, time);
 
+    // 🔴 Un mensaje vacío NO vacía la cola (CDT-60).
+    //
+    // Antes hacía `setToastQueue([])`, y eso convertía cualquier
+    // `showToast(response?.message, "error")` con `response === undefined` —un
+    // request caído— en un borrado silencioso: el usuario apretaba Guardar, no
+    // aparecía nada, y encima se llevaba puesto el aviso que YA estaba en
+    // pantalla. Pedir un toast sin texto no es una orden de limpiar: es una
+    // llamada que se quedó sin mensaje. Se ignora y la cola queda como está.
+    //
+    // Para sacar un toast de la pantalla está `onDismiss` del `ToastViewport`,
+    // que lo quita por `id` sin tocar los demás.
     if (!normalized.message) {
-      setToastQueue([]);
       return;
     }
 

--- a/src/modulos/DebtsManager/TabComponents/AllDebts/RenderForm/RenderForm.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/RenderForm/RenderForm.tsx
@@ -104,10 +104,15 @@ const RenderForm = ({ open, onClose, item, setItem, execute, extraData, user, re
       amount: formState.amount,
       is_advance: formState.is_advance,
       interest: formState.interest,
-      has_mv: formState.has_mv ? 'Y' : 'N',
-      is_forgivable: formState.is_forgivable ? 'Y' : 'N',
-      has_pp: formState.has_pp ? 'Y' : 'N',
-      is_blocking: formState.is_blocking ? 'Y' : 'N',
+      // Booleanos, NO 'Y'/'N' (CDT-60): las cuatro son `tinyint(1)` en
+      // `debt_dptos`. Acá el `boolFlag()` de `SharedDebtService` todavía traduce
+      // el string —por eso este camino no explotaba—, pero mandarlo mal deja el
+      // alta dependiendo de una traducción del back que el camino individual no
+      // tiene. Se manda el tipo real de la columna desde el origen.
+      has_mv: !!formState.has_mv,
+      is_forgivable: !!formState.is_forgivable,
+      has_pp: !!formState.has_pp,
+      is_blocking: !!formState.is_blocking,
     };
 
     const { data: response } = await execute(

--- a/src/modulos/DebtsManager/TabComponents/IndividualDebts/RenderForm/RenderForm.tsx
+++ b/src/modulos/DebtsManager/TabComponents/IndividualDebts/RenderForm/RenderForm.tsx
@@ -59,7 +59,6 @@ const RenderForm: React.FC<RenderFormProps> = ({
   user,
   setItem,
   errors: externalErrors,
-  setErrors: externalSetErrors,
   action,
 }) => {
   const [_formState, _setFormState] = useState<DebtFormState>(() => {
@@ -262,10 +261,21 @@ const RenderForm: React.FC<RenderFormProps> = ({
     const dataToSave = {
       ..._formState,
 
-      has_mv: _formState.has_mv ? 'Y' : 'N',
-      is_forgivable: _formState.is_forgivable ? 'Y' : 'N',
-      has_pp: _formState.has_pp ? 'Y' : 'N',
-      is_blocking: _formState.is_blocking ? 'Y' : 'N',
+      // 🔴 Booleanos, NO 'Y'/'N' (CDT-60). Las cuatro columnas son
+      // `tinyint(1)` desde la migración de 2026-06-30 y son `$fillable` en
+      // `DebtDpto`, así que el string entra crudo al INSERT: Laravel castea al
+      // LEER, no al escribir. Con la base en modo estricto el alta muere con
+      // `ERROR 1366: Incorrect integer value: 'N' for column has_mv`; sin modo
+      // estricto pasa y guarda 0 en las cuatro. Los dos casos son el bug.
+      //
+      // ⚠️ El alta individual (`type: 0`) va por `parent::store()` del kernel,
+      // que NO normaliza. El `boolFlag()` de `SharedDebtService` sólo cubre el
+      // camino compartido (`type: 4`), por eso este formulario era el único que
+      // moría.
+      has_mv: !!_formState.has_mv,
+      is_forgivable: !!_formState.is_forgivable,
+      has_pp: !!_formState.has_pp,
+      is_blocking: !!_formState.is_blocking,
       // Asegurar que amount e interest sean números
       amount: parseFloat(String(_formState.amount || '0')),
       interest: parseFloat(String(_formState.interest || '0')),
@@ -284,8 +294,13 @@ const RenderForm: React.FC<RenderFormProps> = ({
   }, [_formState, validar, onSave]);
 
 
-  const currentErrors = externalErrors || _errors;
-  const currentSetErrors = externalSetErrors || set_Errors;
+  // 🔴 Los DOS juegos de errores, mezclados (CDT-60).
+  //
+  // Era `externalErrors || _errors`, y `externalErrors` es un objeto: `{}` es
+  // truthy, así que el `||` se quedaba SIEMPRE con el del kernel y los locales
+  // no llegaban nunca. Encima los inputs pintaban `_errors` a mano, con lo cual
+  // un rechazo de `checkRulesFields` era invisible. Se mezclan y se pinta esto.
+  const currentErrors: Errors = { ..._errors, ...(externalErrors || {}) };
 
 
   useEffect(() => {
@@ -376,7 +391,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
               optionLabel="label"
               optionValue="id"
               onChange={handleChangeInput}
-              error={_errors}
+              error={currentErrors}
               required
               placeholder="Seleccionar unidad"
               className={currentErrors.dpto_id ? styles.error : ''}
@@ -395,10 +410,10 @@ const RenderForm: React.FC<RenderFormProps> = ({
               onChange={handleChangeInput}
               type="number"
               min="0"
-              error={_errors}
+              error={currentErrors}
               required
               placeholder="0.00"
-              className={_errors.amount ? styles.error : ''}
+              className={currentErrors.amount ? styles.error : ''}
             />
           </div>
           <div className={styles.formField}>
@@ -410,9 +425,9 @@ const RenderForm: React.FC<RenderFormProps> = ({
               type="number"
               min="0"
               max="100"
-              error={_errors}
+              error={currentErrors}
               placeholder="0.00"
-              className={_errors.interest ? styles.error : ''}
+              className={currentErrors.interest ? styles.error : ''}
             />
           </div>
         </div>
@@ -426,9 +441,9 @@ const RenderForm: React.FC<RenderFormProps> = ({
               value={_formState.begin_at}
               onChange={handleChangeInput}
               type="date"
-              error={_errors}
+              error={currentErrors}
               required
-              className={_errors.begin_at ? styles.error : ''}
+              className={currentErrors.begin_at ? styles.error : ''}
             />
           </div>
           <div className={styles.formField}>
@@ -438,9 +453,9 @@ const RenderForm: React.FC<RenderFormProps> = ({
               value={_formState.due_at}
               onChange={handleChangeInput}
               type="date"
-              error={_errors}
+              error={currentErrors}
               required
-              className={_errors.due_at ? styles.error : ''}
+              className={currentErrors.due_at ? styles.error : ''}
             />
           </div>
         </div>
@@ -454,10 +469,10 @@ const RenderForm: React.FC<RenderFormProps> = ({
               value={_formState.subcategory_id}
               options={getSubcategoryOptions()}
               onChange={handleChangeInput}
-              error={_errors}
+              error={currentErrors}
               required
               placeholder="Seleccionar subcategoría"
-              className={_errors.subcategory_id ? styles.error : ''}
+              className={currentErrors.subcategory_id ? styles.error : ''}
             />
           </div>
         </div>
@@ -471,9 +486,9 @@ const RenderForm: React.FC<RenderFormProps> = ({
             onChange={handleChangeInput}
             maxLength={500}
             required={false}
-            error={_errors}
+            error={currentErrors}
             placeholder="Descripción adicional de la deuda (opcional)..."
-            className={_errors.description ? styles.error : ''}
+            className={currentErrors.description ? styles.error : ''}
           />
         </div>
 
@@ -505,7 +520,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
                         value={_formState.has_mv ? 'Y' : 'N'}
                         checked={_formState.has_mv}
                         onChange={handleChangeInput}
-                        error={_errors}
+                        error={currentErrors}
                         reverse={true}
                       />
                       <Tooltip
@@ -524,7 +539,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
                     value={_formState.is_forgivable ? 'Y' : 'N'}
                     checked={_formState.is_forgivable}
                     onChange={handleChangeInput}
-                    error={_errors}
+                    error={currentErrors}
                     reverse={true}
                   />
                   <Tooltip
@@ -542,7 +557,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
                     value={_formState.is_blocking ? 'Y' : 'N'}
                     checked={_formState.is_blocking}
                     onChange={handleChangeInput}
-                    error={_errors}
+                    error={currentErrors}
                     reverse={true}
                   />
                   <Tooltip
@@ -560,7 +575,7 @@ const RenderForm: React.FC<RenderFormProps> = ({
                     value={_formState.has_pp ? 'Y' : 'N'}
                     checked={_formState.has_pp}
                     onChange={handleChangeInput}
-                    error={_errors}
+                    error={currentErrors}
                     reverse={true}
                   />
                   <Tooltip

--- a/src/modulos/DebtsManager/TabComponents/IndividualDebts/__tests__/altaDeudaIndividualMandaBooleanos.test.tsx
+++ b/src/modulos/DebtsManager/TabComponents/IndividualDebts/__tests__/altaDeudaIndividualMandaBooleanos.test.tsx
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  act,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
+import React from "react";
+
+/**
+ * El alta de una deuda individual manda BOOLEANOS, no `'Y'`/`'N'`.
+ *
+ * ## 🔴 Qué se rompía (CDT-60)
+ *
+ * "El botón Crear de Deudas Individuales no hace nada, ningún mensaje."
+ *
+ * La cadena, eslabón por eslabón:
+ *
+ * 1. El formulario armaba el payload con `has_mv: _formState.has_mv ? 'Y':'N'`
+ *    y lo mismo con `is_forgivable`, `has_pp` e `is_blocking`.
+ * 2. Las cuatro son `$fillable` en `DebtDpto`, así que entran por el request.
+ * 3. 🔴 **Laravel NO castea al escribir.** El cast `'boolean'` actúa al LEER;
+ *    al guardar viaja el string crudo.
+ * 4. Las cuatro columnas son `tinyint(1)` desde la migración de 2026-06-30 y la
+ *    base local es estricta:
+ *    `ERROR 1366 (22007): Incorrect integer value: 'N' for column has_mv`.
+ *    El INSERT falla.
+ * 5. Sin sobre de respuesta el toast salía vacío y la pantalla no decía nada.
+ *
+ * ⚠️ El síntoma depende del `sql_mode`: donde no sea estricto el insert pasa y
+ * guarda **0 en las cuatro** —el botón "anda" y las banderas quedan mal—. Los
+ * dos casos son el mismo bug.
+ *
+ * ⚠️ El camino COMPARTIDO (`type: 4`) no moría porque `SharedDebtService`
+ * traduce con `boolFlag()`. El individual (`type: 0`) va por `parent::store()`
+ * del kernel, que no normaliza nada. Por eso el bug sólo se veía acá.
+ *
+ * ## Cómo mide
+ *
+ * 🔴 **Sobre el cuerpo del request que sale**, no sobre el texto del archivo.
+ * Se monta el formulario REAL colgado del `onSave` REAL de `useCrud` —el mismo
+ * que arma el payload con `getParamFields`— y se afirma sobre lo que recibe
+ * `execute`. Un test que buscara `'Y'` en el código es justo el tipo de test
+ * que se barrió en CDT-46.
+ *
+ * ## Reinyección, medida el 2026-08-16
+ *
+ * Con el `? 'Y' : 'N'` de vuelta: **3/4 rojos**.
+ */
+
+const execute = vi.fn();
+
+vi.mock("@/mk/hooks/useAxios", () => ({
+  default: () => ({
+    data: null,
+    reLoad: vi.fn(),
+    execute,
+    loaded: true,
+    error: null,
+    cancel: vi.fn(),
+    waiting: 0,
+    setWaiting: vi.fn(),
+  }),
+}));
+
+const showToast = vi.fn();
+vi.mock("@/mk/contexts/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: 1 },
+    userCan: () => true,
+    store: {},
+    setStore: vi.fn(),
+    showToast,
+  }),
+}));
+
+vi.mock("@/mk/components/ui/Table/Table", () => ({ default: () => null }));
+vi.mock("@/mk/components/ui/Pagination/Pagination", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/hooks/useCrud/FormElement", () => ({ default: () => null }));
+vi.mock("@/mk/components/forms/DataSearch/DataSearch", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/data/ImportDataModal/ImportDataModal", () => ({
+  default: () => null,
+}));
+// ⚠️ `DetailModal` NO se mockea: es quien pinta el botón "Crear deuda
+// individual" del `DataModal`. Sin él no hay nada que apretar y el test mediría
+// el aire.
+vi.mock("@/mk/components/ui/NewModal/NewModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/mk/components/forms/FloatButton/FloatButton", () => ({
+  default: () => null,
+}));
+vi.mock("@/components/NoData/EmptyData", () => ({ default: () => null }));
+vi.mock("@/mk/hooks/useMediaQuery", () => ({ default: () => false }));
+vi.mock("@/components/layout/icons/IconsBiblioteca", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  const mocked: Record<string, any> = { __esModule: true };
+  for (const key of Object.keys(actual)) mocked[key] = () => null;
+  return mocked;
+});
+
+import useCrud, { ModCrudType } from "@/mk/hooks/useCrud/useCrud";
+import RenderForm from "../RenderForm/RenderForm";
+
+const BANDERAS = ["has_mv", "is_forgivable", "has_pp", "is_blocking"] as const;
+
+/** `mod` y `fields` como los declara `IndividualDebts.tsx`. */
+const mod: ModCrudType = {
+  modulo: "v3/debt-dptos",
+  singular: "Deuda",
+  plural: "",
+  permiso: "expense",
+} as ModCrudType;
+
+const fields = {
+  id: { rules: [], api: "e" },
+  begin_at: { rules: ["required"], api: "ae", label: "Fecha de inicio" },
+  due_at: { rules: ["required"], api: "ae", label: "Vencimiento" },
+  type: { rules: [], api: "ae", label: "Tipo" },
+  description: { rules: [], api: "ae", label: "Descripción" },
+  subcategory_id: { rules: ["required"], api: "ae", label: "Subcategoría" },
+  dpto_id: { rules: ["required"], api: "ae", label: "Unidad" },
+  amount: { rules: ["required"], api: "ae", label: "Monto" },
+  interest: { rules: [], api: "ae", label: "Interés" },
+  has_mv: { rules: [], api: "ae", label: "Tiene Mant. Valor" },
+  is_forgivable: { rules: [], api: "ae", label: "Es condonable" },
+  has_pp: { rules: [], api: "ae", label: "Tiene plan de pago" },
+  is_blocking: { rules: [], api: "ae", label: "Es bloqueante" },
+};
+
+const user = {
+  id: 1,
+  client_id: 9,
+  clients: [{ id: 9, has_maintenance_value: 1 }],
+};
+
+const extraData = {
+  categories: [{ id: 1, name: "Servicios", hijos: [{ id: 55, name: "Agua" }] }],
+  dptos: [{ id: 7, nro: "A-101", titular: { name: "Ana", last_name: "Paz" } }],
+};
+
+/** Una deuda válida: pasa la validación local y la del kernel. */
+const deudaValida = {
+  begin_at: "2026-08-01",
+  due_at: "2026-09-01",
+  amount: "150",
+  subcategory_id: 55,
+  dpto_id: 7,
+  description: "Cuota extraordinaria",
+};
+
+const listaOk = () => ({
+  data: { data: [], message: { total: 0 } },
+  error: null,
+});
+
+/**
+ * El formulario real, colgado del `onSave` real del kernel: el payload lo arma
+ * `getParamFields` igual que en la pantalla.
+ */
+const montar = (
+  item: Record<string, any> = deudaValida,
+  fieldsDelModulo: Record<string, any> = fields,
+) => {
+  const Pantalla = () => {
+    const crud: any = useCrud({
+      paramsInitial: { page: 1, perPage: 20, fullType: "L", searchBy: "" },
+      mod,
+      fields: fieldsDelModulo,
+    });
+
+    return (
+      <RenderForm
+        open
+        onClose={() => {}}
+        item={item as any}
+        extraData={extraData}
+        execute={crud.execute}
+        showToast={showToast}
+        reLoad={crud.reLoad}
+        user={user}
+        setItem={crud.setFormState}
+        onSave={crud.onSave}
+        errors={crud.errors}
+        setErrors={crud.setErrors}
+      />
+    );
+  };
+
+  render(<Pantalla />);
+};
+
+const apretarCrear = async () => {
+  const boton = await screen.findByText("Crear deuda individual", {
+    selector: "button, button *",
+  });
+  await act(async () => {
+    fireEvent.click(boton);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+  });
+};
+
+/** El cuerpo del POST que salió a `/v3/debt-dptos`. */
+const cuerpoDelPost = () => {
+  const post = execute.mock.calls.find((c) => c[1] === "POST");
+  return post?.[2];
+};
+
+describe("Deudas Individuales: el cuerpo del alta", () => {
+  beforeEach(() => {
+    execute.mockReset();
+    showToast.mockReset();
+    execute.mockImplementation(async (_url: string, method: string) => {
+      if (method === "POST") {
+        return { data: { success: true, message: "Deuda creada" }, error: null };
+      }
+      return listaOk();
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("el POST sale con las cuatro banderas como booleanos", async () => {
+    montar();
+    await waitFor(() => expect(execute).toHaveBeenCalled());
+    await apretarCrear();
+
+    const cuerpo = cuerpoDelPost();
+    expect(cuerpo, "el alta tiene que despachar un POST").toBeDefined();
+
+    for (const bandera of BANDERAS) {
+      // 🔴 Acá viajaba `'N'` (string) contra una columna `tinyint(1)`.
+      expect(
+        typeof cuerpo[bandera],
+        `${bandera} tiene que viajar como boolean, no como ${JSON.stringify(
+          cuerpo[bandera],
+        )}`,
+      ).toBe("boolean");
+    }
+  });
+
+  it("ninguna bandera viaja como 'Y' ni como 'N'", async () => {
+    montar();
+    await waitFor(() => expect(execute).toHaveBeenCalled());
+    await apretarCrear();
+
+    const cuerpo = cuerpoDelPost();
+    for (const bandera of BANDERAS) {
+      expect([cuerpo[bandera]]).not.toContain("Y");
+      expect([cuerpo[bandera]]).not.toContain("N");
+    }
+  });
+
+  it("una bandera prendida viaja como `true`, no como 'Y'", async () => {
+    montar({ ...deudaValida, is_blocking: true, has_pp: true });
+    await waitFor(() => expect(execute).toHaveBeenCalled());
+    await apretarCrear();
+
+    const cuerpo = cuerpoDelPost();
+    expect(cuerpo.is_blocking).toBe(true);
+    expect(cuerpo.has_pp).toBe(true);
+    expect(cuerpo.has_mv).toBe(false);
+    expect(cuerpo.is_forgivable).toBe(false);
+  });
+
+  it("el alta con datos válidos termina en éxito visible", async () => {
+    montar();
+    await waitFor(() => expect(execute).toHaveBeenCalled());
+    await apretarCrear();
+
+    const avisos = showToast.mock.calls.filter(([msg]) => !!msg);
+    expect(avisos.length, "el alta tiene que decir algo").toBeGreaterThan(0);
+    expect(avisos.some(([, tipo]) => tipo === "success")).toBe(true);
+  });
+});
+
+describe("Deudas Individuales: el rechazo del kernel se ve", () => {
+  beforeEach(() => {
+    execute.mockReset();
+    showToast.mockReset();
+    execute.mockImplementation(async () => listaOk());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("un error del kernel se pinta en el campo, no sólo en una clase CSS", async () => {
+    // 🔴 Tiene que rechazar EL KERNEL, no la validación local.
+    //
+    // Un campo que el formulario también valida (`amount`, `dpto_id`…) frena en
+    // `validar()` y `onSave` del kernel ni corre: ese test estaría midiendo el
+    // error local, que siempre se pintó, y quedaría verde con el bug puesto.
+    //
+    // `description` es el caso real de la divergencia: las reglas viven en el
+    // `fields` del módulo y el `validar()` del formulario está escrito a mano,
+    // así que el kernel puede exigir algo que el formulario no mira.
+    const fieldsConDescripcionRequerida = {
+      ...fields,
+      description: { rules: ["required"], api: "ae", label: "Descripción" },
+    };
+
+    montar(
+      { ...deudaValida, description: "" },
+      fieldsConDescripcionRequerida,
+    );
+    await waitFor(() => expect(execute).toHaveBeenCalled());
+    await apretarCrear();
+
+    expect(
+      execute.mock.calls.some((c) => c[1] === "POST"),
+      "el kernel rechazó: no puede haber POST",
+    ).toBe(false);
+
+    // 🔴 Antes `currentErrors` era `externalErrors || _errors` —y `{}` es
+    // truthy, así que se quedaba SIEMPRE con el del kernel— y encima los inputs
+    // pintaban `_errors` a mano: el rechazo no aparecía en ningún lado y el
+    // click se perdía en el vacío.
+    const mensajes = await screen.findAllByText(/Este campo es requerido/i);
+    expect(
+      mensajes.length,
+      "el rechazo del kernel tiene que verse en el formulario",
+    ).toBeGreaterThan(0);
+  });
+
+  it("y el error local sigue pintándose (el merge no se come ninguno)", async () => {
+    montar({ ...deudaValida, amount: "" });
+    await waitFor(() => expect(execute).toHaveBeenCalled());
+    await apretarCrear();
+
+    const mensajes = await screen.findAllByText(/Este campo es requerido/i);
+    expect(mensajes.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Cierra **CDT-60**: el botón "Crear" de Deudas Individuales no hacía nada — ni guardaba, ni mostraba un mensaje.

## Eran dos defectos encadenados: uno rompía, el otro lo tapaba

**El que rompe.** El formulario mandaba cuatro banderas como `'Y'/'N'`:

```ts
has_mv: _formState.has_mv ? 'Y' : 'N',   // y is_forgivable, has_pp, is_blocking
```

Las cuatro columnas son **`tinyint(1)`** desde la migración de 2026-06-30, y las cuatro son `$fillable` (medido con `getFillable()`, no con grep). 🔴 **Laravel castea al LEER, no al escribir**: el string viaja crudo al INSERT. Con la base en modo estricto:

```
ERROR 1366 (22007): Incorrect integer value: 'N' for column 'has_mv' at row 1
```

⚠️ Y donde el `sql_mode` **no** es estricto el insert pasa y guarda **0 en las cuatro**: el botón "anda" y las banderas quedan mal. Los dos casos son el bug, con caras distintas.

**El que lo tapa.** `useCrud.tsx:1138` hacía `showToast(response?.message, "error")` — con el request caído, `response` es `undefined` — y `useToast` con mensaje vacío hacía `setToastQueue([])`: **no sólo no mostraba nada, se llevaba puesto el aviso que ya estaba en pantalla**.

Por eso este bug sobrevivió: el error existía y **nadie podía verlo**.

## Por qué sólo pasaba en esa pestaña

El camino compartido (`type: 4`) manda el mismo `'Y'/'N'` y **no** muere, porque `SharedDebtService::boolFlag()` lo traduce. El individual (`type: 0`) va por `parent::store()` del kernel, que no normaliza nada.

O sea que `AllDebts` estaba **viviendo de prestado**: mandaba lo mismo y se salvaba por un servicio ajeno. Se arregló también, en este PR. Es el patrón de CDT-26 → CDT-30 otra vez.

## Qué se cambió

1. **El payload manda booleanos**, en `IndividualDebts` y en `AllDebts`.
2. **Ningún error queda mudo**: un guardado fallido sin mensaje del backend muestra un genérico visible, y un rechazo de validación del kernel se pinta **debajo del campo** (antes `currentErrors` sólo servía para una clase CSS).
3. **Un mensaje vacío ya no vacía la cola de avisos.** Pedir un toast sin texto no es una orden de limpiar: es una llamada que se quedó sin mensaje. Para sacar un toast está `onDismiss`, que lo quita por `id` sin tocar los demás.

🔴 Los puntos 2 y 3 son de **kernel**: cambian el flujo de ~40 pantallas. Por eso el contrato nuevo de `onSave` quedó documentado en `useCrud/README.md`.

## Verificado reinyectando — los cuatro mensajes literales

```
× volver el ? 'Y' : 'N':
has_mv tiene que viajar como boolean, no como "N": expected 'string' to be 'boolean'

× volver el toast mudo:
un guardado que falla tiene que decir algo: expected [] to have a length of 1 but got +0
un rechazo de validación tiene que verse: expected [] to have a length of 1 but got +0

× volver el setToastQueue([]):
un pedido sin mensaje no borra los avisos que ya están: expected [] to have a length of 1

× volver el externalErrors || _errors:
Unable to find an element with the text: /Este campo es requerido/i
```

**Los tests miden el cuerpo del request que sale**, no el texto del archivo — un test que buscara `'Y'` en el código es justo lo que acabamos de barrer en CDT-46.

## El barrido de hermanos: 47 coincidencias, 2 reales

El criterio no fue el nombre del campo sino **el tipo de la columna en la base**:

| | qué se hizo |
|---|---|
| `IndividualDebts` y `AllDebts` → `tinyint(1)` | **arreglados** |
| `value={... ? "Y":"N"}` en `<Check>`/`<Switch>` (~30) | props de UI, no salen al request. Sin tocar |
| Surveys, DptoConfig, SurveyTargeting | usan `'Y'/'N'` como estado interno y **convierten en el borde**. Correctos |
| Owners `is_homeowner`, Login `trustDevice` | no existe esa columna: son request-only |
| 4 handlers genéricos de checkbox | **ramas muertas**: esos formularios no tienen checkboxes. ⚠️ Anotado: `payments.confirm` es `tinyint(4)`, así que el día que aparezca un checkbox en Payments ese handler se despierta como bug |

## Cobertura

Este camino **no tenía un solo test**: cero `postJson('…debt-dptos'`, cero tests de front que montaran el formulario. Ahora hay 13, en 3 archivos.

## Verificación

- Suite completa: **120 archivos, 772 tests, todos verdes**.
- `tsc`: 23 errores con el cambio y **23 en el baseline** (medido con stash) → cero agregados. `eslint`: 0.
- ⚠️ El `Errors: 1` es preexistente y ajeno (InstantDB en `Surveys.test.tsx`, ticket **CDT-59**).
- **Sin migraciones**: las columnas ya eran `tinyint(1)`. El front venía atrasado respecto del esquema.

## Qué mirar en pantalla

1. **Deudas → Individuales → Crear**: llenar, abrir *Opciones avanzadas*, prender **Será bloqueante** y **Tendrá plan de pago**, Crear. Tiene que crear **y avisar**. Después abrir el detalle: las banderas tienen que estar como se marcaron, no en 0.
2. La misma pantalla con un campo vacío: el error tiene que aparecer **debajo del campo**, no sólo un borde rojo.
3. 🔴 Por el cambio en el kernel: cerrar un toast a mano y confirmar que **los demás siguen ahí**.
