### PR TITLE
feat(unidades): el interruptor del plan de pagos, contra el enum y no contra un booleano

### DIFF
--- a/src/modulos/Dptos/RenderForm.tsx
+++ b/src/modulos/Dptos/RenderForm.tsx
@@ -9,6 +9,13 @@ import type { MethodType } from "@/mk/hooks/useAxios";
 import { useAuth } from "@/mk/contexts/AuthProvider";
 import { getFullName } from "@/mk/utils/string";
 import useAxios from "@/mk/hooks/useAxios";
+import Switch from "@/mk/components/forms/Switch/Switch";
+import {
+  DPTO_CON_PLAN_DE_PAGOS,
+  DPTO_SIN_PLAN_DE_PAGOS,
+  desdeElInterruptor,
+  tienePlanDePagos,
+} from "./dptoPaymentPlan";
 
 const RenderForm = ({
   open,
@@ -19,7 +26,12 @@ const RenderForm = ({
   user,
   reLoad,
 }: any) => {
-  const [formState, setFormState]: any = useState({ ...item });
+  const [formState, setFormState]: any = useState({
+    ...item,
+    // 🔴 Se guarda el NÚMERO del enum, no un booleano. Ver `dptoPaymentPlan.ts`:
+    // acá `1` es SIN plan, al revés que el booleano de producción.
+    has_payment_plan: desdeElInterruptor(tienePlanDePagos(item?.has_payment_plan)),
+  });
   const [errors, setErrors]: any = useState({});
   const [typeFields, setTypeFields]: any = useState([]);
   const [enabledFields, setEnabledFields]: any = useState({});
@@ -37,7 +49,11 @@ const RenderForm = ({
 
         // Inicializar los campos habilitados y sus valores
         const enabledFieldsInit: any = {};
-        const formStateUpdate = { ...item, type: item.type_id };
+        const formStateUpdate = {
+          ...item,
+          type: item.type_id,
+          has_payment_plan: desdeElInterruptor(tienePlanDePagos(item?.has_payment_plan)),
+        };
 
         // Procesar field_values si existen
         if (item.field_values && Array.isArray(item.field_values)) {
@@ -152,6 +168,7 @@ const RenderForm = ({
         type_id: parseInt(formState.type_id),
         expense_amount: formState.expense_amount,
         dimension: formState.dimension,
+        has_payment_plan: Number(formState.has_payment_plan),
         homeowner_id:
           formState.homeowner_id == "X" ? null : formState.homeowner_id,
         fields: fields,
@@ -190,6 +207,22 @@ const RenderForm = ({
         error={errors}
         required={true}
         disabled={!!formState.id}
+      />
+
+      {/*
+        🔴 El plan de pagos: mientras esté vigente, la mora de esta unidad deja
+        de bloquear a quien vive ahí. Sigue debiendo; deja de estar frenado.
+
+        ⚠️ `optionValue` va con los números del enum y NO con booleanos. El
+        parche de producción manda `Boolean(...)`, y con el enum desde 1 eso
+        llega al API como el case OPUESTO. Ver `dptoPaymentPlan.ts`.
+      */}
+      <Switch
+        label="Tiene plan de pagos"
+        name="has_payment_plan"
+        optionValue={[DPTO_CON_PLAN_DE_PAGOS, DPTO_SIN_PLAN_DE_PAGOS]}
+        value={formState.has_payment_plan}
+        onChange={handleChange}
       />
 
       <Select

--- a/src/modulos/Dptos/__tests__/dptoPaymentPlan.test.ts
+++ b/src/modulos/Dptos/__tests__/dptoPaymentPlan.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DPTO_CON_PLAN_DE_PAGOS,
+  DPTO_SIN_PLAN_DE_PAGOS,
+  desdeElInterruptor,
+  tienePlanDePagos,
+} from "../dptoPaymentPlan";
+
+/**
+ * El interruptor del plan de pagos de una unidad.
+ *
+ * 🔴 Todo este archivo existe por UN caso: el `1`. En producción la columna es
+ * booleana y `1` significa "sí tiene plan"; acá es un enum numérico desde 1 y
+ * `1` significa **sin plan**. El parche de producción (`6396d47a`) trae un
+ * `parseBoolean` que acepta `1` como verdadero, y copiarlo deja la regla dada
+ * vuelta para las 2.888 unidades que no tienen ningún plan.
+ */
+describe("el plan de pagos de una unidad", () => {
+  it("🔴 el 1 es SIN plan, no con plan", () => {
+    expect(tienePlanDePagos(DPTO_SIN_PLAN_DE_PAGOS)).toBe(false);
+    expect(tienePlanDePagos(1)).toBe(false);
+    expect(tienePlanDePagos("1")).toBe(false);
+  });
+
+  it("el 2 es con plan", () => {
+    expect(tienePlanDePagos(DPTO_CON_PLAN_DE_PAGOS)).toBe(true);
+    expect(tienePlanDePagos(2)).toBe(true);
+    expect(tienePlanDePagos("2")).toBe(true);
+  });
+
+  it("🔴 un booleano NO alcanza para decir que sí", () => {
+    // `true` es la forma vieja. Si se aceptara, un front sin actualizar
+    // prendería el plan de pagos de cualquier unidad que mande `true`.
+    expect(tienePlanDePagos(true)).toBe(false);
+    expect(tienePlanDePagos("Y")).toBe(false);
+    expect(tienePlanDePagos("S")).toBe(false);
+  });
+
+  it("lo que no vino no es un plan", () => {
+    expect(tienePlanDePagos(undefined)).toBe(false);
+    expect(tienePlanDePagos(null)).toBe(false);
+    expect(tienePlanDePagos("")).toBe(false);
+    expect(tienePlanDePagos(0)).toBe(false);
+  });
+
+  it("el interruptor manda el número del enum, no un booleano", () => {
+    expect(desdeElInterruptor(true)).toBe(DPTO_CON_PLAN_DE_PAGOS);
+    expect(desdeElInterruptor(false)).toBe(DPTO_SIN_PLAN_DE_PAGOS);
+
+    // ⚠️ Nunca un booleano: `Boolean(2)` es `true`, y del lado del API eso
+    // entra al cast del enum como 1 — otra vez el case equivocado.
+    expect(typeof desdeElInterruptor(true)).toBe("number");
+  });
+
+  it("lo que sale del interruptor lo entiende la lectura", () => {
+    // La ida y la vuelta tienen que cerrar: si no, la pantalla guarda un
+    // valor que ella misma no sabe volver a leer.
+    expect(tienePlanDePagos(desdeElInterruptor(true))).toBe(true);
+    expect(tienePlanDePagos(desdeElInterruptor(false))).toBe(false);
+  });
+});

--- a/src/modulos/Dptos/dptoPaymentPlan.ts
+++ b/src/modulos/Dptos/dptoPaymentPlan.ts
@@ -1,0 +1,53 @@
+/**
+ * El plan de pagos de una unidad — `dptos.has_payment_plan`.
+ *
+ * Cuando un residente se atrasa, la administración puede acordar con él un
+ * plan de pagos. Desde ese momento su deuda deja de bloquearlo: sigue
+ * debiendo, pero no cae en la mora que le impide reservar, invitar o ver su
+ * inicio con normalidad.
+ *
+ * ────────────────────────────────────────────────────────────────────────
+ * 🔴 POR QUÉ NO SE COPIÓ EL PARCHE DE PRODUCCIÓN
+ * ────────────────────────────────────────────────────────────────────────
+ *
+ * El hotfix `6396d47a` trae esto:
+ *
+ * ```ts
+ * const parseBoolean = (value: any) =>
+ *   value === true || value === 1 || value === "1" || value === "Y" || …;
+ * ```
+ *
+ * En producción la columna es booleana y `1` significa **sí tiene plan**. Acá
+ * es un enum numérico desde 1, así que **`1` es `SIN_PLAN`** — el valor
+ * OPUESTO. Copiar ese `parseBoolean` deja el interruptor prendido para las
+ * 2.888 unidades que no tienen ningún plan, y apagado para la única que sí:
+ * la regla entera dada vuelta, sin un solo error.
+ *
+ * Es el mismo `(int) $v === 1` que ya había que desarmar al traer la matriz de
+ * permisos operativos, y el mismo `is_main == 1` de Bancos.
+ *
+ * ⚠️ Y el valor viaja como número, no como booleano. `Boolean(2)` es `true`,
+ * que del lado del API entra al cast del enum como `1` — otra vez el case
+ * equivocado.
+ */
+
+/** Sin plan de pagos: su deuda la bloquea como a cualquiera. */
+export const DPTO_SIN_PLAN_DE_PAGOS = 1;
+
+/** Con plan de pagos vigente: su deuda no la bloquea. */
+export const DPTO_CON_PLAN_DE_PAGOS = 2;
+
+/**
+ * ¿Esta unidad tiene un plan de pagos vigente?
+ *
+ * ⚠️ Acepta el número y su forma en texto porque el sobre del API viaja por
+ * una cadena de `any` y un `2` puede llegar como `"2"`. Lo que NO acepta es
+ * `true`: un booleano acá es un dato de la época anterior y tratarlo como
+ * "sí" es exactamente el error que este archivo existe para evitar.
+ */
+export const tienePlanDePagos = (valor: unknown): boolean =>
+  Number(valor) === DPTO_CON_PLAN_DE_PAGOS;
+
+/** El valor que se manda al API a partir del interruptor de la pantalla. */
+export const desdeElInterruptor = (prendido: boolean): number =>
+  prendido ? DPTO_CON_PLAN_DE_PAGOS : DPTO_SIN_PLAN_DE_PAGOS;


### PR DESCRIPTION
Una unidad con plan de pagos vigente deja de estar bloqueada por su mora: sigue debiendo, pero no cae en el freno que le impide reservar, invitar o ver su inicio con normalidad. La regla vivía **sólo en producción**.

## 🔴 Por qué no se copió el parche

El hotfix `6396d47a` trae esto:

```ts
const parseBoolean = (value: any) =>
  value === true || value === 1 || value === "1" || value === "Y" || …;
```

En producción la columna es booleana y `1` significa **sí tiene plan**. Del lado del API ahora es un enum numérico desde 1, así que **`1` es SIN plan** — el valor opuesto.

Copiarlo dejaba el interruptor **prendido para las 2.888 unidades sin plan** y apagado para la única que sí: la regla entera dada vuelta, sin un solo error.

Es el mismo `(int) $v === 1` que hubo que desarmar al traer la matriz de permisos operativos, y el mismo `is_main == 1` de Bancos.

## Lo que entra

`dptoPaymentPlan.ts` con las dos constantes del enum y dos funciones puras, más **6 tests** — uno dedicado al `1` y otro a que un booleano **no alcanza** para decir que sí.

⚠️ El valor viaja como **número**, no como booleano: `Boolean(2)` es `true`, y eso del lado del API entra al cast del enum como `1` — otra vez el case equivocado.

## Verificación

`tsc` **23 errores, los mismos que en `dev`** · `vitest` **14 verdes** en el módulo.

## Va junto con

`condaty2025-api` **#271** — es el que declara el enum y los tres lectores que faltaban.