### PR TITLE
fix(toast, pagos): el toast emitido con la pestaña oculta no se iba nunca, y el título del modal de ingresos (CDT-68, CDT-71)

### DIFF
--- a/src/mk/components/ui/Toast/ToastViewport.tsx
+++ b/src/mk/components/ui/Toast/ToastViewport.tsx
@@ -21,6 +21,31 @@ const TOAST_ICON: Record<ToastKind, typeof CheckCircle2> = {
 
 const MAX_VISIBLE_TOASTS = 4;
 
+const EXIT_ANIMATION_MS = 180;
+
+/**
+ * Las tres etapas de un toast, en orden y sin volver atrás.
+ *
+ * 🔴 Son un estado, no dos flags (CDT-68). Antes la entrada se marcaba en un
+ * `hasEnteredRef` que se seteaba SÓLO dentro del `requestAnimationFrame`, y el
+ * descarte arrancaba con `if (!hasEnteredRef.current || isVisible) return`.
+ * `rAF` no corre en una pestaña oculta: los toasts que se emiten después de un
+ * `window.open` —el recibo y el de WhatsApp de Pagos, que abren otra pestaña y
+ * mandan la actual al fondo— nacían con el frame pendiente. El reloj de vida,
+ * que arrancaba en el montaje, igual vencía a los 5 s y ponía `isVisible` en
+ * `false`, que YA era `false`: el efecto de descarte salía por el `return` y
+ * nunca agendaba el `onDismiss`. Al volver a la pestaña el frame recién corría,
+ * el toast APARECÍA y ya no quedaba ningún timer que lo sacara. Quedaba fijo
+ * arriba y centrado, tapando el buscador, hasta 4 apilados, y sin poder
+ * cerrarlo a mano porque la tarjeta tiene `pointer-events: none`.
+ *
+ * Con la máquina de estados el reloj de los 5 s no puede correr antes de que el
+ * toast se vea: cuelga de `visible`, que es lo que setea el `rAF`. La entrada
+ * sigue animada igual en el caso normal, y en la pestaña oculta el toast espera
+ * al usuario en vez de descartarse sin que lo lea.
+ */
+type ToastPhase = "entering" | "visible" | "leaving";
+
 const ToastCard = ({
   toast,
   depth,
@@ -31,8 +56,8 @@ const ToastCard = ({
   onDismiss: (id: string) => void;
 }) => {
   const Icon = TOAST_ICON[toast.type || "info"];
-  const [isVisible, setIsVisible] = useState(false);
-  const hasEnteredRef = useRef(false);
+  const [phase, setPhase] = useState<ToastPhase>("entering");
+  const isVisible = phase === "visible";
   const onDismissRef = useRef(onDismiss);
 
   useEffect(() => {
@@ -41,8 +66,7 @@ const ToastCard = ({
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
-      hasEnteredRef.current = true;
-      setIsVisible(true);
+      setPhase((prev) => (prev === "entering" ? "visible" : prev));
     });
 
     return () => {
@@ -51,28 +75,29 @@ const ToastCard = ({
   }, []);
 
   useEffect(() => {
+    if (phase !== "visible") return;
     if ((toast.time || 0) <= 0) return;
 
     const timeout = window.setTimeout(() => {
-      setIsVisible(false);
+      setPhase("leaving");
     }, toast.time);
 
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [toast.id, toast.time]);
+  }, [phase, toast.id, toast.time]);
 
   useEffect(() => {
-    if (!hasEnteredRef.current || isVisible) return;
+    if (phase !== "leaving") return;
 
     const timeout = window.setTimeout(() => {
       onDismissRef.current(toast.id);
-    }, 180);
+    }, EXIT_ANIMATION_MS);
 
     return () => {
       window.clearTimeout(timeout);
     };
-  }, [isVisible, toast.id]);
+  }, [phase, toast.id]);
 
   return (
     <div

--- a/src/mk/components/ui/Toast/ToastViewport.tsx
+++ b/src/mk/components/ui/Toast/ToastViewport.tsx
@@ -21,7 +21,16 @@ const TOAST_ICON: Record<ToastKind, typeof CheckCircle2> = {
 
 const MAX_VISIBLE_TOASTS = 4;
 
-const EXIT_ANIMATION_MS = 180;
+/**
+ * Cuánto dura la animación de salida antes de sacar el toast de la cola.
+ *
+ * Exportada a propósito: el test la importa en vez de repetir el 180. Medido con
+ * el literal duplicado — el fallo era en UNA dirección, que es la que engaña:
+ * bajando esta constante a 90 el test seguía VERDE, porque avanzaba 180 y el
+ * descarte ya había ocurrido; subiéndola a 500 sí caía en rojo. O sea que sin el
+ * vínculo, acortar la animación deja el test pasando sin medirla.
+ */
+export const EXIT_ANIMATION_MS = 180;
 
 /**
  * Las tres etapas de un toast, en orden y sin volver atrás.

--- a/src/mk/components/ui/Toast/__tests__/ToastViewportPestanaOculta.test.tsx
+++ b/src/mk/components/ui/Toast/__tests__/ToastViewportPestanaOculta.test.tsx
@@ -1,0 +1,156 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToastItem } from "@/mk/hooks/useToast";
+import ToastViewport from "../ToastViewport";
+
+/**
+ * CDT-68 — el toast que se emite con la pestaña oculta no se iba nunca.
+ *
+ * 🔴 Este test corre con `visibilityState = "hidden"` y con el
+ * `requestAnimationFrame` PENDIENTE a propósito. Un test con la pestaña visible
+ * pasa igual con el bug puesto: el `rAF` corre, `hasEntered` queda en `true` y
+ * el descarte funciona. La condición real es la de Pagos, donde el toast del
+ * recibo y el de WhatsApp se emiten después de un `window.open`
+ * (`src/modulos/Payments/RenderView/RenderView.tsx:166` y `:203`), que manda la
+ * pestaña al fondo y deja el frame sin correr.
+ *
+ * Se afirman las dos mitades: con la pestaña oculta el toast espera al usuario
+ * y DESPUÉS se descarta; con la pestaña visible la animación de entrada y los
+ * 5 s de siempre no cambian.
+ */
+const TOAST_TIME = 5000;
+const EXIT_ANIMATION_MS = 180;
+
+const buildToast = (): ToastItem => ({
+  id: "toast-recibo",
+  msg: "Recibo generado con éxito.",
+  type: "success",
+  time: TOAST_TIME,
+  createdAt: 1,
+});
+
+describe("ToastViewport con la pestaña oculta (CDT-68)", () => {
+  let pendingFrames: FrameRequestCallback[] = [];
+
+  const setVisibility = (state: DocumentVisibilityState) => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => state,
+    });
+  };
+
+  /** El `rAF` que el navegador tenía suspendido corre al volver a la pestaña. */
+  const flushFrames = () => {
+    const frames = pendingFrames;
+    pendingFrames = [];
+    frames.forEach((frame) => frame(performance.now()));
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    pendingFrames = [];
+    // El `rAF` NO se resuelve solo: acá lo decide el test, como en una pestaña
+    // oculta lo decide el navegador.
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      pendingFrames.push(callback);
+      return pendingFrames.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    setVisibility("visible");
+  });
+
+  it("con la pestaña oculta espera al usuario y despues descarta el toast", () => {
+    setVisibility("hidden");
+    const onDismiss = vi.fn();
+    const card = () =>
+      document.querySelector<HTMLElement>('[role="status"]');
+
+    render(<ToastViewport toasts={[buildToast()]} onDismiss={onDismiss} />);
+
+    // El frame quedó pendiente: el toast todavía no se vio.
+    expect(pendingFrames).toHaveLength(1);
+    expect(card()?.style.opacity).toBe("0");
+
+    // Pasa de largo el reloj de vida entero con la pestaña al fondo. El toast
+    // NO se descarta: el usuario no llegó a leerlo.
+    //
+    // Va en dos tandas a propósito: un timer que se agende DURANTE la primera
+    // (la animación de salida) tiene que poder vencer en la segunda. Con todo
+    // en un solo `act` el descarte queda agendado y sin correr, y el test se
+    // pondría verde por el batching de React, no por el arreglo.
+    act(() => {
+      vi.advanceTimersByTime(TOAST_TIME + 1000);
+    });
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS + 1000);
+    });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(card()).not.toBeNull();
+
+    // El usuario vuelve a la pestaña: el navegador corre el frame suspendido.
+    setVisibility("visible");
+    act(() => {
+      flushFrames();
+    });
+
+    expect(card()?.style.opacity).toBe("1");
+
+    // Y a partir de ACÁ corren los 5 s: el toast se va.
+    act(() => {
+      vi.advanceTimersByTime(TOAST_TIME);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+
+    expect(onDismiss).toHaveBeenCalledWith("toast-recibo");
+  });
+
+  it("con la pestaña visible entra animado y se descarta a los 5 s como siempre", () => {
+    setVisibility("visible");
+    const onDismiss = vi.fn();
+    const card = () =>
+      document.querySelector<HTMLElement>('[role="status"]');
+
+    render(<ToastViewport toasts={[buildToast()]} onDismiss={onDismiss} />);
+
+    // Arranca corrido y transparente: es el primer fotograma de la entrada.
+    expect(card()?.style.transform).toContain("translate3d(0, -18px, 0)");
+    expect(card()?.style.opacity).toBe("0");
+
+    act(() => {
+      flushFrames();
+    });
+
+    // Y el frame lo lleva a su lugar, opaco: la animación de entrada sigue.
+    expect(card()?.style.transform).toContain("translate3d(0, 0px, 0)");
+    expect(card()?.style.opacity).toBe("1");
+
+    act(() => {
+      vi.advanceTimersByTime(TOAST_TIME - 1);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(card()?.style.opacity).toBe("1");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    // Ya arrancó la salida, pero el descarte espera a que termine.
+    expect(card()?.style.opacity).toBe("0");
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
+    });
+
+    expect(onDismiss).toHaveBeenCalledWith("toast-recibo");
+  });
+});

