### PR TITLE
feat(pagos): PaymentMethod.EXTERNAL_AUTOMATIC — el método de los pagos que acredita una integración externa

### DIFF
--- a/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
+++ b/src/modulos/DebtsManager/TabComponents/AllDebts/RenderView/RenderView.tsx
@@ -12,6 +12,7 @@ import ExpenseDetailModal from "@/modulos/Expenses/ExpensesDetails/RenderView/Re
 import ReservationDetailModal from "@/modulos/Reservas/RenderView/RenderView";
 import PaymentRenderView from "@/modulos/Payments/RenderView/RenderView";
 import PaymentRenderForm from "@/modulos/Payments/RenderForm/RenderForm";
+import { METHOD_MAP } from "@/modulos/Payments/Type/PaymentType";
 import {
   MONTHS_ES,
   formatToDayDDMMYYYY,
@@ -108,16 +109,20 @@ const RenderView: React.FC<RenderViewProps> = ({
     return status;
   };
 
-  const getPaymentTypeText = (type: string) => {
-    const paymentTypeMap: { [key: string]: string } = {
-      T: "Transferencia bancaria",
-      E: "Efectivo",
-      C: "Cheque",
-      Q: "Pago QR",
-      O: "Pago en oficina",
-    };
-    return paymentTypeMap[type] || type;
-  };
+  /**
+   * 🔴 Esta tabla tenía las claves viejas —`T`, `E`, `C`, `Q`, `O`— y
+   * `payments.method` es `tinyint` desde la migración a enums numéricos:
+   * medido en la base local, 10.537 pagos con valores 1..5 y ninguno con
+   * letra. O sea que no matcheaba NUNCA y el `|| type` de abajo dejaba el
+   * número pelado en la pantalla, igual que el "3" que ya se reportó en
+   * Expensas.
+   *
+   * Ahora usa el mapa compartido, que es el que se actualiza cuando aparece
+   * un método nuevo. Una tabla propia por consumidor es justamente cómo se
+   * llegó a esto.
+   */
+  const getPaymentTypeText = (type: number | string) =>
+    METHOD_MAP[type] || String(type ?? "");
 
   const getStatusStyle = (status: number, dueDate?: string) => {
     return getStatusConfig(status, dueDate);

--- a/src/modulos/Payments/Type/PaymentType.tsx
+++ b/src/modulos/Payments/Type/PaymentType.tsx
@@ -12,6 +12,15 @@ export enum PaymentMethod {
   QR = 3,
   CASH = 4,
   CHEQUE = 5,
+  /**
+   * Pago acreditado por una integración externa, sin que nadie lo cargue a
+   * mano (hoy el webhook de Orange/Luka de Urubó Village).
+   *
+   * ⚠️ No dice "Orange" a propósito: esa integración es temporal y el case
+   * sirve para las que vengan después. Qué proveedor lo trajo se lee en
+   * `payments.ext`, no en el método.
+   */
+  EXTERNAL_AUTOMATIC = 6,
 }
 
 export enum PaymentType {
@@ -194,6 +203,7 @@ export const PAYMENT_METHOD_OPTIONS = [
   { id: PaymentMethod.CHEQUE, name: "Cheque" },
   { id: PaymentMethod.QR, name: "Pago QR" },
   { id: PaymentMethod.OFFICE, name: "Pago en oficina" },
+  { id: PaymentMethod.EXTERNAL_AUTOMATIC, name: "Pago externo automático" },
 ];
 
 export const STATUS_OPTIONS = [
@@ -212,6 +222,13 @@ export const TYPE_OPTIONS = [
   { id: FormPaymentType.DIRECT, name: "Pago directo" },
 ];
 
+/**
+ * Los métodos que administración puede elegir al CARGAR un pago a mano.
+ *
+ * ⚠️ `EXTERNAL_AUTOMATIC` no está acá a propósito: ese método lo escribe una
+ * integración externa cuando acredita un pago sola. Nadie lo carga a mano, y
+ * ofrecerlo en el formulario dejaría marcar como automático algo que no lo es.
+ */
 export const FORM_PAYMENT_METHODS = [
   { id: PaymentMethod.QR, name: "Pago QR" },
   { id: PaymentMethod.TRANSFER, name: "Transferencia bancaria" },
@@ -226,6 +243,7 @@ export const METHOD_MAP: Record<string | number, string> = {
   [PaymentMethod.QR]: "Pago QR",
   [PaymentMethod.CASH]: "Efectivo",
   [PaymentMethod.CHEQUE]: "Cheque",
+  [PaymentMethod.EXTERNAL_AUTOMATIC]: "Pago externo automático",
 };
 
 export const FORM_LABELS = {

--- a/tests/__fixtures__/enums-ssot.json
+++ b/tests/__fixtures__/enums-ssot.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./enums-ssot.schema.json",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lastUpdated": "2026-08-15",
   "maintainer": "Condaty cross-app team",
   "source": "SSoT canónico de los enums compartidos entre condaty-api, admin, rnGuard y rnOwner. Cada repo mantiene su enum local sincronizado con un test de reflection contra esta fuente. NO es runtime: se usa sólo en CI/tests para detectar drift.\n\n🔴 Desde 1.2.0 los nombres canónicos de los cases son los del API, y cada front declara sus alias en `aliasesByApp`. Antes era al revés —el canónico era el nombre de los fronts— y eso decía justo al contrario de dónde está la verdad: el PHP es lo que está guardado en la base. Esa inversión no es cosmética: mientras el SSoT trató a los fronts como fuente, el API estuvo un mes entero FUERA del contrato sin que se notara.\n\nLa CLAVE de cada enum sigue siendo el nombre con el que lo llaman los fronts (`AccessType`), porque es la clave del `LOCAL_ENUMS` de cada uno. El nombre de la clase en PHP va en `apiClass`.",
@@ -333,7 +333,7 @@
     },
     "PaymentMethod": {
       "type": "int",
-      "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentMethod (PHP).",
+      "comment": "Sincronizado con backend App\\Modules\\Payments\\Enums\\PaymentMethod (PHP).\n\nEXTERNAL_AUTOMATIC (6) es el pago que acredita una integración externa sin que nadie lo cargue a mano: hoy el webhook de Orange/Luka para Urubó Village, y cualquier integración que venga después. Es deliberadamente genérico — no dice 'Orange' — porque la integración de Orange es temporal y el case no debería morir con ella. El proveedor concreto va en `payments.ext` (`orange:{transaction_id}`), no en el método.",
       "apps": [
         "api",
         "admin",
@@ -359,6 +359,10 @@
         {
           "name": "CHEQUE",
           "value": 5
+        },
+        {
+          "name": "EXTERNAL_AUTOMATIC",
+          "value": 6
         }
       ],
       "apiClass": "PaymentMethod"


### PR DESCRIPTION
Propaga a este repo el case `PaymentMethod.EXTERNAL_AUTOMATIC = 6` que agrega el API en https://github.com/mariogfos/condaty2025-api/pull/283 (SSoT de enums **1.2.0 → 1.3.0**).

Es el método con el que el API acredita un pago que trae una **integración externa**, sin que nadie lo cargue a mano — hoy el webhook de Orange/Luka para Urubó Village. Sin el case, el admin muestra un **6 pelado** en la columna Método de pago.

⚠️ El case **no dice "Orange" a propósito**: esa integración es temporal y el enum sirve para las que vengan después. Qué proveedor trajo cada pago se lee en `payments.ext` (`orange:{transaction_id}`) — el método dice *cómo* entró la plata, no *quién* la trajo.

## Dónde entra, y dónde no

| Lugar | ¿Va? | Por qué |
|---|---|---|
| `METHOD_MAP` | **Sí** | Si no, la pantalla muestra el número |
| `PAYMENT_METHOD_OPTIONS` (filtro) | **Sí** | Para poder filtrar los pagos automáticos |
| `FORM_PAYMENT_METHODS` (alta manual) | **No** | Ese método lo escribe una integración cuando acredita sola. Ofrecerlo dejaría marcar como automático algo que no lo es |

## Un bug vivo que quedó en el camino

La pestaña **Todas** de Deudas tenía su propia tabla de etiquetas con las claves viejas:

```ts
const paymentTypeMap = { T: "Transferencia bancaria", E: "Efectivo", C: "Cheque", Q: "Pago QR", O: "Pago en oficina" };
```

🔴 `payments.method` es `tinyint` desde el flip a enums numéricos. Medido en la base local: **10.537 pagos con valores 1..5 y ninguno con letra**. O sea que ese mapa **no matcheaba nunca**, y el `|| type` de abajo dejaba el número pelado en la pantalla — el mismo síntoma del "3" que ya se reportó en Expensas.

Ahora usa el `METHOD_MAP` compartido, que es el que se actualiza cuando aparece un método nuevo. Una tabla propia por consumidor es justamente cómo se llega a esto.

## Fuera de alcance a propósito

`PAYMENT_TYPE_MAP` en `DebtsManager/TabComponents/constants.ts` tiene el mismo problema (claves con letra) pero **no lo consume nadie**: es código muerto. Se deja para el barrido módulo por módulo que está en curso.

## Verificación

- `tsc`: **23 errores antes y 23 después**, ninguno en los archivos tocados (baseline medido con los cambios guardados).
- **159 tests verdes** (enums + Payments + DebtsManager).
- 🔴 **Reinyección verificada**: sacando `EXTERNAL_AUTOMATIC` del enum, el test de sincronía con el SSoT se pone **rojo**. Y se confirmó que la reinyección había entrado antes de creerle al resultado — el primer intento con `sd` no matcheó y habría dado un falso verde.

## Orden de merge

Va junto con el API, rnOwner y rnGuard: es un solo release.
