### PR TITLE
chore(payments): borrar la declaración muerta de admin/partial-debts (CDT-69)

### DIFF
--- a/src/modulos/Payments/api.ts
+++ b/src/modulos/Payments/api.ts
@@ -4,7 +4,6 @@ export const paymentsApi = {
   unitFinancialState: (dptoId: string | number) =>
     `${PAYMENTS_V3_BASE}/units/${dptoId}/financial-state`,
   adminDebts: `${PAYMENTS_V3_BASE}/admin/debts`,
-  adminPartialDebts: `${PAYMENTS_V3_BASE}/admin/partial-debts`,
   create: PAYMENTS_V3_BASE,
   simulate: `${PAYMENTS_V3_BASE}/simulate`,
   partialSummary: (debtId: string | number) =>


### PR DESCRIPTION
Parte de front de **CDT-69**. Una línea, sin cambio de comportamiento.

Se borra la declaración `adminPartialDebts` de `src/modulos/Payments/api.ts`, que apuntaba a `/v3/payments/admin/partial-debts`. **Esa ruta se elimina del API en el mismo ticket.**

## Por qué existía y por qué se va

Nadie la consumía. `rg` sobre los **tres** fronts —`condaty-admin`, `rnOwner`, `rnGuard`— daba **una sola aparición**: esta línea, que la declaraba y nada más.

Se borra en vez de dejarla porque **una declaración que apunta a una ruta inexistente no se lee como código muerto: se lee como una API disponible.** El próximo que la cablee se come un 404.

Y hay un motivo peor para no dejarla: ese endpoint exigía `available_partial_amount > 0`, y eso **esconde las deudas con total Bs 0,00** (medido: 4 filas, ids `4478, 4550, 12190, 14262`). Era la trampa que CDT-69 descartó por medición — cablear ese endpoint habría arreglado *una lista que esconde filas* **creando otra lista que esconde filas**. Dejar el puntero deja viva la trampa.

## Verificación

- `rg -uu "adminPartialDebts|partial-debts"` sobre `src` y `tests` → **cero**.
- `npx vitest --run src/modulos/Payments` → **8 archivos, 56 tests, cero fallas**.
- `npx tsc --noEmit` → 23 diagnósticos, **todos preexistentes**, y lo que decide: **`TS2339`/`TS2551` = 0**. Ésa es justo la clase de error que el compilador emitiría por cualquier lectura sobreviviente de la propiedad borrada, así que el cero es prueba **a nivel compilador** de que no había llamador.

## Orden de merge

**Independiente del PR del API**: nadie llamaba la ruta, así que cualquier orden es seguro y no hay ventana de rotura.

## Code review

Aprobado, **cero hallazgos** en las cuatro lentes. ⚠️ El sobre le asignó riesgo `high`, y conviene saber por qué: el clasificador lo derivó de que **la carpeta se llama `Payments`**, no de lo que el cambio hace. Es el borrado de un string muerto.