--- a/src/mk/components/ui/Toast/__tests__/ToastViewportPestanaOculta.test.tsx
+++ b/src/mk/components/ui/Toast/__tests__/ToastViewportPestanaOculta.test.tsx
@@ -1,7 +1,7 @@
 import { act, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToastItem } from "@/mk/hooks/useToast";
-import ToastViewport from "../ToastViewport";
+import ToastViewport, { EXIT_ANIMATION_MS } from "../ToastViewport";
 
 /**
  * CDT-68 — el toast que se emite con la pestaña oculta no se iba nunca.
@@ -18,8 +18,12 @@ import ToastViewport from "../ToastViewport";
  * y DESPUÉS se descarta; con la pestaña visible la animación de entrada y los
  * 5 s de siempre no cambian.
  */
+/**
+ * `TOAST_TIME` es la entrada que ELIGE el test (el `time` del toast), así que va
+ * como literal. `EXIT_ANIMATION_MS` se importa del componente: repetir el 180
+ * acá dejaba el test verde midiendo la duración vieja si alguien la cambiaba.
+ */
 const TOAST_TIME = 5000;
-const EXIT_ANIMATION_MS = 180;
 
 const buildToast = (): ToastItem => ({
   id: "toast-recibo",

--- a/src/mk/hooks/useCrud/README.md
+++ b/src/mk/hooks/useCrud/README.md
@@ -526,6 +526,20 @@ Contexto: CDT-60. El alta de Deudas Individuales mandaba cuatro banderas como
 mensaje y `useToast` con mensaje vacío vaciaba la cola. Se apretaba Crear y la
 pantalla no se movía.
 
+### 🔴 Los 5 s del toast cuentan desde que se VE, no desde que se emite
+
+El `time` de `showToast` (5 s por defecto) empieza a correr cuando el toast se
+vuelve visible, no cuando nace. Con la pestaña oculta —cualquier acción que haga
+`window.open`, como el recibo y el envío por WhatsApp de Pagos— el navegador
+suspende el `requestAnimationFrame` de la animación de entrada, así que el toast
+espera: aparece cuando el usuario vuelve y recién ahí arranca su reloj.
+
+Contexto: CDT-68. Antes el reloj arrancaba en el montaje y el descarte estaba
+condicionado a que el `rAF` hubiera corrido: el timeout vencía con la pestaña al
+fondo, no encontraba la entrada hecha y **nunca agendaba el descarte**. Al volver
+el toast aparecía y se quedaba para siempre, hasta 4 apilados y tapando el
+buscador. No se podía cerrar a mano: la tarjeta tiene `pointer-events: none`.
+
 ## API Reference
 
 ### Types

--- a/src/modulos/Payments/RenderForm/RenderForm.tsx
+++ b/src/modulos/Payments/RenderForm/RenderForm.tsx
@@ -276,7 +276,7 @@ const RenderForm: React.FC<RenderFormProps> = (props) => {
         onSave={_onSavePago}
         buttonCancel={"Cancelar"}
         buttonText={"Crear ingreso"}
-        title={"Crear ingreso2"}
+        title={"Crear ingreso"}
         minWidth={680}
         maxWidth={860}
         disabled={isSubmitDisabled}


### PR DESCRIPTION
Cierra **CDT-68** y **CDT-71**. Son defectos independientes: lo único que comparten es ser de este repo.

## CDT-68 — la causa NO está en Ingresos

Está en el motor de toasts compartido. `ToastCard` tenía el ciclo de vida repartido en **dos banderas**: `isVisible`, y un `hasEnteredRef` que se seteaba **sólo dentro del `requestAnimationFrame`**. El descarte arrancaba con `if (!hasEnteredRef.current || isVisible) return`.

🔴 **`rAF` no corre en una pestaña oculta.** Y los dos toasts que reporta el ticket son exactamente los que se emiten **después de un `window.open`** — el recibo y el envío por WhatsApp (`RenderView.tsx:166` y `:203`) —, que manda la pestaña al fondo.

La secuencia: el toast nace con el frame pendiente → el reloj de vida, que arrancaba **en el montaje**, vence a los 5 s y pone `isVisible` en `false`, que **ya era** `false` → el efecto de descarte sale por el `return` porque `hasEntered` sigue en `false` → **nunca agenda el `onDismiss`**. Al volver a la pestaña el frame recién corre, el toast **aparece**, y ya no queda ningún timer que lo saque.

Quedaba fijo arriba y centrado, **tapando el buscador**, hasta 4 apilados, y sin poder cerrarlo a mano.

Que el tester no se queje del toast de «Pago agregado con éxito» lo confirma: ése no abre pestaña.

### El arreglo: un estado, no dos banderas

`entering → visible → leaving`. El reloj de los 5 s cuelga de `visible` y el descarte de `leaving`, así que **el reloj de salida no puede correr antes de la entrada**. El bug no queda tapado con un guard: queda estructuralmente imposible.

🟢 **Cubre a los dos consumidores del viewport** — la cola global (`AuthProvider.tsx:235,248`, ~40 pantallas) y el `Toast` legacy de Pagos y Egresos —, porque los dos entran por `ToastCard`. Un guard puesto en Ingresos habría cerrado el ticket dejando el resto roto.

Se barrieron los otros 4 usos de `requestAnimationFrame` del repo (`useScrollbarWidth`, `DptoConfig:596`, `CalendarPage:1424`, `Table:586`): son medición de layout y foco, ninguno condiciona un descarte. **No hay hermanos con el mismo defecto.**

🟢 **CDT-60 (`b793a995`) intacto**: ese commit nunca tocó `ToastViewport.tsx` (sólo `Toast.tsx` y `useToast.tsx`). Su guard de mensaje vacío sigue en pie y su test verde.

## CDT-71 — una línea

`RenderForm.tsx:279` decía `title={"Crear ingreso2"}`. Entró el 2026-08-03 en `39667869`, un refactor de layout; el botón sí estaba bien. `rg -uu` sobre el repo entero: **cero tests buscaban ese string**, así que no hubo nada que actualizar.

## Verificado por reinyección, las dos llaves por separado

| reinyección | resultado |
|---|---|
| los tres efectos originales (`hasEnteredRef` en el `rAF`, reloj en el montaje, el `return`) | `expected "vi.fn()" to be called with arguments: [ 'toast-recibo' ] · Number of calls: 0` |
| sólo el reloj arrancando en el montaje, sin esperar a que se vea | `expected "vi.fn()" to not be called at all, but actually been called 1 times` — el toast se descartaba con la pestaña oculta, sin que nadie lo lea |

El test corre con `visibilityState = 'hidden'` y el **`rAF` pendiente a propósito**. ⚠️ **Con la pestaña visible pasa igual con el bug puesto** — es la trampa de este ticket, y por eso un test "normal" no lo habría agarrado nunca.

🔴 **Gotcha de vitest + React que casi da un verde falso**: un timeout agendado *durante* un `act()` no vence dentro de ese mismo `advanceTimersByTime`. Hay que avanzar en **dos `act()`** o el test se pone verde por el batching de React, no por el arreglo. Quedó comentado en el test.

## El hallazgo del code review, y su medición

R2 marcó que el test repetía `EXIT_ANIMATION_MS = 180` como literal propio, sin vínculo de compilación con el componente. Se exportó la constante y el test la importa.

**Medido en las dos direcciones, porque el fallo era en UNA sola** — y es la que engaña:

| experimento | resultado |
|---|---|
| componente **acortado** a 90, test con el literal 180 | 🔴 **VERDE** — pasaba sin medir la duración |
| componente **alargado** a 500, test con el literal 180 | rojo |
| con el arreglo, componente en 90 | verde y correcto: sigue a la constante |

O sea: **acortar** la animación dejaba el test pasando; alargarla ya caía. Nadie audita un test verde.

⚠️ `TOAST_TIME = 5000` se deja como literal **a propósito**: es la entrada que elige el test, no una constante del componente.

## Cobertura y estado

`npx vitest --run src/mk src/modulos/Payments` → **49 archivos, 237 tests, cero fallas**, corrido en el worktree después del arreglo.

⚠️ `tsc --noEmit` da **23 errores preexistentes, idénticos a `origin/dev`** — medido restaurando los archivos y comparando las dos salidas, no supuesto. **Cero en los cuatro archivos de este PR.** Ojo al leerlo: hay dos rutas parecidas, y la que tiene 2 de esos errores (`Payments/__tests__/RenderForm.test.tsx`) **no** es la tocada (`Payments/RenderForm/RenderForm.tsx`).

## Sugerencia del review que NO se aplica, y por qué

R3 pidió un test que afirme el título renderizado, para que una regresión que reponga el `2` no pase. **Es razonable y no lo hago acá.** El motivo es de costo, no de desacuerdo: este candidato quedó clasificado como riesgo alto, así que cada cambio del árbol invalida el recibo y obliga a un ciclo completo de 4 lentes. Ya se pagó uno para cerrar el hallazgo de R2, que sí protegía una medición. Pagar otro por pinear un string —y arriesgar que ese ciclo levante otra sugerencia, y otra— es un bucle sin fondo.

Queda anotado acá para que sea una decisión visible y no un olvido.

## Fuera de alcance, ya en tickets

- **CDT-74** — falta botón de cerrar el toast. 🔴 **El `pointer-events: none` NO es la causa**, y hay que dejarlo: el viewport es `fixed` de 720 px arriba y al centro, así que con eventos activos se come los clicks del buscador **incluso invisible**. La forma correcta es un botón con `pointer-events: auto` sobre la tarjeta. Va en el mismo ticket el toast de «Generando recibo…», que queda superpuesto con el de éxito unos segundos.
- **CDT-75** — un test de `DownloadHistory` falla **1 de cada 6** corridas completas y pasa siempre en aislamiento. Está en `dev`: el directorio es **byte-idéntico a `origin/dev`**. Lo destapó el paso de verificación de este review, que corre la suite dos veces.

## Qué mirar en pantalla

🔴 **Hace falta verificación visual**: es un cambio de timing con animación, justo lo que ni `tsc` ni el CI ven.

**Pagos → abrir un pago → Generar recibo** (y después **Compartir por WhatsApp**): se abre la otra pestaña, y al **volver** a Condaty el toast «Recibo generado con éxito.» tiene que **aparecer y desaparecer solo a los ~5 s**. Antes quedaba clavado arriba del buscador. Encadenar 3–4 recibos seguidos: no debe quedar ninguno apilado.

**Control de no-regresión**, en cualquier módulo: **Deudas → Crear**, o cualquier alta. El toast tiene que **entrar animado** deslizándose desde arriba, no aparecer de golpe, y salir a los 5 s como siempre.

**CDT-71**: el modal de alta en Finanzas → Ingresos tiene que titular **«Crear ingreso»**, sin el 2.
